### PR TITLE
Fix file downloads

### DIFF
--- a/sceptre/admincentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/admincentral/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/admincentral/config/prod/bootstrap.yaml
+++ b/sceptre/admincentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/admincentral/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/admincentral/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/admincentral/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/admincentral/config/prod/cfn-s3objects-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -N -P templates/remote"

--- a/sceptre/admincentral/config/prod/essentials.yaml
+++ b/sceptre/admincentral/config/prod/essentials.yaml
@@ -8,4 +8,4 @@ parameters:
   LambdaBucketVersioning: Enabled
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/admincentral/config/prod/it-services-s3-gateway-vpc-endpoint.yaml
+++ b/sceptre/admincentral/config/prod/it-services-s3-gateway-vpc-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"

--- a/sceptre/admincentral/config/prod/it-services.yaml
+++ b/sceptre/admincentral/config/prod/it-services.yaml
@@ -5,4 +5,4 @@ parameters:
   VpcName: it-services
 hooks:
   before_launch:
-   - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+   - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/admincentral/config/prod/peer-vpn-it-services.yaml
+++ b/sceptre/admincentral/config/prod/peer-vpn-it-services.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/admincentral/config/prod/rotate-credentials.yaml
+++ b/sceptre/admincentral/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/develop/AccountAlertTopics.yaml
+++ b/sceptre/bridge/config/develop/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/develop/BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/develop/BridgeServer2-vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcSubnetPrefix: "172.48"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/develop/bootstrap.yaml
+++ b/sceptre/bridge/config/develop/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/develop/bridge-aux.yaml
+++ b/sceptre/bridge/config/develop/bridge-aux.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: bridge-aux
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/develop/cfn-cr-saml-provider.yaml
+++ b/sceptre/bridge/config/develop/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/develop/peer-vpn-BridgeServer2-develop.yaml
+++ b/sceptre/bridge/config/develop/peer-vpn-BridgeServer2-develop.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/develop/peer-vpn-bridge-aux.yaml
+++ b/sceptre/bridge/config/develop/peer-vpn-bridge-aux.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/develop/rotate-credentials.yaml
+++ b/sceptre/bridge/config/develop/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/bridge/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/prod/BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/BridgeServer2-vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcSubnetPrefix: "172.32"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/prod/bootstrap.yaml
+++ b/sceptre/bridge/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/bridge/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/prod/guardduty-member.yaml
+++ b/sceptre/bridge/config/prod/guardduty-member.yaml
@@ -7,4 +7,4 @@ parameters:
   InvitationId: 7eb3d07072c3f8d9e77c87e161fe3137
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml --create-dirs -o templates/remote/GuardDutyMember.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/prod/peer-vpn-BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/peer-vpn-BridgeServer2-vpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/prod/rotate-credentials.yaml
+++ b/sceptre/bridge/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/prod/tgw-spoke-BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/tgw-spoke-BridgeServer2-vpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml --create-dirs -o templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/itsandbox/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/itsandbox/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/itsandbox/config/prod/bootstrap.yaml
+++ b/sceptre/itsandbox/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/itsandbox/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/itsandbox/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/itsandbox/config/prod/dustbunnyvpc.yaml
+++ b/sceptre/itsandbox/config/prod/dustbunnyvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: "dustbunnyvpc"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/itsandbox/config/prod/essentials.yaml
+++ b/sceptre/itsandbox/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm "/infra/AdmincentralAwsAccountId"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/itsandbox/config/prod/rotate-credentials.yaml
+++ b/sceptre/itsandbox/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/itsandbox/config/prod/sage-tgw-spoke.yaml
+++ b/sceptre/itsandbox/config/prod/sage-tgw-spoke.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml --create-dirs -o templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/logcentral/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/bootstrap.yaml
+++ b/sceptre/logcentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/logcentral/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/essentials.yaml
+++ b/sceptre/logcentral/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/guardduty-member.yaml
+++ b/sceptre/logcentral/config/prod/guardduty-member.yaml
@@ -7,4 +7,4 @@ parameters:
   InvitationId: 5ab3d0707465fa98488a783d295555dd
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml --create-dirs -o templates/remote/GuardDutyMember.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/logcentral/config/prod/peer-vpc-admincentral.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/rotate-credentials.yaml
+++ b/sceptre/logcentral/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/sumologic-role-s3cloudtrail.yaml
+++ b/sceptre/logcentral/config/prod/sumologic-role-s3cloudtrail.yaml
@@ -8,4 +8,4 @@ parameters:
   Resource: "arn:aws:s3:::essentials-awss3cloudtrailbucket-1jz6pf8dzid7r"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml --create-dirs -o templates/remote/sumologic-role.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/sumologic-role-s3config.yaml
