### PR TITLE
[IT-1101] Remove OperatorEmail from essentials stack

### DIFF
--- a/sceptre/admincentral/config/prod/essentials.yaml
+++ b/sceptre/admincentral/config/prod/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
-  OperatorEmail: aws.admincentral@sagebase.org
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
   LambdaBucketVersioning: Enabled
 hooks:

--- a/sceptre/imagecentral/config/prod/essentials.yaml
+++ b/sceptre/imagecentral/config/prod/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
-  OperatorEmail: "aws.imagecentral@sagebase.org"
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_create:

--- a/sceptre/itsandbox/config/prod/essentials.yaml
+++ b/sceptre/itsandbox/config/prod/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
-  OperatorEmail: "aws.itsandbox@sagebase.org"
   VpcPeeringRequesterAwsAccountId: !ssm "/infra/AdmincentralAwsAccountId"
 hooks:
   before_launch:

--- a/sceptre/logcentral/config/prod/essentials.yaml
+++ b/sceptre/logcentral/config/prod/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
-  OperatorEmail: aws.logcentral@sagebase.org
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:

--- a/sceptre/organizations/config/prod/essentials.yaml
+++ b/sceptre/organizations/config/prod/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
-  OperatorEmail: "aws.organizations@sagebase.org"
   VpcPeeringRequesterAwsAccountId: !ssm "/infra/AdmincentralAwsAccountId"
 hooks:
   before_launch:

--- a/sceptre/sageit/config/prod/essentials.yaml
+++ b/sceptre/sageit/config/prod/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
-  OperatorEmail: aws-it@sagebase.org
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:

--- a/sceptre/sandbox/config/prod/essentials.yaml
+++ b/sceptre/sandbox/config/prod/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
-  OperatorEmail: aws.sandbox@sagebase.org
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:

--- a/sceptre/scicomp/config/prod/essentials.yaml
+++ b/sceptre/scicomp/config/prod/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
-  OperatorEmail: aws.scicomp@sagebase.org
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:

--- a/sceptre/scipool/config/develop/essentials.yaml
+++ b/sceptre/scipool/config/develop/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: "essentials"
 dependencies:
   - "develop/bootstrap.yaml"
 parameters:
-  OperatorEmail: "aws.scipooldev@sagebase.org"
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:

--- a/sceptre/scipool/config/prod/essentials.yaml
+++ b/sceptre/scipool/config/prod/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
-  OperatorEmail: "aws.scipoolprod@sagebase.org"
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:

--- a/sceptre/scipool/config/strides/essentials.yaml
+++ b/sceptre/scipool/config/strides/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: "essentials"
 dependencies:
   - "strides/bootstrap.yaml"
 parameters:
-  OperatorEmail: "aws.strides@sagebase.org"
   VpcPeeringRequesterAwsAccountId: "745159704268"  # org-sagebase-admincentral
 hooks:
   before_launch:

--- a/sceptre/securitycentral/config/prod/essentials.yaml
+++ b/sceptre/securitycentral/config/prod/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
-  OperatorEmail: aws.securitycentral@sagebase.org
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:

--- a/sceptre/synapsedev/config/prod/essentials.yaml
+++ b/sceptre/synapsedev/config/prod/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
-  OperatorEmail: aws.synapsedev@sagebase.org
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:

--- a/sceptre/synapsedw/config/prod/essentials.yaml
+++ b/sceptre/synapsedw/config/prod/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
-  OperatorEmail: synapse.dw@sagebase.org
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:

--- a/sceptre/synapseprod/config/prod/essentials.yaml
+++ b/sceptre/synapseprod/config/prod/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
-  OperatorEmail: platform@sagebase.org
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:

--- a/sceptre/transit/config/prod/essentials.yaml
+++ b/sceptre/transit/config/prod/essentials.yaml
@@ -3,7 +3,6 @@ stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
-  OperatorEmail: "aws.transit@sagebase.org"
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:


### PR DESCRIPTION
Removal of AWS config in PR https://github.com/Sage-Bionetworks/aws-infra/pull/296
removed OperatorEmail parameter therefore we need to update
the deployment to match.

depends on https://github.com/Sage-Bionetworks/aws-infra/pull/296