### PR TITLE
Update org-formation run commmand

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "print-tasks": "npx org-formation print-tasks ./org-formation/_tasks.yaml --verbose --print-stack --output yaml --max-concurrent-stacks 100 --max-concurrent-tasks 100",
-    "perform-tasks": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --verbose --max-concurrent-stacks 1 --max-concurrent-tasks 1",
-    "ci-perform-tasks": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 100 --max-concurrent-tasks 100 --perform-cleanup",
+    "perform-tasks": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 1 --max-concurrent-tasks 1",
+    "ci-perform-tasks": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 1 --max-concurrent-tasks 1 --perform-cleanup",
+    "ci-perform-tasks-parallel": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 100 --max-concurrent-tasks 100 --perform-cleanup",
     "validate-tasks": "npx org-formation validate-tasks ./org-formation/_tasks.yaml --verbose --print-stack --failed-tasks-tolerance 0  --max-concurrent-stacks 100 --max-concurrent-tasks 100",
     "cfn-lint": "cfn-lint ./.printed-stacks/**/*.yaml -i W2001,E3001,E1019,W1020,W2509,E3021"
   },


### PR DESCRIPTION
Running ofn perform-tasks command in parallel fails intermittently
when creating new accounts.  We try to run ofn in single task
mode to see if it makes a difference.