### PR TITLE
pin shared template versions

### DIFF
--- a/org-formation/010-scps/_tasks.yaml
+++ b/org-formation/010-scps/_tasks.yaml
@@ -3,7 +3,7 @@ Parameters:
 
 PreventDisableGuardDuty:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/prevent-disable-guardduty.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/SCP/prevent-disable-guardduty.yaml
   StackName: !Sub '${resourcePrefix}-prevent-disable-guardduty'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
@@ -21,7 +21,7 @@ PreventDisableGuardDuty:
 
 PreventDisableCloudtrail:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/prevent-disable-cloudtrail.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/SCP/prevent-disable-cloudtrail.yaml
   StackName: !Sub '${resourcePrefix}-prevent-disable-cloudtrail'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
@@ -39,7 +39,7 @@ PreventDisableCloudtrail:
 
 PreventDisableCloudwatchConfigs:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/prevent-disable-cloudwatch-configs.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/SCP/prevent-disable-cloudwatch-configs.yaml
   StackName: !Sub '${resourcePrefix}-prevent-disable-cloudwatch-configs'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
@@ -50,7 +50,7 @@ PreventDisableCloudwatchConfigs:
 
 DenyAllRegionsOutsideUsEast1:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/deny-all-regions-outside-us-east-1.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/SCP/deny-all-regions-outside-us-east-1.yaml
   StackName: !Sub '${resourcePrefix}-deny-all-regions-outside-us-east-1'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
@@ -63,7 +63,7 @@ DenyAllRegionsOutsideUsEast1:
 
 DenyAllRegionsOutsideUs:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/deny-all-regions-outside-us.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/SCP/deny-all-regions-outside-us.yaml
   StackName: !Sub '${resourcePrefix}-deny-all-regions-outside-us'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:

--- a/org-formation/040-budgets/_tasks.yaml
+++ b/org-formation/040-budgets/_tasks.yaml
@@ -3,7 +3,7 @@ Parameters:
 
 BudgetAlarms:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/Billing/budgets.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/Billing/budgets.yaml
   StackName: !Sub '${resourcePrefix}-billing-alarm'
   TerminationProtection: false
   DefaultOrganizationBinding:

--- a/org-formation/060-cloudtrail/_tasks.yaml
+++ b/org-formation/060-cloudtrail/_tasks.yaml
@@ -3,7 +3,7 @@ Parameters:
 
 CloudTrail:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/Cloudtrail/cloudtrail-trail.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/Cloudtrail/cloudtrail-trail.yaml
   StackName: !Sub '${resourcePrefix}-cloudtrail'
   StackDescription: CloudTrail
   DefaultOrganizationBindingRegion: !Ref primaryRegion

--- a/org-formation/080-aws-config-inventory/_tasks.yml
+++ b/org-formation/080-aws-config-inventory/_tasks.yml
@@ -8,7 +8,7 @@ Parameters:
 # Enable AWS Config in all member accounts and send Findings and Config history to the centralized s3 bucket in the archive account
 ConfigBase:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/Config/config.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/Config/config.yaml
   StackName: !Sub '${resourcePrefix}-${appName}-base'
   StackDescription: AWS Config - Base
   TerminationProtection: false

--- a/org-formation/200-baseline/_tasks.yaml
+++ b/org-formation/200-baseline/_tasks.yaml
@@ -3,7 +3,7 @@ Parameters:
 
 PasswordPolicy:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/ORG/password-policy.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/ORG/password-policy.yaml
   StackName: baseline-password-policy
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
@@ -12,7 +12,7 @@ PasswordPolicy:
 
 OrgFormationBuildAccessRole:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/org-cross-account-role.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/IAM/org-cross-account-role.yaml
   StackName: org-formation-build-access-role
   Parameters:
     MasterAccountId: !Ref MasterAccount

