### PR TITLE
Update jumpcloud SAML role to SSO role

### DIFF
--- a/sceptre/scipool/config/develop/sc-kms-key.yaml
+++ b/sceptre/scipool/config/develop/sc-kms-key.yaml
@@ -7,4 +7,5 @@ stack_tags:
 dependencies:
   - "develop/bootstrap.yaml"
 parameters:
-  AdminRoleArn: !stack_output_external jumpcloud-idp::ScipooldevAdminSamlProviderRoleArn
+  # SSO generated admin role
+  AdminRoleArn: "arn:aws:iam::465877038949:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_a99f9cc4789c4254"

--- a/sceptre/scipool/config/prod/sc-kms-key.yaml
+++ b/sceptre/scipool/config/prod/sc-kms-key.yaml
@@ -7,4 +7,5 @@ stack_tags:
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
-  AdminRoleArn: !stack_output_external jumpcloud-idp::ScipoolprodAdminSamlProviderRoleArn
+  # SSO generated admin role
+  AdminRoleArn: "arn:aws:iam::237179673806:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_56cd956ee776e6c0"


### PR DESCRIPTION
We switch to using AWS SSO and removed SAML integration therefore
the SAML roles are gone.  We replace with the AWS generated SSO role.

We need to hard code the value because the SSO role is created by
the organizations account where AWS SSO runs.