### PR TITLE
[SC-306] Setup EFS for lambda

### DIFF
--- a/sceptre/scipool/config/develop/docker-runner-efs.yaml
+++ b/sceptre/scipool/config/develop/docker-runner-efs.yaml
@@ -1,0 +1,7 @@
+template_path: remote/efs.yaml
+stack_name: docker-runner-efs
+dependencies:
+  - develop/bootstrap.yaml
+hooks:
+  before_launch:
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/EFS/efs.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/docker-runner-efs.yaml
+++ b/sceptre/scipool/config/develop/docker-runner-efs.yaml
@@ -4,4 +4,4 @@ dependencies:
   - develop/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/EFS/efs.yaml -N -P templates/remote"
+    - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/EFS/efs.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/docker-runner-efs.yaml
+++ b/sceptre/scipool/config/prod/docker-runner-efs.yaml
@@ -1,0 +1,7 @@
+template_path: remote/efs.yaml
+stack_name: docker-runner-efs
+dependencies:
+  - develop/bootstrap.yaml
+hooks:
+  before_launch:
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/EFS/efs.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/docker-runner-efs.yaml
+++ b/sceptre/scipool/config/prod/docker-runner-efs.yaml
@@ -1,7 +1,7 @@
 template_path: remote/efs.yaml
 stack_name: docker-runner-efs
 dependencies:
-  - develop/bootstrap.yaml
+  - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/EFS/efs.yaml -N -P templates/remote"
+    - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/EFS/efs.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/docker-runner-efs.yaml
+++ b/sceptre/scipool/config/strides/docker-runner-efs.yaml
@@ -1,0 +1,7 @@
+template_path: remote/efs.yaml
+stack_name: docker-runner-efs
+dependencies:
+  - develop/bootstrap.yaml
+hooks:
+  before_launch:
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/EFS/efs.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/docker-runner-efs.yaml
+++ b/sceptre/scipool/config/strides/docker-runner-efs.yaml
@@ -1,7 +1,7 @@
 template_path: remote/efs.yaml
 stack_name: docker-runner-efs
 dependencies:
-  - develop/bootstrap.yaml
+  - strides/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/EFS/efs.yaml -N -P templates/remote"
+    - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/EFS/efs.yaml -N -P templates/remote"


### PR DESCRIPTION
Setup an elastic file system (EFS) to support a lambda to run
docker containers.  Lambdas have a hard storage limit of 512MB
so we create an EFS for the docker to attach to. This will provide
user apps with expanded storage.