### PR TITLE
[IT-1178] Update Bridge prod SSO policy

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -570,8 +570,27 @@ SsoBridgeProdDeveloper:
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref bridgeProdDeveloperGroup
-    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
+    permissionSetName: 'Developer-Deny-Delete-Rds-Dynamo'
+    managedPolicies: [ 'arn:aws:iam::aws:policy/PowerUserAccess' ]
     sessionDuration: 'PT8H'
+    inlinePolicy: >-
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Deny",
+            "Action": [
+              "rds:DeleteDBCluster",
+              "rds:DeleteDBClusterSnapshot",
+              "rds:DeleteDBInstance",
+              "rds:DeleteDBSnapshot",
+              "dynamodb:UpdateTable",
+              "dynamodb:DeleteTable"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
 
 SsoBridgeProdIosDeveloper:
   Type: update-stacks


### PR DESCRIPTION
The existing Bridge prod SAML policy restricts develops from being able to
delete RDS and Dynamo DB tables[1].  This change adds that restriction.

[1] https://github.com/Sage-Bionetworks-IT/organizations-infra/blob/master/sceptre/bridge/templates/iam-policies.yaml#L30-L56