### PR TITLE
improve ofn performance

### DIFF
--- a/org-formation/005-types/_tasks.yaml
+++ b/org-formation/005-types/_tasks.yaml
@@ -11,7 +11,6 @@ NoDefaultVpcRp:
   Type: register-type
   ResourceType: 'Community::Organizations::NoDefaultVPC'
   SchemaHandlerPackage: !Sub 's3://${catalogBucket}/community-organizations-nodefaultvpc-0.1.0.zip'
-  MaxConcurrentTasks: 100
   OrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'
@@ -21,7 +20,6 @@ EbsEncryptionDefaultsRp:
   Type: register-type
   ResourceType: 'Community::Organizations::EbsEncryptionDefaults'
   SchemaHandlerPackage: !Sub 's3://${catalogBucket}/community-ec2-ebsencryptiondefaults-0.2.0.zip'
-  MaxConcurrentTasks: 100
   OrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'
@@ -31,7 +29,6 @@ OrganizationsPolicyRp:
   Type: register-type
   ResourceType: 'Community::Organizations::Policy'
   SchemaHandlerPackage: !Sub 's3://${catalogBucket}/community-organizations-policy-0.1.0.zip'
-  MaxConcurrentTasks: 100
   OrganizationBinding:
     IncludeMasterAccount: true
     Region: !Ref primaryRegion # Only compatible to us-east-1 region
@@ -40,7 +37,6 @@ AccountPublicAccessBlockRp:
   Type: register-type
   ResourceType: 'Community::S3::PublicAccessBlock'
   SchemaHandlerPackage: !Sub 's3://${catalogBucket}/community-s3-publicaccessblock-0.2.0.zip'
-  MaxConcurrentTasks: 100
   OrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'
@@ -50,7 +46,6 @@ OrganizationsDelegatedAdminRp:
   Type: register-type
   ResourceType: 'Community::Organizations::DelegatedAdmin'
   SchemaHandlerPackage: !Sub 's3://${catalogBucket}/community-organizations-delegatedadmin-0.1.0.zip'
-  MaxConcurrentTasks: 100
   OrganizationBinding:
     IncludeMasterAccount: true
     Region: !Ref primaryRegion # Only compatible to us-east-1 region
@@ -59,7 +54,6 @@ EnableAWSServiceRp:
   Type: register-type
   ResourceType: 'Community::Organizations::EnableAWSServiceAccess'
   SchemaHandlerPackage: !Sub 's3://${catalogBucket}/community-organizations-enableawsserviceaccess-0.1.0.zip'
-  MaxConcurrentTasks: 100
   OrganizationBinding:
     IncludeMasterAccount: true
     Region: !Ref primaryRegion # Only compatible to us-east-1 region
@@ -68,7 +62,6 @@ PasswordPolicyRp:
   Type: register-type
   ResourceType: 'Community::IAM::PasswordPolicy'
   SchemaHandlerPackage: !Sub 's3://${catalogBucket}/community-iam-passwordpolicy-0.2.0.zip'
-  MaxConcurrentTasks: 10
   OrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'
@@ -78,7 +71,6 @@ ServiceQuotasS3Rp:
   Type: register-type
   ResourceType: 'Community::ServiceQuotas::S3'
   SchemaHandlerPackage: !Sub 's3://${catalogBucket}/community-servicequotas-s3-0.1.0.zip'
-  MaxConcurrentTasks: 100
   OrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'
@@ -88,7 +80,6 @@ ServiceQuotasCloudFormationRp:
   Type: register-type
   ResourceType: 'Community::ServiceQuotas::CloudFormation'
   SchemaHandlerPackage: !Sub 's3://${catalogBucket}/community-servicequotas-cloudformation-0.1.0.zip'
-  MaxConcurrentTasks: 100
   OrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'
@@ -98,7 +89,6 @@ ServiceQuotasDynamoDbRp:
   Type: register-type
   ResourceType: 'Community::ServiceQuotas::DynamoDB'
   SchemaHandlerPackage: !Sub 's3://${catalogBucket}/community-servicequotas-dynamodb-0.1.0.zip'
-  MaxConcurrentTasks: 100
   OrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'
@@ -108,7 +98,6 @@ SsoAssignmentGroupRp:
   Type: register-type
   ResourceType: 'Community::SSO::AssignmentGroup'
   SchemaHandlerPackage: !Sub 's3://${catalogBucket}/community-sso-assignmentgroup-0.3.1.zip'
-  MaxConcurrentTasks: 10
   OrganizationBinding:
     IncludeMasterAccount: true
     Region: !Ref primaryRegion

--- a/org-formation/010-scps/_tasks.yaml
+++ b/org-formation/010-scps/_tasks.yaml
@@ -5,7 +5,6 @@ PreventDisableGuardDuty:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/prevent-disable-guardduty.yaml
   StackName: !Sub '${resourcePrefix}-prevent-disable-guardduty'
-  MaxConcurrentStacks: 10
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
@@ -16,7 +15,6 @@ PreventDisableCloudtrail:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/prevent-disable-cloudtrail.yaml
   StackName: !Sub '${resourcePrefix}-prevent-disable-cloudtrail'
-  MaxConcurrentStacks: 10
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
@@ -27,7 +25,6 @@ PreventDisableCloudwatchConfigs:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/prevent-disable-cloudwatch-configs.yaml
   StackName: !Sub '${resourcePrefix}-prevent-disable-cloudwatch-configs'
