### PR TITLE
IT-1071: Add a user for GHA to assume depoyer role

### DIFF
--- a/sceptre/sageit/config/prod/ghasvcaccount.yaml
+++ b/sceptre/sageit/config/prod/ghasvcaccount.yaml
@@ -1,0 +1,8 @@
+template_path: remote/service-account.yaml
+stack_name: gha-svc-account
+parameters:
+  ServiceUserPolicies:
+    ["arn:aws:iam::797640923903:role/accounts-AWSIAMPortalDeployerRole-17FJXSP3DEYFM"]
+hooks:
+  before_launch:
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-account.yaml -N -P templates/remote"

--- a/sceptre/sageit/templates/accounts.yaml
+++ b/sceptre/sageit/templates/accounts.yaml
@@ -8,8 +8,6 @@ Resources:
   #    MFA device, access-keys, ssh-keys, and policies.
   # 2. Detach the user from all groups.
   # EC2 instance role to deploy portals
-  AWSIAMGithubActionUser:
-    Type: AWS::IAM::User
   AWSIAMPortalDeployerPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -59,7 +57,6 @@ Resources:
             Effect: Allow
             Principal:
               - Service: ec2.amazonaws.com
-              - AWS: !GetAtt AWSIAMGithubActionUser.Arn
             Action:
               - sts:AssumeRole
       Path: /

--- a/sceptre/sageit/templates/accounts.yaml
+++ b/sceptre/sageit/templates/accounts.yaml
@@ -8,6 +8,8 @@ Resources:
   #    MFA device, access-keys, ssh-keys, and policies.
   # 2. Detach the user from all groups.
   # EC2 instance role to deploy portals
+  AWSIAMGithubActionUser:
+    Type: AWS::IAM::User
   AWSIAMPortalDeployerPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -56,7 +58,8 @@ Resources:
           -
             Effect: Allow
             Principal:
-              Service: ec2.amazonaws.com
+              - Service: ec2.amazonaws.com
+              - AWS: !GetAtt AWSIAMGithubActionUser.Arn
             Action:
               - sts:AssumeRole
       Path: /


### PR DESCRIPTION
[IT-1071] This PR adds a user for Github Actions in the sageit account, that user can assume the deployer role (same role currently used by the Jenkins deployer). The goal is to move the build/deploy from Jenkins to GHA. 


[IT-1071]: https://sagebionetworks.jira.com/browse/IT-1071