### PR TITLE
[SC-148] Remove parkmycloud from sandbox

### DIFF
--- a/sceptre/sandbox/config/prod/park-my-cloud.yaml
+++ b/sceptre/sandbox/config/prod/park-my-cloud.yaml
@@ -1,9 +1,0 @@
-template_path: remote/ParkMyCloud.yaml
-stack_name: park-my-cloud
-dependencies:
-  - prod/bootstrap.yaml
-parameters:
-  PMCExternalID: !ssm /infra/PMCExternalID
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml -N -P templates/remote"


### PR DESCRIPTION
Sandbox provisioner has been deprecated.  Users have full access to the
EC2 console to start/stop/restart their instances so we no longer
need PMC for sandbox account.