### PR TITLE
IT-1039: Give idp roles access to keys

### DIFF
--- a/sceptre/synapsedev/templates/SynapseCMK-template.json
+++ b/sceptre/synapsedev/templates/SynapseCMK-template.json
@@ -180,6 +180,13 @@
                                         "cloudfront:*"
                                     ],
                                     "Resource": "*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "sts:AssumeRole"
+                                    ],
+                                    "Resource": "*"
                                 }
                             ]
                         }
@@ -247,6 +254,28 @@
                                         },
                                         {
                                             "Ref": "AWS::AccountId"
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    {
+                                                        "Fn::ImportValue": "us-east-1-jumpcloud-idp-SynapseDevDeveloperSamlProviderRoleId"
+                                                    },
+                                                    ":*"
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    {
+                                                        "Fn::ImportValue": "us-east-1-jumpcloud-idp-SynapseDevAdminSamlProviderRoleId"
+                                                    },
+                                                    ":*"
+                                                ]
+                                            ]
                                         }
                                     ]
                                 }
@@ -277,6 +306,12 @@
                                                 ":root"
                                             ]
                                         ]
+                                    },
+                                    {
+                                        "Fn::ImportValue": "us-east-1-jumpcloud-idp-SynapseDevDeveloperSamlProviderRoleArn"
+                                    },
+                                    {
+                                        "Fn::ImportValue": "us-east-1-jumpcloud-idp-SynapseDevAdminSamlProviderRoleArn"
                                     }
                                 ]
                             },


### PR DESCRIPTION
[IT-1039] This PR gives the idp roles access to the keys. This is necessary to be able to delete a Synapse stack when logged in thru JC at the console. This is prelim work to move away from IAM users to service accounts for the dev stacks.


[IT-1039]: https://sagebionetworks.jira.com/browse/IT-1039