-  MaxConcurrentStacks: 10
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
@@ -38,7 +35,6 @@ DenyAllRegionsOutsideUsEast1:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/deny-all-regions-outside-us-east-1.yaml
   StackName: !Sub '${resourcePrefix}-deny-all-regions-outside-us-east-1'
-  MaxConcurrentStacks: 10
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
@@ -49,7 +45,6 @@ DenyAllRegionsOutsideUs:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/deny-all-regions-outside-us.yaml
   StackName: !Sub '${resourcePrefix}-deny-all-regions-outside-us'
-  MaxConcurrentStacks: 10
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     IncludeMasterAccount: true

--- a/org-formation/200-baseline/_tasks.yaml
+++ b/org-formation/200-baseline/_tasks.yaml
@@ -5,7 +5,6 @@ PasswordPolicy:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/ORG/password-policy.yaml
   StackName: baseline-password-policy
-  MaxConcurrentStacks: 10
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'
@@ -17,7 +16,6 @@ OrgFormationBuildAccessRole:
   StackName: org-formation-build-access-role
   Parameters:
     MasterAccountId: !Ref MasterAccount
-  MaxConcurrentStacks: 10
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'

--- a/org-formation/300-account-defaults/_tasks.yaml
+++ b/org-formation/300-account-defaults/_tasks.yaml
@@ -5,7 +5,6 @@ Ec2EbsEncryptionDefaults:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/EC2/ec2-ebs-encryption.yaml
   StackName: account-default-ec2-ebs-encryption
-  MaxConcurrentStacks: 10
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
     ExcludeAccount: !Ref ImageCentralAccount
@@ -16,7 +15,6 @@ Ec2NoVpcDefaults:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/VPC/ec2-no-default-vpc.yaml
   StackName: ec2-no-default-vpc
-  MaxConcurrentStacks: 10
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
     Account: !Ref MasterAccount
@@ -26,7 +24,6 @@ SceptreCloudformationBucket:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/S3/public-bucket.yaml
   StackName: sceptre-cloudformation-bucket
-  MaxConcurrentStacks: 10
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'
@@ -36,7 +33,6 @@ SceptreLambdaBucket:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/S3/public-bucket.yaml
   StackName: sceptre-lambda-bucket
-  MaxConcurrentStacks: 10
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'
@@ -46,7 +42,6 @@ ItKmsKey:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/KMS/kms-key.yaml
   StackName: it-kms-key
-  MaxConcurrentStacks: 10
   Parameters:
     AliasName: alias/it-infra
     AdminPrincipalArns:

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -5,7 +5,6 @@ AccessOrganizationsAdmin:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/jumpcloud-idp.yaml
   StackName: access-organizations-admin
-  MaxConcurrentStacks: 10
   Parameters:
     MetadataDocument: !ReadFile ./MetadataDocuments/organizations-admin.xml
     SamlProviderName: organizations-admin
@@ -20,7 +19,6 @@ JCMobileHealthDataEngineeringAdmin:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/jumpcloud-idp.yaml
   StackName: jc-mobilehealth-dataengineering-admin
-  MaxConcurrentStacks: 10
   Parameters:
     MetadataDocument: !ReadFile ./MetadataDocuments/mobilehealth-dataengineering-admin.xml
     SamlProviderName: mobilehealth-dataengineering-admin
@@ -36,7 +34,6 @@ JumpcloudiAtlasProdAdmin:
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/jumpcloud-idp.yaml
   DependsOn: CommunityIamSamlProviderRP
   StackName: jc-access-iatlas-prod-admin
-  MaxConcurrentStacks: 10
   Parameters:
     MetadataDocument: !ReadFile ./MetadataDocuments/iatlas-prod-admin.xml
     SamlProviderName: iatlas-prod-admin
@@ -52,7 +49,6 @@ NlpSandboxServiceAccount:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/service-account.yaml
   StackName: NlpSandboxServiceAccount
-  MaxConcurrentStacks: 10
   Parameters:
     ManagedPolicyArns:
       - arn:aws:iam::aws:policy/AmazonEC2FullAccess

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "print-tasks": "npx org-formation print-tasks ./org-formation/_tasks.yaml --output yaml --max-concurrent-stacks 100 --max-concurrent-tasks 100",
-    "perform-tasks": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 50 --max-concurrent-tasks 1",
-    "ci-perform-tasks": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --perform-cleanup",
+    "perform-tasks": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 1 --max-concurrent-tasks 1",
+    "ci-perform-tasks": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 100 --max-concurrent-tasks 100 --perform-cleanup",
     "validate-tasks": "npx org-formation validate-tasks ./org-formation/_tasks.yaml --failed-tasks-tolerance 0  --max-concurrent-stacks 100 --max-concurrent-tasks 100",
     "cfn-lint": "cfn-lint ./.printed-stacks/**/*.yaml -i W2001,E3001,E1019,W1020,W2509,E3021"
   },


### PR DESCRIPTION
The CI build job takes 20 mins to create a single AWS which seems really slow.
Attempt to make it faster by running more CI deployments in parallel.

The benefit of this is that it should make deployments faster, the
drawback is that it will make logs more difficult to read because logs
will be all jumpbled up.

The strategy is to run in parallel only on CI deployment, when manually
running deployments the concurrent executors can be set to 1 to get more
sane logs.