### PR TITLE
[IT-1101] re-org OUs and SCPs

### DIFF
--- a/org-formation/010-scps/_tasks.yaml
+++ b/org-formation/010-scps/_tasks.yaml
@@ -32,7 +32,7 @@ PreventDisableCloudwatchConfigs:
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
   Parameters:
-    targetIds: [ !Ref TestOU ]
+    targetIds: [ !Ref PolicyStagingOU ]
 
 DenyAllRegionsOutsideUsEast1:
   Type: update-stacks
@@ -43,7 +43,7 @@ DenyAllRegionsOutsideUsEast1:
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
   Parameters:
-    targetIds: [ !Ref ITOU, !Ref ScipoolDevAccount, !Ref ScipoolProdAccount, !Ref ScicompAccount]
+    targetIds: [ !Ref ItProdOU, !Ref ScienceProdOU]
 
 DenyAllRegionsOutsideUs:
   Type: update-stacks

--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -18,16 +18,23 @@ Organization:
     Properties:
       DefaultOrganizationAccessRoleName: OrganizationAccountAccessRole
 
-  ScienceOU:
+  ScienceDevOU:
     Type: OC::ORG::OrganizationalUnit
     Properties:
-      OrganizationalUnitName: science
+      OrganizationalUnitName: ScienceDev
       Accounts:
         - !Ref ScipoolDevAccount
-        - !Ref ScipoolProdAccount
-        - !Ref ScicompAccount
         - !Ref SandboxAccount
         - !Ref MobileHealthDataEngineeringAccount
+        - !Ref SageITAccount
+
+  ScienceProdOU:
+    Type: OC::ORG::OrganizationalUnit
+    Properties:
+      OrganizationalUnitName: ScienceProd
+      Accounts:
+        - !Ref ScipoolProdAccount
+        - !Ref ScicompAccount
 
   PlatformOU:
     Type: OC::ORG::OrganizationalUnit
@@ -37,11 +44,15 @@ Organization:
         - !Ref SynapseOU
         - !Ref BridgeOU
 
-  ITOU:
+  ItDevOU:
     Type: OC::ORG::OrganizationalUnit
     Properties:
-      OrganizationalUnitName: IT
-      OrganizationalUnits: !Ref TestOU
+      OrganizationalUnitName: ItDev
+
+  ItProdOU:
+    Type: OC::ORG::OrganizationalUnit
+    Properties:
+      OrganizationalUnitName: ItProd
       Accounts:
         - !Ref TransitAccount
         - !Ref AdminCentralAccount
@@ -49,12 +60,13 @@ Organization:
         - !Ref LogCentralAccount
         - !Ref SecurityCentralAccount
         - !Ref ImageCentralAccount
-        - !Ref ITSandboxAccount
 
-  TestOU:
+  PolicyStagingOU:
     Type: OC::ORG::OrganizationalUnit
     Properties:
-      OrganizationalUnitName: test
+      OrganizationalUnitName: PolicyStaging
+      Accounts:
+        - !Ref ITSandboxAccount
 
   SynapseOU:
     Type: OC::ORG::OrganizationalUnit


### PR DESCRIPTION
Re organize accounts and org units to separate dev and prod accounts.
Update SCPs on OUs and accounts.  This brings in more inline with AWS best
practice for organizations[1]

[1] https://docs.aws.amazon.com/whitepapers/latest/organizing-your-aws-environment/recommended-ous.html