### PR TITLE
[SC-240] Allow S3 Launch role to create policies

### DIFF
--- a/sceptre/scipool/templates/sc-s3-launchrole.yaml
+++ b/sceptre/scipool/templates/sc-s3-launchrole.yaml
@@ -28,6 +28,8 @@ Resources:
                 Action:
                   - "servicecatalog:ListServiceActionsForProvisioningArtifact"
                   - "servicecatalog:ExecuteprovisionedProductServiceAction"
+                  - "iam:CreatePolicy"
+                  - "iam:DeletePolicy"
                   - "iam:ListRolePolicies"
                   - "iam:ListPolicies"
                   - "iam:DeleteRole"
@@ -37,6 +39,7 @@ Resources:
                   - "iam:CreateRole"
                   - "iam:DetachRolePolicy"
                   - "iam:AttachRolePolicy"
+                  - "iam:PutRolePolicy"
                   - "iam:TagRole"
                   - "cloudformation:DescribeStackResource"
                   - "cloudformation:DescribeStackResources"


### PR DESCRIPTION
Setting up S3 same region access restriction requires creating
custom bucket policies. Allow the role that creates the bucket
permissions to create those policies.