### PR TITLE
Guardduty for strides account

### DIFF
--- a/org-formation/070-guard-duty/GuardDutyExternalConnect.yaml
+++ b/org-formation/070-guard-duty/GuardDutyExternalConnect.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Associate a Guardduty member to the master
+Parameters:
+  MemberAccountId:
+    Type: String
+    Description: Guardduty member account ID
+  MemberRootEmail:
+    Type: String
+    Description: Guardduty member root email address
+  MasterDectector:
+    Type: String
+    Description: The Guardduty detector ID from the master GD account
+Resources:
+  GuardDutyMember:
+    Type: 'AWS::GuardDuty::Member'
+    Properties:
+      DetectorId: !Ref MasterDectector
+      Email: !Ref MemberRootEmail
+      MemberId: !Ref MemberAccountId
+      Status: Invited

--- a/org-formation/070-guard-duty/_tasks.yaml
+++ b/org-formation/070-guard-duty/_tasks.yaml
@@ -40,6 +40,23 @@ GuardDuty:
     resourcePrefix: !Ref resourcePrefix
     accountId: !Ref accountId
 
+# one off association for Guardduty in org-sagebase-strides account because it's not in the Sage ORG
+# the other half of this Guardduty association is in ../sceptre/strides
+GuardDutyConnectStrides:
+  Type: update-stacks
+  Template: ./GuardDutyExternalConnect.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-connect-strides'
+  StackDescription: Associate an external Guardduty member account
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+    Account:
+      - !Ref accountId
+  Parameters:
+    MemberAccountId: "423819316185"           # org-sagebase-strides
+    MemberRootEmail: "aws.strides@sagebase.org"
+    MasterDectector: !CopyValue [ !Sub '${resourcePrefix}-${appName}-DetectorId' ]
+
 # bucket that contains the trusted IP addresses that are excluded from GuardDuty findings
 GuardDutyTrustedIpsBucket:
   Type: update-stacks

--- a/org-formation/070-guard-duty/_tasks.yaml
+++ b/org-formation/070-guard-duty/_tasks.yaml
@@ -55,7 +55,7 @@ GuardDutyConnectStrides:
   Parameters:
     MemberAccountId: "423819316185"           # org-sagebase-strides
     MemberRootEmail: "aws.strides@sagebase.org"
-    MasterDectector: !CopyValue [ !Sub '${resourcePrefix}-${appName}-DetectorId' ]
+    MasterDectector: !CopyValue [ !Sub '${resourcePrefix}-${appName}-detector-id' ]
 
 # bucket that contains the trusted IP addresses that are excluded from GuardDuty findings
 GuardDutyTrustedIpsBucket:

--- a/sceptre/strides/config/prod/guardduty.yaml
+++ b/sceptre/strides/config/prod/guardduty.yaml
@@ -2,5 +2,4 @@
 template_path: "guardduty.yaml"
 stack_name: "guardduty"
 parameters:
-  resourcePrefix: "sagebase"
   accountId: "140124849929"       # org-sagebase-securitycentral

--- a/sceptre/strides/config/prod/guardduty.yaml
+++ b/sceptre/strides/config/prod/guardduty.yaml
@@ -1,0 +1,6 @@
+# setup AWS guard duty member
+template_path: "guardduty.yaml"
+stack_name: "guardduty"
+parameters:
+  resourcePrefix: "sagebase"
+  accountId: "140124849929"       # org-sagebase-securitycentral

--- a/sceptre/strides/templates/guardduty.yaml
+++ b/sceptre/strides/templates/guardduty.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: GuardDuty - Base
+Description: Associate a Guardduty member with a master account
 Parameters:
   accountId:
     Type: String

--- a/sceptre/strides/templates/guardduty.yaml
+++ b/sceptre/strides/templates/guardduty.yaml
@@ -1,0 +1,38 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: GuardDuty - Base
+Parameters:
+  resourcePrefix:
+    Type: String
+  accountId:
+    Type: String
+    Description: The identifier from the account used to manage GuardDuty
+Resources:
+  Detector:
+    Type: AWS::GuardDuty::Detector
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E1012
+    Properties:
+      Enable: true
+      FindingPublishingFrequency: FIFTEEN_MINUTES
+  Master:
+    Type: AWS::GuardDuty::Master
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E1012
+    Properties:
+      DetectorId:
+        Ref: Detector
+      MasterId:
+        Ref: accountId
+Outputs:
+  DetectorId:
+    Value:
+      Ref: Detector
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}-detector-id

--- a/sceptre/strides/templates/guardduty.yaml
+++ b/sceptre/strides/templates/guardduty.yaml
@@ -1,8 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: GuardDuty - Base
 Parameters:
-  resourcePrefix:
-    Type: String
   accountId:
     Type: String
     Description: The identifier from the account used to manage GuardDuty


### PR DESCRIPTION
Setup guardduty member in AWS strides account sending it's finding
to the master securitycentral account.  We setup with sceptre because
strides is no in our ORG therefore it cannot be managed by
org-formation.