+++ b/sceptre/logcentral/config/prod/sumologic-role-s3config.yaml
@@ -8,4 +8,4 @@ parameters:
   Resource: "arn:aws:s3:::essentials-awss3configbucket-9n8wjykhvr5z"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml --create-dirs -o templates/remote/sumologic-role.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/vpc.yaml
+++ b/sceptre/logcentral/config/prod/vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-   - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+   - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/organizations/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/organizations/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/organizations/config/prod/bootstrap.yaml
+++ b/sceptre/organizations/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/organizations/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/organizations/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/organizations/config/prod/essentials.yaml
+++ b/sceptre/organizations/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm "/infra/AdmincentralAwsAccountId"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/organizations/config/prod/rotate-credentials.yaml
+++ b/sceptre/organizations/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/sageit/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/bootstrap.yaml
+++ b/sceptre/sageit/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/sageit/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/sageit/config/prod/cfn-s3objects-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/defaultvpc.yaml
+++ b/sceptre/sageit/config/prod/defaultvpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpcName: sagedefaultvpc
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/essentials.yaml
+++ b/sceptre/sageit/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/peer-defaultvpc-admincentral.yaml
+++ b/sceptre/sageit/config/prod/peer-defaultvpc-admincentral.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/prod-csbc-pson-s3web.yaml
+++ b/sceptre/sageit/config/prod/prod-csbc-pson-s3web.yaml
@@ -9,4 +9,4 @@ parameters:
   OwnerEmail: michael.lee@sagebionetworks.org
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-s3WebCloudfront.yaml --create-dirs -o templates/remote/managed-s3WebCloudfront.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-s3WebCloudfront.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/rotate-credentials.yaml
+++ b/sceptre/sageit/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/sageit-org-acm-cert.yaml
+++ b/sceptre/sageit/config/prod/sageit-org-acm-cert.yaml
@@ -11,4 +11,4 @@ parameters:
   DnsDomainName: "sageit.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml --create-dirs -o templates/remote/acm-certificate.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/vpn-sageit-org-redirector.yaml
+++ b/sceptre/sageit/config/prod/vpn-sageit-org-redirector.yaml
@@ -18,4 +18,4 @@ parameters:
   TargetKey: "endpoints/cvpn-endpoint-055bd9db65af09d63"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/s3-redirector.yaml --create-dirs -o templates/remote/s3-redirector.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/s3-redirector.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/staging/staging-csbc-pson-s3web.yaml
