### PR TITLE
[IT-1101] Setup budget notifications

### DIFF
--- a/org-formation/040-budgets/README.md
+++ b/org-formation/040-budgets/README.md
@@ -1,0 +1,24 @@
+### Purpose of these templates
+The single template in this folder deploys a budget and a budget alarm to each account based on tags in the account specification. The alert when the threshold is met will be sent to the e-mail address specified on the account.
+
+As an example, consider the following account:
+
+``` yaml
+  TempDevAccount:
+    Type: OC::ORG::Account
+    Properties:
+      Alias: ba-temp-dev
+      AccountName: Temporary Development Account
+      AccountId: '215869187117'
+      RootEmail: aws-temp-dev@bee.awesome
+      Tags:
+        budget-alarm-threshold: 200
+        budget-alarm-threshold-email-recipient: aws-budget-owner@bee.awesome
+```
+
+This account has a budget threshold set for $200 monthly. An email with a budget alarm will be sent when:
+- forecasted spent (end of month) exceeds 200 usd (100% of threshold)
+- actual spent (month to date) exceeds 160 usd (80% of threshold)
+- actual spent (month to date) exceeds 200 usd (100% of threshold)
+
+The alerts will be sent to `aws-budget-owner@bee.awesome`.

--- a/org-formation/040-budgets/_tasks.yaml
+++ b/org-formation/040-budgets/_tasks.yaml
@@ -1,5 +1,5 @@
 Parameters:
-  <<: !Include '../_parameters.yml'
+  <<: !Include '../_parameters.yaml'
 
 BudgetAlarms:
   Type: update-stacks

--- a/org-formation/040-budgets/_tasks.yml
+++ b/org-formation/040-budgets/_tasks.yml
@@ -1,0 +1,15 @@
+Parameters:
+  <<: !Include '../_parameters.yml'
+
+BudgetAlarms:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/Billing/budgets.yaml
+  StackName: !Sub '${resourcePrefix}-billing-alarm'
+  TerminationProtection: false
+  DefaultOrganizationBinding:
+    Region: !Ref primaryRegion
+    AccountsWithTag: budget-alarm-threshold
+  Parameters:
+    budgetName: !Sub '${resourcePrefix}-budget-${CurrentAccount.AccountId}'
+    budgetAmount: !GetAtt CurrentAccount.Tags.budget-alarm-threshold
+    emailAddress: !GetAtt CurrentAccount.Tags.budget-alarm-threshold-email-recipient

--- a/org-formation/_tasks.yaml
+++ b/org-formation/_tasks.yaml
@@ -37,6 +37,11 @@ SeviceControlPolicies:
   DependsOn: [ Types ]
   Path: ./010-scps/_tasks.yaml
 
+Budgets:
+  Type: include
+  DependsOn: [ Types ]
+  Path: ./040-budgets/_tasks.yaml
+
 Baseline:
   Type: include
   DependsOn: [ Types ]


### PR DESCRIPTION
Setup a AWS account budget notification. This will allow us to configure
a budget on an account with tags.  Notifications are sent when an account
exceeds the budget.

depends on https://github.com/Sage-Bionetworks/aws-infra/pull/286