### PR TITLE
[PLFM-6685] re-org region restriction

### DIFF
--- a/org-formation/010-scps/_tasks.yaml
+++ b/org-formation/010-scps/_tasks.yaml
@@ -39,7 +39,7 @@ DenyAllRegionsOutsideUsEast1:
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
   Parameters:
-    targetIds: [ !Ref ItProdOU, !Ref ScienceProdOU]
+    targetIds: [ !Ref ItDevOU, !Ref ItProdOU, !Ref ScienceProdOU ]
 
 DenyAllRegionsOutsideUs:
   Type: update-stacks
@@ -49,4 +49,4 @@ DenyAllRegionsOutsideUs:
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
   Parameters:
-    targetIds: [ !Ref OrganizationRoot ]
+    targetIds: [ !Ref ScienceDevOU  ]


### PR DESCRIPTION
Instead of applying region restriction at the ORG root, move
it to member OUs so that it targeted to specific AWS accounts.

This will remove region restriction from Synapse and Bridge accounts.