+++ b/sceptre/sageit/config/staging/staging-csbc-pson-s3web.yaml
@@ -9,4 +9,4 @@ parameters:
   OwnerEmail: michael.lee@sagebionetworks.org
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-s3WebCloudfront.yaml --create-dirs -o templates/remote/managed-s3WebCloudfront.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-s3WebCloudfront.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/sandbox/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/bootstrap.yaml
+++ b/sceptre/sandbox/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/sandbox/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/cfn-explode-macro.yaml
+++ b/sceptre/sandbox/config/prod/cfn-explode-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-explode-macro/master/cfn-explode-macro.yaml --create-dirs -o templates/remote/cfn-explode-macro.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-explode-macro/master/cfn-explode-macro.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/sandbox/config/prod/cfn-s3objects-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/cfn-sc-actions-provider.yaml
+++ b/sceptre/sandbox/config/prod/cfn-sc-actions-provider.yaml
@@ -8,4 +8,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-sc-actions-provider.yaml --create-dirs -o templates/remote/cfn-sc-actions-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-sc-actions-provider.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/cfn-ssm-param-macro.yaml
+++ b/sceptre/sandbox/config/prod/cfn-ssm-param-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml --create-dirs -o templates/remote/cfn-macro-ssm-param.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/essentials.yaml
+++ b/sceptre/sandbox/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/park-my-cloud.yaml
+++ b/sceptre/sandbox/config/prod/park-my-cloud.yaml
@@ -6,4 +6,4 @@ parameters:
   PMCExternalID: !ssm /infra/PMCExternalID
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml --create-dirs -o templates/remote/ParkMyCloud.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/peer-vpn-sandcastlevpc.yaml
+++ b/sceptre/sandbox/config/prod/peer-vpn-sandcastlevpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/rotate-credentials.yaml
+++ b/sceptre/sandbox/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/s3-gateway-vpc-endpoint.yaml
+++ b/sceptre/sandbox/config/prod/s3-gateway-vpc-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/sage-tgw-spoke.yaml
+++ b/sceptre/sandbox/config/prod/sage-tgw-spoke.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml --create-dirs -o templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/sandcastlevpc.yaml
+++ b/sceptre/sandbox/config/prod/sandcastlevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: sandcastlevpc
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/service-linked-roles.yaml
+++ b/sceptre/sandbox/config/prod/service-linked-roles.yaml
@@ -4,4 +4,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml --create-dirs -o templates/remote/service-linked-roles.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/scicomp/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/bootstrap.yaml
+++ b/sceptre/scicomp/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/scicomp/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/scicomp/config/prod/cfn-s3objects-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
+++ b/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
@@ -5,4 +5,4 @@ parameters:
     - "563295687221"  # org-sagebase-sandbox
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cloudwatch-cross-account-sharing.yaml --create-dirs -o templates/remote/cloudwatch-cross-account-sharing.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cloudwatch-cross-account-sharing.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/computevpc.yaml
+++ b/sceptre/scicomp/config/prod/computevpc.yaml
@@ -5,4 +5,4 @@ parameters:
   VpcName: computevpc
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/essentials.yaml
+++ b/sceptre/scicomp/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/guardduty-member.yaml
+++ b/sceptre/scicomp/config/prod/guardduty-member.yaml
@@ -7,4 +7,4 @@ parameters:
   InvitationId: b8b3d07074f4b54d579c4927a4b5f78e
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml --create-dirs -o templates/remote/GuardDutyMember.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/park-my-cloud.yaml
+++ b/sceptre/scicomp/config/prod/park-my-cloud.yaml
@@ -6,4 +6,4 @@ parameters:
   PMCExternalID: !ssm /infra/PMCExternalID
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml --create-dirs -o templates/remote/ParkMyCloud.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/peer-vpn-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/peer-vpn-computevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/peer-vpn-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/peer-vpn-snowflakevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/rotate-credentials.yaml
+++ b/sceptre/scicomp/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/s3-computevpc-gateway-endpoint.yaml
+++ b/sceptre/scicomp/config/prod/s3-computevpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
+++ b/sceptre/scicomp/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/sage-tgw-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/sage-tgw-computevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/sage-tgw-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/sage-tgw-snowflakevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/sagebionetworks-org-acm-cert.yaml
+++ b/sceptre/scicomp/config/prod/sagebionetworks-org-acm-cert.yaml
@@ -11,4 +11,4 @@ parameters:
   DnsDomainName: "sagebionetworks.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml --create-dirs -o templates/remote/acm-certificate.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/service-linked-roles.yaml
+++ b/sceptre/scicomp/config/prod/service-linked-roles.yaml
@@ -4,4 +4,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml --create-dirs -o templates/remote/service-linked-roles.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/snowflakevpc.yaml
@@ -5,4 +5,4 @@ parameters:
   VpcName: snowflakevpc
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/sumologic-role.yaml
+++ b/sceptre/scicomp/config/prod/sumologic-role.yaml
@@ -8,4 +8,4 @@ parameters:
   Resource: !ssm /infra/BeanstalkBucketArn
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml --create-dirs -o templates/remote/sumologic-role.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/tgw-spoke-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/tgw-spoke-computevpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml --create-dirs -o templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/tgw-spoke-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/tgw-spoke-snowflakevpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml --create-dirs -o templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/develop/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/bootstrap.yaml
+++ b/sceptre/scipool/config/develop/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/cesspoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: "cesspoolvpc"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
@@ -13,4 +13,4 @@ parameters:
   OidcClientId: '100055'
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml --create-dirs -o templates/remote/cfn-cr-alb-rule.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/cfn-cr-saml-provider.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/cfn-cr-sc-actions-provider.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-sc-actions-provider.yaml
@@ -8,4 +8,4 @@ dependencies:
   - develop/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml --create-dirs -o templates/remote/cfn-cr-sc-actions-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-sc-bucket-policy.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/master/cfn-cr-sc-bucket-policy.yaml --create-dirs -o templates/remote/cfn-cr-sc-bucket-policy.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/master/cfn-cr-sc-bucket-policy.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-synapse-tagger.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.0.10/cfn-cr-synapse-tagger.yaml --create-dirs -o templates/remote/cfn-cr-synapse-tagger.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.0.10/cfn-cr-synapse-tagger.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/cfn-macro-ssm-param.yaml
