### PR TITLE
[IT-1178] Update Scicomp SSO viewer policy

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -317,8 +317,15 @@ scicompViewer:
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref scicompViewerGroup
-    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-viewer-permission-set-arn' ]
+    permissionSetName: 'viewer-plus'
     sessionDuration: 'PT12H'
+    managedPolicies:
+      - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
+      - arn:aws:iam::aws:policy/job-function/SupportUser
+      - arn:aws:iam::aws:policy/AmazonDocDBReadOnlyAccess
+      - arn:aws:iam::aws:policy/AWSElasticBeanstalkReadOnlyAccess
+      - arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess
+      - arn:aws:iam::aws:policy/AWSLambdaReadOnlyAccess
 
 scicompDeveloper:
   Type: update-stacks


### PR DESCRIPTION
The current Scicomp SAML integration setup has a custom policy[1] for
the viewers, it's a viewer job function policy[2] and view other things
role.  We setup Scicomp SSO to match.

[1] https://github.com/Sage-Bionetworks-IT/organizations-infra/blob/master/sceptre/scicomp/templates/jumpcloud-idp.yaml#L74-L85
[2] https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html#security-iam-awsmanpol-jobfunction-updates