### PR TITLE
[IT-1178] Setup SSO group access to AWS mobile health data engineering account

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -53,8 +53,8 @@ Parameters:
 SsoMobileHealthDataEngineeringAdmin:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-mobileHealthDataEngineeringAdminGroup'
-  StackDescription: 'SSO: Administrator role used by mobileHealthDataEngineeringAdminGroup group'
+  StackName: !Sub '${resourcePrefix}-${appName}-mobilehealth-dataengineering-admin'
+  StackDescription: 'SSO: Administrator role used by mobileHealth DataEngineering admin group'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     IncludeMasterAccount: true

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -279,4 +279,3 @@ SsoMobileHealthDataEngineeringAdmin:
     principalId: !Ref mobileHealthDataEngineeringAdminGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
     sessionDuration: 'PT12H'
-

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -50,11 +50,11 @@ Parameters:
     Type: String
     Default: '906769aa66-e218c196-4107-417d-8b75-c2e81a4aa290'
 
-SsoMobilehealthDataengineeringAdmin:
+SsoMobileHealthDataEngineeringAdmin:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-mobilehealthDataengineeringAdmin'
-  StackDescription: 'SSO: Administrator role used by mobilehealthDataengineeringAdmin group'
+  StackName: !Sub '${resourcePrefix}-${appName}-mobileHealthDataEngineeringAdminGroup'
+  StackDescription: 'SSO: Administrator role used by mobileHealthDataEngineeringAdminGroup group'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
@@ -63,7 +63,7 @@ SsoMobilehealthDataengineeringAdmin:
       Account: !Ref MobileHealthDataEngineeringAccount
   Parameters:
     instanceArn: !Ref instanceArn
-    principalId: !Ref mobilehealthDataengineeringAdmin
+    principalId: !Ref mobileHealthDataEngineeringAdminGroup
     permissionSetName: 'Administrator'
     managedPolicies: [ 'arn:aws:iam::aws:policy/AdministratorAccess' ]
     sessionDuration: 'PT12H'

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -278,4 +278,4 @@ SsoMobileHealthDataEngineeringAdmin:
     instanceArn: !Ref instanceArn
     principalId: !Ref mobileHealthDataEngineeringAdminGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
-    sessionDuration: 'PT12H'
+    sessionDuration: 'PT8H'

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -46,6 +46,28 @@ Parameters:
     Type: String
     Default: '906769aa66-8c4034aa-9441-47b2-8770-34422ea4affa'
 
+  mobilehealthDataengineeringAdmin:     #JC aws-mobilehealth-dataengineering-admins
+    Type: String
+    Default: '906769aa66-e218c196-4107-417d-8b75-c2e81a4aa290'
+
+SsoMobilehealthDataengineeringAdmin:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-mobilehealthDataengineeringAdmin'
+  StackDescription: 'SSO: Administrator role used by mobilehealthDataengineeringAdmin group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref MobileHealthDataEngineeringAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref mobilehealthDataengineeringAdmin
+    permissionSetName: 'Administrator'
+    managedPolicies: [ 'arn:aws:iam::aws:policy/AdministratorAccess' ]
+    sessionDuration: 'PT12H'
+
 SsoAdministrator:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -46,27 +46,9 @@ Parameters:
     Type: String
     Default: '906769aa66-8c4034aa-9441-47b2-8770-34422ea4affa'
 
-  mobilehealthDataengineeringAdmin:     #JC aws-mobilehealth-dataengineering-admins
+  mobilehealthDataengineeringAdminGroup:     #JC aws-mobilehealth-dataengineering-admins
     Type: String
     Default: '906769aa66-e218c196-4107-417d-8b75-c2e81a4aa290'
-
-SsoMobileHealthDataEngineeringAdmin:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-mobilehealth-dataengineering-admin'
-  StackDescription: 'SSO: Administrator role used by mobileHealth DataEngineering admin group'
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: true
-  OrganizationBindings:
-    TargetBinding:
-      Account: !Ref MobileHealthDataEngineeringAccount
-  Parameters:
-    instanceArn: !Ref instanceArn
-    principalId: !Ref mobileHealthDataEngineeringAdminGroup
-    permissionSetName: 'Administrator'
-    managedPolicies: [ 'arn:aws:iam::aws:policy/AdministratorAccess' ]
-    sessionDuration: 'PT12H'
 
 SsoAdministrator:
   Type: update-stacks
@@ -279,3 +261,22 @@ scicompDeveloper:
     principalId: !Ref scicompViewerGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
     sessionDuration: 'PT8H'
+
+SsoMobileHealthDataEngineeringAdmin:
+  Type: update-stacks
+  DependsOn: SsoAdministrator
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-mobilehealth-dataengineering-admin'
+  StackDescription: 'SSO: Administrator role used by mobileHealth data engineering admin group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref MobileHealthDataEngineeringAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref mobileHealthDataEngineeringAdminGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
+    sessionDuration: 'PT12H'
+


### PR DESCRIPTION
Setup to allow users in the JC aws-mobilehealth-dataengineering-admins group
access to the AWS MobileHealthDataEngineeringAccount.