### PR TITLE
Allow Admin role to archive GD findings in securitycentral

### DIFF
--- a/sceptre/securitycentral/templates/jumpcloud-idp.yaml
+++ b/sceptre/securitycentral/templates/jumpcloud-idp.yaml
@@ -20,6 +20,7 @@ Resources:
       RoleName: !GetAtt SecuritycentralAdminSamlProvider.Name
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AdministratorAccess
+        - !Ref SecurityResponsePolicy
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -30,6 +31,17 @@ Resources:
             Condition:
               StringEquals:
                 "SAML:aud": "https://signin.aws.amazon.com/saml"
+  SecurityResponsePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - guardduty:ArchiveFindings
+            Resource:
+              - "*"
 Outputs:
   SecuritycentralAdminSamlProviderArn:
     Value: !Ref SecuritycentralAdminSamlProvider


### PR DESCRIPTION
@zaro0508 will this change override the orgf SCP that denies archive on GD findings?

- [x] This fix is to allow IAM entities with the admin role to archive findings from the GD dashboard, so we can know if they are handled or not
- [x] passes pre-commit