+++ b/sceptre/scipool/config/develop/cfn-macro-ssm-param.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "develop/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml --create-dirs -o templates/remote/cfn-macro-ssm-param.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/cfn-s3objects-macro.yaml
+++ b/sceptre/scipool/config/develop/cfn-s3objects-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "develop/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/develop/cfn-tag-instance-policy.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "develop/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml --create-dirs -o templates/remote/cfn-tag-instance-policy.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/essentials.yaml
+++ b/sceptre/scipool/config/develop/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/lambda-budgets.yaml
+++ b/sceptre/scipool/config/develop/lambda-budgets.yaml
@@ -10,4 +10,4 @@ parameters:
   Thresholds: !file_contents templates/develop/lambda-budgets/thresholds.yaml
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml --create-dirs -o templates/remote/lambda-budgets.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/lambda-sc-cost-meter.yaml
+++ b/sceptre/scipool/config/develop/lambda-sc-cost-meter.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-cost-meter/master/lambda-sc-cost-meter.yaml --create-dirs -o templates/remote/lambda-sc-cost-meter.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-cost-meter/master/lambda-sc-cost-meter.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/lambda-send-budget-alert.yaml
+++ b/sceptre/scipool/config/develop/lambda-send-budget-alert.yaml
@@ -10,4 +10,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml --create-dirs -o templates/remote/lambda-send-budget-alert.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/maintenance.yaml
+++ b/sceptre/scipool/config/develop/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml --create-dirs -o templates/remote/maintenance.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/peer-vpn-cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/peer-vpn-cesspoolvpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: "10.1.0.0/16"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/rotate-credentials.yaml
+++ b/sceptre/scipool/config/develop/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/synapse-oidc-idp.yaml
+++ b/sceptre/scipool/config/develop/synapse-oidc-idp.yaml
@@ -10,4 +10,4 @@ parameters:
   ThumbprintList: "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml --create-dirs -o templates/remote/cfn-cr-oidc-idp.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/tgw-spoke-cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/tgw-spoke-cesspoolvpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml --create-dirs -o templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/bootstrap.yaml
