### PR TITLE
update template references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,7 +122,7 @@ lambdas/*.zip
 .DS_Store
 
 # temp files
-/temp/
+temp/
 
 # pipenv
 Pipfile*

--- a/sceptre/admincentral/config/config.yaml
+++ b/sceptre/admincentral/config/config.yaml
@@ -4,3 +4,4 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: bootstrap-awss3cloudformationbucket-19qromfd235z9
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"

--- a/sceptre/admincentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/admincentral/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/admincentral/config/prod/bootstrap.yaml
+++ b/sceptre/admincentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/admincentral/config/prod/essentials.yaml
+++ b/sceptre/admincentral/config/prod/essentials.yaml
@@ -8,4 +8,4 @@ parameters:
   LambdaBucketVersioning: Enabled
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/admincentral/config/prod/it-services-s3-gateway-vpc-endpoint.yaml
+++ b/sceptre/admincentral/config/prod/it-services-s3-gateway-vpc-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/gateway-vpc-endpoint.yaml -N -P templates/remote"

--- a/sceptre/admincentral/config/prod/it-services.yaml
+++ b/sceptre/admincentral/config/prod/it-services.yaml
@@ -5,4 +5,4 @@ parameters:
   VpcName: it-services
 hooks:
   before_launch:
-   - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+   - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/admincentral/config/prod/peer-vpn-it-services.yaml
+++ b/sceptre/admincentral/config/prod/peer-vpn-it-services.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/config.yaml
+++ b/sceptre/bridge/config/config.yaml
@@ -3,3 +3,4 @@ project_code: sage-bionetworks
 region: {{ var.region | default("us-east-1") }}
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"

--- a/sceptre/bridge/config/develop/AccountAlertTopics.yaml
+++ b/sceptre/bridge/config/develop/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/develop/BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/develop/BridgeServer2-vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcSubnetPrefix: "172.48"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/develop/bootstrap.yaml
+++ b/sceptre/bridge/config/develop/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/develop/bridge-aux.yaml
+++ b/sceptre/bridge/config/develop/bridge-aux.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: bridge-aux
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/develop/peer-vpn-BridgeServer2-develop.yaml
+++ b/sceptre/bridge/config/develop/peer-vpn-BridgeServer2-develop.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/develop/peer-vpn-bridge-aux.yaml
+++ b/sceptre/bridge/config/develop/peer-vpn-bridge-aux.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/bridge/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/prod/BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/BridgeServer2-vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcSubnetPrefix: "172.32"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/prod/bootstrap.yaml
+++ b/sceptre/bridge/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/prod/guardduty-member.yaml
+++ b/sceptre/bridge/config/prod/guardduty-member.yaml
@@ -7,4 +7,4 @@ parameters:
   InvitationId: 7eb3d07072c3f8d9e77c87e161fe3137
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/GuardDutyMember.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/prod/peer-vpn-BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/peer-vpn-BridgeServer2-vpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/bridge/config/prod/tgw-spoke-BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/tgw-spoke-BridgeServer2-vpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/imagecentral/config/config.yaml
+++ b/sceptre/imagecentral/config/config.yaml
@@ -4,3 +4,4 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: bootstrap-awss3cloudformationbucket-smj37h9t0c4z
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"

--- a/sceptre/itsandbox/config/config.yaml
+++ b/sceptre/itsandbox/config/config.yaml
@@ -4,3 +4,4 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: bootstrap-awss3cloudformationbucket-l0axns15gl9h
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"

--- a/sceptre/itsandbox/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/itsandbox/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/itsandbox/config/prod/bootstrap.yaml
+++ b/sceptre/itsandbox/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/itsandbox/config/prod/dustbunnyvpc.yaml
+++ b/sceptre/itsandbox/config/prod/dustbunnyvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: "dustbunnyvpc"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/itsandbox/config/prod/essentials.yaml
+++ b/sceptre/itsandbox/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm "/infra/AdmincentralAwsAccountId"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/itsandbox/config/prod/sage-tgw-spoke.yaml
+++ b/sceptre/itsandbox/config/prod/sage-tgw-spoke.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/config.yaml
+++ b/sceptre/logcentral/config/config.yaml
@@ -4,3 +4,4 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: bootstrap-awss3cloudformationbucket-mgktko2ect4d
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"

--- a/sceptre/logcentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/logcentral/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/bootstrap.yaml
+++ b/sceptre/logcentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/essentials.yaml
+++ b/sceptre/logcentral/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/guardduty-member.yaml
+++ b/sceptre/logcentral/config/prod/guardduty-member.yaml
@@ -7,4 +7,4 @@ parameters:
   InvitationId: 5ab3d0707465fa98488a783d295555dd
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/GuardDutyMember.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/logcentral/config/prod/peer-vpc-admincentral.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/sumologic-role-s3cloudtrail.yaml
+++ b/sceptre/logcentral/config/prod/sumologic-role-s3cloudtrail.yaml
@@ -8,4 +8,4 @@ parameters:
   Resource: "arn:aws:s3:::essentials-awss3cloudtrailbucket-1jz6pf8dzid7r"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/sumologic-role.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/sumologic-role-s3config.yaml
+++ b/sceptre/logcentral/config/prod/sumologic-role-s3config.yaml
@@ -8,4 +8,4 @@ parameters:
   Resource: "arn:aws:s3:::essentials-awss3configbucket-9n8wjykhvr5z"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/sumologic-role.yaml -N -P templates/remote"

--- a/sceptre/logcentral/config/prod/vpc.yaml
+++ b/sceptre/logcentral/config/prod/vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-   - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+   - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/organizations/config/config.yaml
+++ b/sceptre/organizations/config/config.yaml
@@ -4,3 +4,4 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: "bootstrap-awss3cloudformationbucket-wyojnuok594o"
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"

--- a/sceptre/organizations/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/organizations/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/organizations/config/prod/bootstrap.yaml
+++ b/sceptre/organizations/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/organizations/config/prod/essentials.yaml
+++ b/sceptre/organizations/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm "/infra/AdmincentralAwsAccountId"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/config.yaml
+++ b/sceptre/sageit/config/config.yaml
@@ -4,3 +4,4 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: bootstrap-awss3cloudformationbucket-1n3izilcxyb3d
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"

--- a/sceptre/sageit/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/sageit/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/bootstrap.yaml
+++ b/sceptre/sageit/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/defaultvpc.yaml
+++ b/sceptre/sageit/config/prod/defaultvpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpcName: sagedefaultvpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/essentials.yaml
+++ b/sceptre/sageit/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/gha-svc-account.yaml
+++ b/sceptre/sageit/config/prod/gha-svc-account.yaml
@@ -24,4 +24,4 @@ parameters:
     }
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/IAM/service-account.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/IAM/service-account.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/peer-defaultvpc-admincentral.yaml
+++ b/sceptre/sageit/config/prod/peer-defaultvpc-admincentral.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/prod-csbc-pson-s3web.yaml
+++ b/sceptre/sageit/config/prod/prod-csbc-pson-s3web.yaml
@@ -9,4 +9,4 @@ parameters:
   OwnerEmail: michael.lee@sagebionetworks.org
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-s3WebCloudfront.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/managed-s3WebCloudfront.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/sageit-org-acm-cert.yaml
+++ b/sceptre/sageit/config/prod/sageit-org-acm-cert.yaml
@@ -11,4 +11,4 @@ parameters:
   DnsDomainName: "sageit.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/acm-certificate.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/prod/vpn-sageit-org-redirector.yaml
+++ b/sceptre/sageit/config/prod/vpn-sageit-org-redirector.yaml
@@ -18,4 +18,4 @@ parameters:
   TargetKey: "endpoints/cvpn-endpoint-055bd9db65af09d63"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/s3-redirector.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/s3-redirector.yaml -N -P templates/remote"

--- a/sceptre/sageit/config/staging/staging-csbc-pson-s3web.yaml
+++ b/sceptre/sageit/config/staging/staging-csbc-pson-s3web.yaml
@@ -9,4 +9,4 @@ parameters:
   OwnerEmail: michael.lee@sagebionetworks.org
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-s3WebCloudfront.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/managed-s3WebCloudfront.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/config.yaml
+++ b/sceptre/sandbox/config/config.yaml
@@ -4,3 +4,4 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: bootstrap-awss3cloudformationbucket-z6hnifi9i3p
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"

--- a/sceptre/sandbox/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/sandbox/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/bootstrap.yaml
+++ b/sceptre/sandbox/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/cfn-sc-actions-provider.yaml
+++ b/sceptre/sandbox/config/prod/cfn-sc-actions-provider.yaml
@@ -8,4 +8,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-sc-actions-provider.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/cfn-sc-actions-provider.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/essentials.yaml
+++ b/sceptre/sandbox/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/park-my-cloud.yaml
+++ b/sceptre/sandbox/config/prod/park-my-cloud.yaml
@@ -6,4 +6,4 @@ parameters:
   PMCExternalID: !ssm /infra/PMCExternalID
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/ParkMyCloud.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/peer-vpn-sandcastlevpc.yaml
+++ b/sceptre/sandbox/config/prod/peer-vpn-sandcastlevpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/s3-gateway-vpc-endpoint.yaml
+++ b/sceptre/sandbox/config/prod/s3-gateway-vpc-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/gateway-vpc-endpoint.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/sage-tgw-spoke.yaml
+++ b/sceptre/sandbox/config/prod/sage-tgw-spoke.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/sandcastlevpc.yaml
+++ b/sceptre/sandbox/config/prod/sandcastlevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: sandcastlevpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/sandbox/config/prod/service-linked-roles.yaml
+++ b/sceptre/sandbox/config/prod/service-linked-roles.yaml
@@ -4,4 +4,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/service-linked-roles.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/config.yaml
+++ b/sceptre/scicomp/config/config.yaml
@@ -4,3 +4,4 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: bootstrap-awss3cloudformationbucket-114n2ojlbvj21
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"

--- a/sceptre/scicomp/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/scicomp/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/bootstrap.yaml
+++ b/sceptre/scicomp/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
+++ b/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
@@ -5,4 +5,4 @@ parameters:
     - "563295687221"  # org-sagebase-sandbox
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cloudwatch-cross-account-sharing.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/cloudwatch-cross-account-sharing.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/computevpc.yaml
+++ b/sceptre/scicomp/config/prod/computevpc.yaml
@@ -5,4 +5,4 @@ parameters:
   VpcName: computevpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/essentials.yaml
+++ b/sceptre/scicomp/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/guardduty-member.yaml
+++ b/sceptre/scicomp/config/prod/guardduty-member.yaml
@@ -7,4 +7,4 @@ parameters:
   InvitationId: b8b3d07074f4b54d579c4927a4b5f78e
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/GuardDutyMember.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/park-my-cloud.yaml
+++ b/sceptre/scicomp/config/prod/park-my-cloud.yaml
@@ -6,4 +6,4 @@ parameters:
   PMCExternalID: !ssm /infra/PMCExternalID
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/ParkMyCloud.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/peer-vpn-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/peer-vpn-computevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/peer-vpn-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/peer-vpn-snowflakevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/s3-computevpc-gateway-endpoint.yaml
+++ b/sceptre/scicomp/config/prod/s3-computevpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/gateway-vpc-endpoint.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
+++ b/sceptre/scicomp/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/gateway-vpc-endpoint.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/sage-tgw-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/sage-tgw-computevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/transit-gateway-attachment.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/sage-tgw-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/sage-tgw-snowflakevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/transit-gateway-attachment.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/sagebionetworks-org-acm-cert.yaml
+++ b/sceptre/scicomp/config/prod/sagebionetworks-org-acm-cert.yaml
@@ -11,4 +11,4 @@ parameters:
   DnsDomainName: "sagebionetworks.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/acm-certificate.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/service-linked-roles.yaml
+++ b/sceptre/scicomp/config/prod/service-linked-roles.yaml
@@ -4,4 +4,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/service-linked-roles.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/snowflakevpc.yaml
@@ -5,4 +5,4 @@ parameters:
   VpcName: snowflakevpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/sumologic-role.yaml
+++ b/sceptre/scicomp/config/prod/sumologic-role.yaml
@@ -8,4 +8,4 @@ parameters:
   Resource: !ssm /infra/BeanstalkBucketArn
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/sumologic-role.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/tgw-spoke-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/tgw-spoke-computevpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/scicomp/config/prod/tgw-spoke-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/tgw-spoke-snowflakevpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/config.yaml
+++ b/sceptre/scipool/config/config.yaml
@@ -3,4 +3,5 @@ project_code: "sage-bionetworks"
 region: {{ var.region | default("us-east-1") }}
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"
 service_catalog_library: "service-catalog-library"

--- a/sceptre/scipool/config/develop/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/develop/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/bootstrap.yaml
+++ b/sceptre/scipool/config/develop/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/cesspoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: "cesspoolvpc"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/develop/cfn-tag-instance-policy.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "develop/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/cfn-tag-instance-policy.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/essentials.yaml
+++ b/sceptre/scipool/config/develop/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/maintenance.yaml
+++ b/sceptre/scipool/config/develop/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/maintenance.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/peer-vpn-cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/peer-vpn-cesspoolvpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: "10.1.0.0/16"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/gateway-vpc-endpoint.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/develop/tgw-spoke-cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/tgw-spoke-cesspoolvpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/bootstrap.yaml
+++ b/sceptre/scipool/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/prod/cfn-tag-instance-policy.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/cfn-tag-instance-policy.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/essentials.yaml
+++ b/sceptre/scipool/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/guardduty-member.yaml
+++ b/sceptre/scipool/config/prod/guardduty-member.yaml
@@ -7,4 +7,4 @@ parameters:
   InvitationId: "e8b856409ed7b77ef161631e7c91b9e6"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/GuardDutyMember.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/internalpoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: internalpoolvpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/maintenance.yaml
+++ b/sceptre/scipool/config/prod/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/maintenance.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/peer-vpn-internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/peer-vpn-internalpoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/s3-internalpoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/prod/s3-internalpoolvpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/gateway-vpc-endpoint.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/tgw-spoke-internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/tgw-spoke-internalpoolvpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/strides/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/bootstrap.yaml
+++ b/sceptre/scipool/config/strides/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/strides/cfn-tag-instance-policy.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "strides/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/cfn-tag-instance-policy.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/essentials.yaml
+++ b/sceptre/scipool/config/strides/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"  # org-sagebase-admincentral
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/guardduty-member.yaml
+++ b/sceptre/scipool/config/strides/guardduty-member.yaml
@@ -7,4 +7,4 @@ parameters:
   InvitationId: "34ba75f792d6a90ecac857bb9989a639"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/GuardDutyMember.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/maintenance.yaml
+++ b/sceptre/scipool/config/strides/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/maintenance.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/peer-vpn-stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/peer-vpn-stridespoolvpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: !stack_output_external stridespoolvpc::VpnCidr      # org-sagebase-admincentral sophos-utm VPN CIDR
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/rotate-credentials.yaml
+++ b/sceptre/scipool/config/strides/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/rotate-credentials.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/s3-stridespoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/strides/s3-stridespoolvpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/gateway-vpc-endpoint.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/stridespoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: stridespoolvpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/tgw-spoke-stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/tgw-spoke-stridespoolvpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/transit-gateway-spoke.yaml -N -P templates/remote"

--- a/sceptre/securitycentral/config/config.yaml
+++ b/sceptre/securitycentral/config/config.yaml
@@ -4,3 +4,4 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: bootstrap-awss3cloudformationbucket-4kli9fevbzjn
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"

--- a/sceptre/securitycentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/securitycentral/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/securitycentral/config/prod/bootstrap.yaml
+++ b/sceptre/securitycentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/securitycentral/config/prod/essentials.yaml
+++ b/sceptre/securitycentral/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/synapsedev/config/config.yaml
+++ b/sceptre/synapsedev/config/config.yaml
@@ -4,3 +4,4 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: bootstrap-awss3cloudformationbucket-1wg2dfoc7pfei
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"

--- a/sceptre/synapsedev/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapsedev/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/synapsedev/config/prod/bootstrap.yaml
+++ b/sceptre/synapsedev/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/synapsedev/config/prod/essentials.yaml
+++ b/sceptre/synapsedev/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/synapsedev/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapsedev/config/prod/peer-vpc-admincentral.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/synapsedev/config/prod/vpc.yaml
+++ b/sceptre/synapsedev/config/prod/vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/synapsedw/config/config.yaml
+++ b/sceptre/synapsedw/config/config.yaml
@@ -4,3 +4,4 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: bootstrap-awss3cloudformationbucket-igkja54vcica
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"

--- a/sceptre/synapsedw/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapsedw/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/synapsedw/config/prod/bootstrap.yaml
+++ b/sceptre/synapsedw/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/synapsedw/config/prod/essentials.yaml
+++ b/sceptre/synapsedw/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/synapsedw/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapsedw/config/prod/peer-vpc-admincentral.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/synapsedw/config/prod/vpc.yaml
+++ b/sceptre/synapsedw/config/prod/vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/config.yaml
+++ b/sceptre/synapseprod/config/config.yaml
@@ -4,3 +4,4 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: bootstrap-awss3cloudformationbucket-u7g8la3mrvxv
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"

--- a/sceptre/synapseprod/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapseprod/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/bootstrap.yaml
+++ b/sceptre/synapseprod/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/essentials.yaml
+++ b/sceptre/synapseprod/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/guardduty-member.yaml
+++ b/sceptre/synapseprod/config/prod/guardduty-member.yaml
@@ -7,4 +7,4 @@ parameters:
   InvitationId: 7ab3d070757a69a548196c2a55c89830
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/GuardDutyMember.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapseprod/config/prod/peer-vpc-admincentral.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/peer-route-config.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/synapse-ops-vpc-v2.yaml
+++ b/sceptre/synapseprod/config/prod/synapse-ops-vpc-v2.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/synapseprod/config/prod/vpc.yaml
+++ b/sceptre/synapseprod/config/prod/vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-   - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+   - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"

--- a/sceptre/transit/config/config.yaml
+++ b/sceptre/transit/config/config.yaml
@@ -4,3 +4,4 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: "bootstrap-awss3cloudformationbucket-1xwtf97lo91vb"
 template_key_prefix: {{ environment_variable.GITHUB_REF | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+aws_infra_url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra"

--- a/sceptre/transit/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/transit/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/AccountAlertTopics.yaml -N -P templates/remote"

--- a/sceptre/transit/config/prod/bootstrap.yaml
+++ b/sceptre/transit/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/bootstrap.yaml -N -P templates/remote"

--- a/sceptre/transit/config/prod/essentials.yaml
+++ b/sceptre/transit/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/essentials.yaml -N -P templates/remote"

--- a/sceptre/transit/config/prod/unionstationvpc.yaml
+++ b/sceptre/transit/config/prod/unionstationvpc.yaml
@@ -8,4 +8,4 @@ parameters:
   VpnCidr: "10.50.0.0/16"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_url}}/master/vpc.yaml -N -P templates/remote"


### PR DESCRIPTION
Our workflow has been to add CFN template files to aws-infra repo let the
CI deploy to S3 bucket then reference the file from the S3 bucket.  This
changes it so that we reference the file directly from GH instead of the S3
bucket.