### PR TITLE
Disable EBS encryption for imagecentral account

### DIFF
--- a/org-formation/300-account-defaults/_tasks.yaml
+++ b/org-formation/300-account-defaults/_tasks.yaml
@@ -7,6 +7,7 @@ Ec2EbsEncryptionDefaults:
   MaxConcurrentStacks: 10
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
+    ExcludeAccount: !Ref ImageCentralAccount
     Account: '*'
     Region: us-east-1
 


### PR DESCRIPTION
EBS encryption  needs to be disabled in order to build public image because
packer can no longer start unencrypted boot images
https://github.com/hashicorp/packer/issues/9529