+++ b/sceptre/scipool/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-alb-rule.yaml
@@ -13,4 +13,4 @@ parameters:
   OidcClientId: '100053'
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml --create-dirs -o templates/remote/cfn-cr-alb-rule.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/cfn-cr-sc-actions-provider.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-sc-actions-provider.yaml
@@ -8,4 +8,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml --create-dirs -o templates/remote/cfn-cr-sc-actions-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-sc-bucket-policy.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/master/cfn-cr-sc-bucket-policy.yaml --create-dirs -o templates/remote/cfn-cr-sc-bucket-policy.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/master/cfn-cr-sc-bucket-policy.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-synapse-tagger.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.0.10/cfn-cr-synapse-tagger.yaml --create-dirs -o templates/remote/cfn-cr-synapse-tagger.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.0.10/cfn-cr-synapse-tagger.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/cfn-macro-ssm-param.yaml
+++ b/sceptre/scipool/config/prod/cfn-macro-ssm-param.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml --create-dirs -o templates/remote/cfn-macro-ssm-param.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/scipool/config/prod/cfn-s3objects-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/prod/cfn-tag-instance-policy.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml --create-dirs -o templates/remote/cfn-tag-instance-policy.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/essentials.yaml
+++ b/sceptre/scipool/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/guardduty-member.yaml
+++ b/sceptre/scipool/config/prod/guardduty-member.yaml
@@ -7,4 +7,4 @@ parameters:
   InvitationId: "e8b856409ed7b77ef161631e7c91b9e6"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml --create-dirs -o templates/remote/GuardDutyMember.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/internalpoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: internalpoolvpc
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/lambda-budgets.yaml
+++ b/sceptre/scipool/config/prod/lambda-budgets.yaml
@@ -10,4 +10,4 @@ parameters:
   Thresholds: !file_contents templates/prod/lambda-budgets/thresholds.yaml
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml --create-dirs -o templates/remote/lambda-budgets.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/lambda-sc-cost-meter.yaml
+++ b/sceptre/scipool/config/prod/lambda-sc-cost-meter.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-cost-meter/master/lambda-sc-cost-meter.yaml --create-dirs -o templates/remote/lambda-sc-cost-meter.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-cost-meter/master/lambda-sc-cost-meter.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/lambda-send-budget-alert.yaml
+++ b/sceptre/scipool/config/prod/lambda-send-budget-alert.yaml
@@ -10,4 +10,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml --create-dirs -o templates/remote/lambda-send-budget-alert.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/maintenance.yaml
+++ b/sceptre/scipool/config/prod/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml --create-dirs -o templates/remote/maintenance.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/peer-vpn-internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/peer-vpn-internalpoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/rotate-credentials.yaml
+++ b/sceptre/scipool/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/s3-internalpoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/prod/s3-internalpoolvpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/synapse-oidc-idp.yaml
+++ b/sceptre/scipool/config/prod/synapse-oidc-idp.yaml
@@ -10,4 +10,4 @@ parameters:
   ThumbprintList: "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml --create-dirs -o templates/remote/cfn-cr-oidc-idp.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/tgw-spoke-internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/tgw-spoke-internalpoolvpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml --create-dirs -o templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/strides/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/bootstrap.yaml
+++ b/sceptre/scipool/config/strides/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-alb-rule.yaml
@@ -13,4 +13,4 @@ parameters:
   OidcClientId: '100063'
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml --create-dirs -o templates/remote/cfn-cr-alb-rule.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/cfn-cr-saml-provider.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/cfn-cr-sc-actions-provider.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-sc-actions-provider.yaml
@@ -8,4 +8,4 @@ dependencies:
   - strides/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml --create-dirs -o templates/remote/cfn-cr-sc-actions-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-sc-bucket-policy.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/master/cfn-cr-sc-bucket-policy.yaml --create-dirs -o templates/remote/cfn-cr-sc-bucket-policy.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/master/cfn-cr-sc-bucket-policy.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-synapse-tagger.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.0.10/cfn-cr-synapse-tagger.yaml --create-dirs -o templates/remote/cfn-cr-synapse-tagger.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.0.10/cfn-cr-synapse-tagger.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/cfn-macro-ssm-param.yaml
+++ b/sceptre/scipool/config/strides/cfn-macro-ssm-param.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "strides/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml --create-dirs -o templates/remote/cfn-macro-ssm-param.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/cfn-s3objects-macro.yaml
+++ b/sceptre/scipool/config/strides/cfn-s3objects-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "strides/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/strides/cfn-tag-instance-policy.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "strides/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml --create-dirs -o templates/remote/cfn-tag-instance-policy.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/essentials.yaml
+++ b/sceptre/scipool/config/strides/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"  # org-sagebase-admincentral
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/guardduty-member.yaml
+++ b/sceptre/scipool/config/strides/guardduty-member.yaml
@@ -7,4 +7,4 @@ parameters:
   InvitationId: "34ba75f792d6a90ecac857bb9989a639"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml --create-dirs -o templates/remote/GuardDutyMember.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/lambda-sc-cost-meter.yaml
