### PR TITLE
[IT-1178] Setup SSO group access to AWS Sandbox account

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -30,6 +30,52 @@ Parameters:
     Type: String
     Default: '906769aa66-5d23a723-54f3-4c08-a67b-311e555f4e85'
 
+  # Principal ID from Identity Provider's group used by sandbox developers
+  sandboxDeveloperGroup:
+    Type: String
+    Default: '906769aa66-c66c6e77-3904-4bfc-b96d-98315a9bb913'
+
+  # Principal ID from Identity Provider's group used by sandbox developers
+  sandboxAdminGroup:
+    Type: String
+    Default: '906769aa66-0133decd-a118-4b53-b5a1-7ca6a3077212'
+
+sandboxDeveloper:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-sandboxDeveloper'
+  StackDescription: 'SSO: Developer role used by sandboxAdmin group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref SandboxAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref sandboxDeveloperGroup
+    permissionSetName: 'Developer'
+    managedPolicies: [ 'arn:aws:iam::aws:policy/PowerUserAccess' ]
+    sessionDuration: 'PT12H'
+
+sandboxAdmin:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-sandboxDeveloper'
+  StackDescription: 'SSO: Administrator role used by sandboxAdmin group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref SandboxAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref sandboxAdminGroup
+    permissionSetName: 'Administrator'
+    managedPolicies: [ 'arn:aws:iam::aws:policy/AdministratorAccess' ]
+    sessionDuration: 'PT4H'
+
 SsoAdministrator:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -30,51 +30,13 @@ Parameters:
     Type: String
     Default: '906769aa66-5d23a723-54f3-4c08-a67b-311e555f4e85'
 
-  # Principal ID from Identity Provider's group used by sandbox developers
-  sandboxDeveloperGroup:
+  sandboxDeveloperGroup:  #JC aws-sandbox-developers
     Type: String
     Default: '906769aa66-c66c6e77-3904-4bfc-b96d-98315a9bb913'
 
-  # Principal ID from Identity Provider's group used by sandbox admins
-  sandboxAdminGroup:
+  sandboxAdminGroup:    #JC aws-sandbox-admins
     Type: String
     Default: '906769aa66-0133decd-a118-4b53-b5a1-7ca6a3077212'
-
-SsoSandboxDeveloper:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-sandbox-developer'
-  StackDescription: 'SSO: Developer role used by sandbox developer group'
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: true
-  OrganizationBindings:
-    TargetBinding:
-      Account: !Ref SandboxAccount
-  Parameters:
-    instanceArn: !Ref instanceArn
-    principalId: !Ref sandboxDeveloperGroup
-    permissionSetName: 'Developer'
-    managedPolicies: [ 'arn:aws:iam::aws:policy/PowerUserAccess' ]
-    sessionDuration: 'PT12H'
-
-SsoSandboxAdmin:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-sandbox-admin'
-  StackDescription: 'SSO: Administrator role used by sandbox admin group'
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: true
-  OrganizationBindings:
-    TargetBinding:
-      Account: !Ref SandboxAccount
-  Parameters:
-    instanceArn: !Ref instanceArn
-    principalId: !Ref sandboxAdminGroup
-    permissionSetName: 'Administrator'
-    managedPolicies: [ 'arn:aws:iam::aws:policy/AdministratorAccess' ]
-    sessionDuration: 'PT4H'
 
 SsoAdministrator:
   Type: update-stacks
@@ -215,3 +177,39 @@ SsoViewerSupporter:
     instanceArn: !Ref instanceArn
     principalId: !Ref scienceSupporterGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-viewer-permission-set-arn' ]
+
+SsoSandboxDeveloper:
+  Type: update-stacks
+  DependsOn: SsoDeveloper
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-sandbox-developer'
+  StackDescription: 'SSO: Developer role used by sandbox developer group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref SandboxAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref sandboxDeveloperGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
+    sessionDuration: 'PT8H'
+
+SsoSandboxAdmin:
+  Type: update-stacks
+  DependsOn: SsoAdministrator
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-sandbox-admin'
+  StackDescription: 'SSO: Administrator role used by sandbox admin group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref SandboxAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref sandboxAdminGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
+    sessionDuration: 'PT4H'

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -47,7 +47,7 @@ sandboxDeveloper:
   StackDescription: 'SSO: Developer role used by sandboxAdmin group'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
-    IncludeMasterAccount: false
+    IncludeMasterAccount: true
   OrganizationBindings:
     TargetBinding:
       Account: !Ref SandboxAccount
@@ -61,11 +61,11 @@ sandboxDeveloper:
 sandboxAdmin:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-sandboxDeveloper'
+  StackName: !Sub '${resourcePrefix}-${appName}-sandboxAdmin'
   StackDescription: 'SSO: Administrator role used by sandboxAdmin group'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
-    IncludeMasterAccount: false
+    IncludeMasterAccount: true
   OrganizationBindings:
     TargetBinding:
       Account: !Ref SandboxAccount

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -35,7 +35,7 @@ Parameters:
     Type: String
     Default: '906769aa66-c66c6e77-3904-4bfc-b96d-98315a9bb913'
 
-  # Principal ID from Identity Provider's group used by sandbox developers
+  # Principal ID from Identity Provider's group used by sandbox admins
   sandboxAdminGroup:
     Type: String
     Default: '906769aa66-0133decd-a118-4b53-b5a1-7ca6a3077212'

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -43,8 +43,8 @@ Parameters:
 SsoSandboxDeveloper:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-sandboxDeveloper'
-  StackDescription: 'SSO: Developer role used by sandboxDeveloper group'
+  StackName: !Sub '${resourcePrefix}-${appName}-sandbox-developer'
+  StackDescription: 'SSO: Developer role used by sandbox developer group'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
@@ -61,8 +61,8 @@ SsoSandboxDeveloper:
 SsoSandboxAdmin:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-sandboxAdmin'
-  StackDescription: 'SSO: Administrator role used by sandboxAdmin group'
+  StackName: !Sub '${resourcePrefix}-${appName}-sandbox-admin'
+  StackDescription: 'SSO: Administrator role used by sandbox admin group'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     IncludeMasterAccount: true

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -40,11 +40,11 @@ Parameters:
     Type: String
     Default: '906769aa66-0133decd-a118-4b53-b5a1-7ca6a3077212'
 
-sandboxDeveloper:
+SsoSandboxDeveloper:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
   StackName: !Sub '${resourcePrefix}-${appName}-sandboxDeveloper'
-  StackDescription: 'SSO: Developer role used by sandboxAdmin group'
+  StackDescription: 'SSO: Developer role used by sandboxDeveloper group'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
@@ -58,7 +58,7 @@ sandboxDeveloper:
     managedPolicies: [ 'arn:aws:iam::aws:policy/PowerUserAccess' ]
     sessionDuration: 'PT12H'
 
-sandboxAdmin:
+SsoSandboxAdmin:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
   StackName: !Sub '${resourcePrefix}-${appName}-sandboxAdmin'


### PR DESCRIPTION
Setup to allow users in the JC aws-sadnbox-admins and aws-sandbox-developers
groups access to the AWS sandbox account.