--- a/org-formation/300-account-defaults/_tasks.yaml
+++ b/org-formation/300-account-defaults/_tasks.yaml
@@ -3,7 +3,7 @@ Parameters:
 
 Ec2EbsEncryptionDefaults:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/EC2/ec2-ebs-encryption.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/EC2/ec2-ebs-encryption.yaml
   StackName: account-default-ec2-ebs-encryption
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
@@ -13,7 +13,7 @@ Ec2EbsEncryptionDefaults:
 
 Ec2NoVpcDefaults:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/VPC/ec2-no-default-vpc.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/VPC/ec2-no-default-vpc.yaml
   StackName: ec2-no-default-vpc
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
@@ -22,7 +22,7 @@ Ec2NoVpcDefaults:
 
 SceptreCloudformationBucket:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/S3/public-bucket.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/S3/public-bucket.yaml
   StackName: sceptre-cloudformation-bucket
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
@@ -31,7 +31,7 @@ SceptreCloudformationBucket:
 
 SceptreLambdaBucket:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/S3/public-bucket.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/S3/public-bucket.yaml
   StackName: sceptre-lambda-bucket
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
@@ -40,7 +40,7 @@ SceptreLambdaBucket:
 
 ItKmsKey:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/KMS/kms-key.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/KMS/kms-key.yaml
   StackName: it-kms-key
   Parameters:
     AliasName: alias/it-infra

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -3,7 +3,7 @@ Parameters:
 
 AccessOrganizationsAdmin:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/jumpcloud-idp.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/IAM/jumpcloud-idp.yaml
   StackName: access-organizations-admin
   Parameters:
     MetadataDocument: !ReadFile ./MetadataDocuments/organizations-admin.xml
@@ -17,7 +17,7 @@ AccessOrganizationsAdmin:
 
 JCMobileHealthDataEngineeringAdmin:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/jumpcloud-idp.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/IAM/jumpcloud-idp.yaml
   StackName: jc-mobilehealth-dataengineering-admin
   Parameters:
     MetadataDocument: !ReadFile ./MetadataDocuments/mobilehealth-dataengineering-admin.xml
@@ -31,7 +31,7 @@ JCMobileHealthDataEngineeringAdmin:
 
 JumpcloudiAtlasProdAdmin:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/jumpcloud-idp.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/IAM/jumpcloud-idp.yaml
   StackName: jc-access-iatlas-prod-admin
   Parameters:
     MetadataDocument: !ReadFile ./MetadataDocuments/iatlas-prod-admin.xml
@@ -46,7 +46,7 @@ JumpcloudiAtlasProdAdmin:
 # A service account for https://github.com/nlpsandbox/aws-cloudformation
 NlpSandboxServiceAccount:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/service-account.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/IAM/service-account.yaml
   StackName: NlpSandboxServiceAccount
   Parameters:
     ManagedPolicyArns:
@@ -60,7 +60,7 @@ NlpSandboxServiceAccount:
 
 JCWorkflowsNextflowDevAdmin:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/jumpcloud-idp.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/IAM/jumpcloud-idp.yaml
   StackName: jc-workflows-nextflow-dev-admin
   MaxConcurrentStacks: 10
   Parameters:
@@ -75,7 +75,7 @@ JCWorkflowsNextflowDevAdmin:
 
 WorkflowsNextflowCIServiceAccounts:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/service-account.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/IAM/service-account.yaml
   StackName: workflows-nextflow-ci-service-account
   Parameters:
     ManagedPolicyArns:
@@ -89,7 +89,7 @@ WorkflowsNextflowCIServiceAccounts:
 
 JCWorkflowsNextflowProdAdmin:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/jumpcloud-idp.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/IAM/jumpcloud-idp.yaml
   StackName: jc-workflows-nextflow-prod-admin
   MaxConcurrentStacks: 10
   Parameters:
@@ -104,7 +104,7 @@ JCWorkflowsNextflowProdAdmin:
 
 JCNlpSandboxAdmin:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/jumpcloud-idp.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/IAM/jumpcloud-idp.yaml
   StackName: jc-nlp-sandbox-admin
   MaxConcurrentStacks: 10
   Parameters:
@@ -119,7 +119,7 @@ JCNlpSandboxAdmin:
 
 NlpSandboxCIServiceAccounts:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/IAM/service-account.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/IAM/service-account.yaml
   StackName: nlp-sandbox-ci-service-account
   Parameters:
     ManagedPolicyArns:


### PR DESCRIPTION
Pinning versions makes it safer to update shared templates.  This only
pins org-formation usage of the shared templates.  We should make Sceptre
use pinned versions as well but will save that for a separate PR.