### PR TITLE
update cloudwatch template

### DIFF
--- a/org-formation/060-cloudtrail/_tasks.yaml
+++ b/org-formation/060-cloudtrail/_tasks.yaml
@@ -3,19 +3,20 @@ Parameters:
 
 CloudwatchTrailLog:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/Cloudwatch/cloudwatch-log.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/Cloudwatch/cloudwatch-log.yaml
   StackName: !Sub '${resourcePrefix}-cloudwatch-log'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     Account: '*'
     IncludeMasterAccount: true
   Parameters:
+    LogGroupName: !Sub '/aws/cloudtrail/${resourcePrefix}-cloudwatch-log.log'
     RetentionInDays: !GetAtt CurrentAccount.Tags.CloudwatchCloudTrailLogRetentionPeriod
 
 CloudTrail:
   Type: update-stacks
   DependsOn: [ "CloudwatchTrailLog" ]
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/Cloudtrail/cloudtrail-trail.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/Cloudtrail/cloudtrail-trail.yaml
   StackName: !Sub '${resourcePrefix}-cloudtrail'
   StackDescription: CloudTrail
   DefaultOrganizationBindingRegion: !Ref primaryRegion


### PR DESCRIPTION
Update to use newer version of cloudwatch template to create log group.
The new template requires passing in LogGroupName parameter.

depends on https://github.com/Sage-Bionetworks/aws-infra/pull/297