### PR TITLE
remove lerna

### DIFF
--- a/sceptre/itsandbox/package.json
+++ b/sceptre/itsandbox/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "itsandbox",
-  "scripts": {
-    "predeploy": "assume add member --profile orgman-servicerole --role-arn arn:aws:iam::804034162148:role/OrganizationAccountAccessRole && assume switch member",
-    "deploy": "sceptre launch prod --yes"
-  }
-}

--- a/sceptre/lerna.json
+++ b/sceptre/lerna.json
@@ -1,6 +1,0 @@
-{
-  "packages": [
-    "**/*"
-  ],
-  "version": "independent"
-}

--- a/sceptre/organizations/package.json
+++ b/sceptre/organizations/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "organizations",
-  "scripts": {
-      "deploy": "sceptre --var \"profile=orgman-servicerole\" launch prod --yes"
-  }
-}

--- a/sceptre/package.json
+++ b/sceptre/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "sceptre",
-  "private": true,
-  "devDependencies": {
-    "lerna": "^3.22.1"
-  }
-}

--- a/sceptre/sandbox/package.json
+++ b/sceptre/sandbox/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "sandbox",
-  "scripts": {
-      "predeploy": "assume add member --profile orgman-servicerole --role-arn arn:aws:iam::563295687221:role/OrganizationAccountAccessRole && assume switch member",
-      "deploy": "sceptre launch prod --yes"
-  }
-}

--- a/sceptre/scicomp/package.json
+++ b/sceptre/scicomp/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "scicomp",
-  "scripts": {
-      "predeploy": "assume add member --profile orgman-servicerole --role-arn arn:aws:iam::055273631518:role/OrganizationAccountAccessRole && assume switch member",
-      "deploy": "sceptre launch prod --yes"
-  }
-}


### PR DESCRIPTION
Curl failures causes lerna build to fail.  Also it was difficult
to run all sceptre deploys in one VM due to assuming of roles.
Assuming roles is easier when done in separate environments.