### PR TITLE
Allow more permissive regions on IT accounts and put SageIT in ItProdOU

### DIFF
--- a/org-formation/010-scps/_tasks.yaml
+++ b/org-formation/010-scps/_tasks.yaml
@@ -39,7 +39,7 @@ DenyAllRegionsOutsideUsEast1:
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
   Parameters:
-    targetIds: [ !Ref ItDevOU, !Ref ItProdOU, !Ref ScienceProdOU ]
+    targetIds: [ !Ref ScienceProdOU ]
 
 DenyAllRegionsOutsideUs:
   Type: update-stacks
@@ -49,4 +49,4 @@ DenyAllRegionsOutsideUs:
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
   Parameters:
-    targetIds: [ !Ref ScienceDevOU  ]
+    targetIds: [ !Ref ScienceDevOU, !Ref ItDevOU, !Ref ItProdOU  ]

--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -26,7 +26,6 @@ Organization:
         - !Ref ScipoolDevAccount
         - !Ref SandboxAccount
         - !Ref MobileHealthDataEngineeringAccount
-        - !Ref SageITAccount
         - !Ref NlpSandboxAccount
         - !Ref WorkflowsNextflowDevAccount
 
@@ -64,6 +63,7 @@ Organization:
         - !Ref LogCentralAccount
         - !Ref SecurityCentralAccount
         - !Ref ImageCentralAccount
+        - !Ref SageITAccount
 
   PolicyStagingOU:
     Type: OC::ORG::OrganizationalUnit


### PR DESCRIPTION
- [x] This allows IT prod and dev accounts to have resources in multiple US regions, which is needed to allow resources that have already been created in us-west and could be useful in the future as long as IT is careful.
- [x] Setup pre-commit and run the validators (info in README.md)
