### PR TITLE
[IT-1205] deploy VPC request authorizer role

### DIFF
--- a/org-formation/300-account-defaults/_tasks.yaml
+++ b/org-formation/300-account-defaults/_tasks.yaml
@@ -60,9 +60,12 @@ VpcPeeringRequest:
   StackName: !Sub '${resourcePrefix}-vpc-peering-request'
   StackDescription: 'Authorize VPC peering requests'
   Parameters:
-    VpcPeeringRequesterAwsAccountId: '745159704268'
+    VpcPeeringRequesterAwsAccountId: !Ref AdminCentralAccount
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     IncludeMasterAccount: false
     Account:
       - !Ref NlpSandboxAccount
+      - !Ref WorkflowsNextflowDevAccount
+      - !Ref WorkflowsNextflowProdAccount
+      - !Ref MobileHealthDataEngineeringAccount

--- a/org-formation/300-account-defaults/_tasks.yaml
+++ b/org-formation/300-account-defaults/_tasks.yaml
@@ -53,3 +53,16 @@ ItKmsKey:
     IncludeMasterAccount: true
     Account: '*'
     Region: !Ref primaryRegion
+
+VpcPeeringRequest:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.12/templates/VPC/vpc-peering-request.yaml
+  StackName: !Sub '${resourcePrefix}-vpc-peering-request'
+  StackDescription: 'Authorize VPC peering requests'
+  Parameters:
+    VpcPeeringRequesterAwsAccountId: '745159704268'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+    Account:
+      - !Ref NlpSandboxAccount


### PR DESCRIPTION
Create a VPC peering request role to allow account to automatically accept
peering requests . We did this same thing in sceptre with essentials.yaml[1]

[1] https://github.com/Sage-Bionetworks/aws-infra/blob/master/templates/essentials.yaml#L92

depends on https://github.com/Sage-Bionetworks/aws-infra/pull/304