### PR TITLE
grant SCS3LaunchRole Lambda Create/Delete permissions

### DIFF
--- a/sceptre/scipool/templates/sc-s3-launchrole.yaml
+++ b/sceptre/scipool/templates/sc-s3-launchrole.yaml
@@ -41,6 +41,8 @@ Resources:
                   - "iam:AttachRolePolicy"
                   - "iam:PutRolePolicy"
                   - "iam:TagRole"
+                  - "lambda:CreateFunction"
+                  - "lambda:DeleteFunction"
                   - "cloudformation:DescribeStackResource"
                   - "cloudformation:DescribeStackResources"
                   - "cloudformation:GetTemplate"

--- a/sceptre/scipool/templates/sc-s3-launchrole.yaml
+++ b/sceptre/scipool/templates/sc-s3-launchrole.yaml
@@ -41,6 +41,7 @@ Resources:
                   - "iam:DetachRolePolicy"
                   - "iam:AttachRolePolicy"
                   - "iam:PutRolePolicy"
+                  - "iam:DeleteRolePolicy"
                   - "iam:TagRole"
                   - "iam:ListPolicyVersions"
                   - "lambda:CreateFunction"

--- a/sceptre/scipool/templates/sc-s3-launchrole.yaml
+++ b/sceptre/scipool/templates/sc-s3-launchrole.yaml
@@ -42,10 +42,12 @@ Resources:
                   - "iam:AttachRolePolicy"
                   - "iam:PutRolePolicy"
                   - "iam:TagRole"
+                  - "iam:ListPolicyVersions"
                   - "lambda:CreateFunction"
                   - "lambda:DeleteFunction"
                   - "lambda:GetFunctionConfiguration"
                   - "lambda:AddPermission"
+                  - "lambda:RemovePermission"
                   - "cloudformation:DescribeStackResource"
                   - "cloudformation:DescribeStackResources"
                   - "cloudformation:GetTemplate"
@@ -62,6 +64,7 @@ Resources:
                   - "cloudformation:UpdateStack"
                   - "cloudformation:*ChangeSet*"
                   - "SNS:Subscribe"
+                  - "SNS:Unsubscribe"
                 Resource: '*'
 Outputs:
   LaunchRoleArn:

--- a/sceptre/scipool/templates/sc-s3-launchrole.yaml
+++ b/sceptre/scipool/templates/sc-s3-launchrole.yaml
@@ -44,6 +44,8 @@ Resources:
                   - "iam:TagRole"
                   - "lambda:CreateFunction"
                   - "lambda:DeleteFunction"
+                  - "lambda:GetFunctionConfiguration"
+                  - "lambda:AddPermission"
                   - "cloudformation:DescribeStackResource"
                   - "cloudformation:DescribeStackResources"
                   - "cloudformation:GetTemplate"
@@ -59,6 +61,7 @@ Resources:
                   - "cloudformation:ValidateTemplate"
                   - "cloudformation:UpdateStack"
                   - "cloudformation:*ChangeSet*"
+                  - "SNS:Subscribe"
                 Resource: '*'
 Outputs:
   LaunchRoleArn:

--- a/sceptre/scipool/templates/sc-s3-launchrole.yaml
+++ b/sceptre/scipool/templates/sc-s3-launchrole.yaml
@@ -29,6 +29,7 @@ Resources:
                   - "servicecatalog:ListServiceActionsForProvisioningArtifact"
                   - "servicecatalog:ExecuteprovisionedProductServiceAction"
                   - "iam:CreatePolicy"
+                  - "iam:GetPolicy"
                   - "iam:DeletePolicy"
                   - "iam:ListRolePolicies"
                   - "iam:ListPolicies"


### PR DESCRIPTION
Allow SCS3LaunchRole to create and Delete Lambda function, which is necessary for restricting S3 Bucket downloads to the same AWS region.