+++ b/sceptre/scipool/config/strides/lambda-sc-cost-meter.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-cost-meter/master/lambda-sc-cost-meter.yaml --create-dirs -o templates/remote/lambda-sc-cost-meter.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-cost-meter/master/lambda-sc-cost-meter.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/maintenance.yaml
+++ b/sceptre/scipool/config/strides/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml --create-dirs -o templates/remote/maintenance.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/peer-vpn-stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/peer-vpn-stridespoolvpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: !stack_output_external stridespoolvpc::VpnCidr      # org-sagebase-admincentral sophos-utm VPN CIDR
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/rotate-credentials.yaml
+++ b/sceptre/scipool/config/strides/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/s3-stridespoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/strides/s3-stridespoolvpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/stridespoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: stridespoolvpc
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/synapse-oidc-idp.yaml
+++ b/sceptre/scipool/config/strides/synapse-oidc-idp.yaml
@@ -10,4 +10,4 @@ parameters:
   ThumbprintList: "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml --create-dirs -o templates/remote/cfn-cr-oidc-idp.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/tgw-spoke-stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/tgw-spoke-stridespoolvpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml --create-dirs -o templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/securitycentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/securitycentral/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/securitycentral/config/prod/bootstrap.yaml
+++ b/sceptre/securitycentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/securitycentral/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/securitycentral/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/securitycentral/config/prod/essentials.yaml
+++ b/sceptre/securitycentral/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/securitycentral/config/prod/rotate-credentials.yaml
+++ b/sceptre/securitycentral/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/synapsedev/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapsedev/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/synapsedev/config/prod/bootstrap.yaml
+++ b/sceptre/synapsedev/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/synapsedev/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/synapsedev/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/synapsedev/config/prod/essentials.yaml
+++ b/sceptre/synapsedev/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/synapsedev/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapsedev/config/prod/peer-vpc-admincentral.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/synapsedev/config/prod/rotate-credentials.yaml
+++ b/sceptre/synapsedev/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/synapsedev/config/prod/vpc.yaml
+++ b/sceptre/synapsedev/config/prod/vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/synapsedw/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapsedw/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/synapsedw/config/prod/bootstrap.yaml
+++ b/sceptre/synapsedw/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/synapsedw/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/synapsedw/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/synapsedw/config/prod/essentials.yaml
+++ b/sceptre/synapsedw/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/synapsedw/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapsedw/config/prod/peer-vpc-admincentral.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/synapsedw/config/prod/rotate-credentials.yaml
+++ b/sceptre/synapsedw/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/synapsedw/config/prod/vpc.yaml
+++ b/sceptre/synapsedw/config/prod/vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapseprod/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/bootstrap.yaml
+++ b/sceptre/synapseprod/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/synapseprod/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/essentials.yaml
+++ b/sceptre/synapseprod/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/guardduty-member.yaml
+++ b/sceptre/synapseprod/config/prod/guardduty-member.yaml
@@ -7,4 +7,4 @@ parameters:
   InvitationId: 7ab3d070757a69a548196c2a55c89830
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml --create-dirs -o templates/remote/GuardDutyMember.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapseprod/config/prod/peer-vpc-admincentral.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/rotate-credentials.yaml
+++ b/sceptre/synapseprod/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/synapse-ops-vpc-v2.yaml
+++ b/sceptre/synapseprod/config/prod/synapse-ops-vpc-v2.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/vpc.yaml
+++ b/sceptre/synapseprod/config/prod/vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-   - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+   - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/transit/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/transit/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/transit/config/prod/bootstrap.yaml
+++ b/sceptre/transit/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/transit/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/transit/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"

--- a/sceptre/transit/config/prod/essentials.yaml
+++ b/sceptre/transit/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/transit/config/prod/rotate-credentials.yaml
+++ b/sceptre/transit/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/transit/config/prod/unionstationvpc.yaml
+++ b/sceptre/transit/config/prod/unionstationvpc.yaml
@@ -8,4 +8,4 @@ parameters:
   VpnCidr: "10.50.0.0/16"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"


### PR DESCRIPTION
Sceptre downloads shared templates from our Sage CFN template repo
(https://bootstrap-awss3cloudformationbucket-19qromfd235z9.s3.amazonaws.com/index.html)

Curl would fail downloading templates intermittenly which caused
deployment failures in our CI/CD.  We attempt to fix this by using
wget instead. The benefits are:
 * by defaultt wget is set to retry 20 timees
 * -N option will download templates if it's newer than the existing
   file.  (does not work when downloading files from github)