### PR TITLE
Revert "Sumologic access to config and cloudtrail buckets (#188)"

### DIFF
--- a/org-formation/060-cloudtrail/_tasks.yaml
+++ b/org-formation/060-cloudtrail/_tasks.yaml
@@ -30,18 +30,3 @@ CloudTrail:
     bucketName: !Sub '${resourcePrefix}-cloudtrail-${CurrentAccount.AccountId}'
     CloudWatchLogsLogGroupArn: !CopyValue [ !Sub '${primaryRegion}-${resourcePrefix}-cloudwatch-log-LogGroupArn' ]
     CloudWatchLogsRoleArn: !CopyValue [ !Sub '${primaryRegion}-${resourcePrefix}-cloudwatch-log-LogRoleArn' ]
-
-CloudTrailSumoLogicRole:
-  Type: update-stacks
-  DependsOn: [ "CloudTrail" ]
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.13/templates/sumologic-role.yaml
-  StackName: !Sub '${resourcePrefix}-cloudtrail-sumologic-role'
-  StackDescription: Allow Sumologic to access cloudTrail data
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    Account: !Ref LogCentralAccount
-    IncludeMasterAccount: false
-  Parameters:
-    ExternalID: "us2:00000000001E813D"
-    Actions: 's3:GetObject,s3:GetObjectVersion,s3:ListBucketVersions,s3:ListBucket'
-    Resource: !CopyValue [ !Sub '${primaryRegion}-${resourcePrefix}-cloudtrail-CloudTrailBucketArn' ]

--- a/org-formation/080-aws-config-inventory/_tasks.yml
+++ b/org-formation/080-aws-config-inventory/_tasks.yml
@@ -21,18 +21,3 @@ ConfigBase:
   Parameters:
     resourcePrefix: !Ref resourcePrefix
     bucketName: !Sub '${resourcePrefix}-${appName}-${CurrentAccount.AccountId}'
-
-ConfigSumoLogicRole:
-  Type: update-stacks
-  DependsOn: [ "ConfigBase" ]
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.13/templates/sumologic-role.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-sumologic-role'
-  StackDescription: Allow Sumologic to access AWS config data
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    Account: !Ref LogCentralAccount
-    IncludeMasterAccount: false
-  Parameters:
-    ExternalID: "us2:00000000001E813D"
-    Actions: 's3:GetObject,s3:GetObjectVersion,s3:ListBucketVersions,s3:ListBucket'
-    Resource: !CopyValue [ !Sub '${primaryRegion}-${resourcePrefix}-${appName}-base-ConfigAuditBucketArn' ]


### PR DESCRIPTION
This reverts commit 77711558c385214bbca6ad58796387c4786a0dc3.

The sumo template adds the strides account number to the bucket policy
which breaks it from allowing other accounts to write logs
to the bucket.