### PR TITLE
Remove termination proctection

### DIFF
--- a/org-formation/040-budgets/_tasks.yaml
+++ b/org-formation/040-budgets/_tasks.yaml
@@ -5,7 +5,6 @@ BudgetAlarms:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/Billing/budgets.yaml
   StackName: !Sub '${resourcePrefix}-billing-alarm'
-  TerminationProtection: false
   DefaultOrganizationBinding:
     Region: !Ref primaryRegion
     AccountsWithTag: budget-alarm-threshold

--- a/org-formation/060-cloudtrail/_tasks.yaml
+++ b/org-formation/060-cloudtrail/_tasks.yaml
@@ -13,6 +13,5 @@ CloudTrail:
   OrganizationBindings:
     LogArchiveBinding:
       Account: !Ref LogCentralAccount
-  TerminationProtection: true
   Parameters:
     bucketName: !Sub '${resourcePrefix}-cloudtrail-${CurrentAccount.AccountId}'

--- a/org-formation/080-aws-config-inventory/_tasks.yml
+++ b/org-formation/080-aws-config-inventory/_tasks.yml
@@ -11,7 +11,6 @@ ConfigBase:
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/Config/config.yaml
   StackName: !Sub '${resourcePrefix}-${appName}-base'
   StackDescription: AWS Config - Base
-  TerminationProtection: false
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     IncludeMasterAccount: true


### PR DESCRIPTION
Cloudformation termination protection doesn't really work with CI/CD
setup.  Protection from removal is done in GH reviews.