### PR TITLE
PLFM-5619: Add permissions to enable platform autoupdates

### DIFF
--- a/sceptre/synapsedev/templates/SynapseCMK-template.json
+++ b/sceptre/synapsedev/templates/SynapseCMK-template.json
@@ -114,7 +114,8 @@
                                         "iam:DeleteInstanceProfile",
                                         "iam:GetInstanceProfile",
                                         "iam:RemoveRoleFromInstanceProfile",
-                                        "iam:AddRoleToInstanceProfile"
+                                        "iam:AddRoleToInstanceProfile",
+                                        "iam:CreateServiceLinkedRole"
                                     ],
                                     "Resource": "*"
                                 },

--- a/sceptre/synapsedev/templates/SynapseCMK-template.json
+++ b/sceptre/synapsedev/templates/SynapseCMK-template.json
@@ -188,6 +188,13 @@
                                         "sts:AssumeRole"
                                     ],
                                     "Resource": "*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:*"
+                                    ],
+                                    "Resource": "*"
                                 }
                             ]
                         }


### PR DESCRIPTION
[PLFM-5619]: Adding various permissions to get the beanstalk stack enabled for platform updates
This is already deployed in dev account, just keep this synced.
Will add to prod config.
