### PR TITLE
Setup CI service user/role for iAtlas account

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -43,6 +43,19 @@ JumpcloudiAtlasProdAdmin:
     Account: !Ref iAtlasProdAccount
     Region: us-east-1
 
+# A service account for https://github.com/Sage-Bionetworks/iatlas-infra
+iAtlasCIServiceAccount:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.4/templates/IAM/service-account.yaml
+  StackName: iatlas-prod-ci-access
+  Parameters:
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AdministratorAccess
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+    Account: !Ref iAtlasProdAccount
+    Region: us-east-1
+
 # A service account for https://github.com/nlpsandbox/aws-cloudformation
 NlpSandboxServiceAccount:
   Type: update-stacks


### PR DESCRIPTION
This is to setup a AWS service user/role to deploy CFN templates to
the iAtlas AWS account.