### PR TITLE
GHA svc account to deploy a portal

### DIFF
--- a/sceptre/sageit/config/prod/gha-svc-account.yaml
+++ b/sceptre/sageit/config/prod/gha-svc-account.yaml
@@ -1,0 +1,27 @@
+template_path: remote/service-account.yaml
+stack_name: gha-svc-account
+parameters:
+  PolicyDocument: >-
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": [
+            "s3:DeleteObject",
+            "s3:GetBucketLocation",
+            "s3:GetObject",
+            "s3:ListBucket",
+            "s3:ListObjects",
+            "s3:PutObject",
+            "cloudfront:CreateInvalidation",
+            "cloudfront:GetInvalidation",
+            "cloudfront:ListInvalidations"
+          ],
+          "Resource": "*",
+          "Effect": "Allow"
+        }
+      ]
+    }
+hooks:
+  before_launch:
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/IAM/service-account.yaml -N -P templates/remote"


### PR DESCRIPTION
This PR creates service role for for GHA to deploy a portal in the 'sageit' account. Trimmed down the permissions to S3 and CFront (needs to sync a build to S3 and create an invalidation'.
