### PR TITLE
Give specific users access to kms keys

### DIFF
--- a/sceptre/scipool/config/develop/sc-kms-key.yaml
+++ b/sceptre/scipool/config/develop/sc-kms-key.yaml
@@ -7,5 +7,7 @@ stack_tags:
 dependencies:
   - "develop/bootstrap.yaml"
 parameters:
-  # SSO generated admin role
-  AdminRoleArn: "arn:aws:iam::465877038949:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_a99f9cc4789c4254"
+  AdminRoleArns:
+    - !stack_output_external bootstrap::AWSIAMCfServiceRoleArn
+    - "arn:aws:sts::465877038949:assumed-role/AWSReservedSSO_Administrator_a99f9cc4789c4254/khai.do@sagebase.org"
+    - "arn:aws:sts::465877038949:assumed-role/AWSReservedSSO_Administrator_a99f9cc4789c4254/x.schildwachter@sagebase.org"

--- a/sceptre/scipool/config/prod/sc-kms-key.yaml
+++ b/sceptre/scipool/config/prod/sc-kms-key.yaml
@@ -7,5 +7,7 @@ stack_tags:
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
-  # SSO generated admin role
-  AdminRoleArn: "arn:aws:iam::237179673806:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_56cd956ee776e6c0"
+  AdminRoleArns:
+    - !stack_output_external bootstrap::AWSIAMCfServiceRoleArn
+    - "arn:aws:sts::237179673806:assumed-role/AWSReservedSSO_Administrator_56cd956ee776e6c0/khai.do@sagebase.org"
+    - "arn:aws:sts::237179673806:assumed-role/AWSReservedSSO_Administrator_56cd956ee776e6c0/x.schildwachter@sagebase.org"

--- a/sceptre/scipool/config/strides/sc-kms-key.yaml
+++ b/sceptre/scipool/config/strides/sc-kms-key.yaml
@@ -7,4 +7,7 @@ stack_tags:
 dependencies:
   - "strides/bootstrap.yaml"
 parameters:
-  AdminRoleArn: !stack_output_external jumpcloud-idp::StridesAdminSamlProviderRoleArn
+  AdminRoleArns:
+    - !stack_output_external bootstrap::AWSIAMCfServiceRoleArn
+    - "arn:aws:sts::423819316185:assumed-role/strides-admin/khai.do@sagebase.org"
+    - "arn:aws:sts::423819316185:assumed-role/strides-admin/x.schildwachter@sagebase.org"

--- a/sceptre/scipool/templates/sc-kms-key.yaml
+++ b/sceptre/scipool/templates/sc-kms-key.yaml
@@ -3,9 +3,9 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Service Catalog KMS Key and IAM policy
 
 Parameters:
-  AdminRoleArn:
-    Type: String
-    Description: ARN of the Administrator Role for a particular account
+  AdminRoleArns:
+    Type: CommaDelimitedList
+    Description: list of role ARNs allowed to administor the kms key
 
 Resources:
 
@@ -48,10 +48,7 @@ Resources:
           - Sid: "Allow administration of the key to CFN service role"
             Effect: "Allow"
             Principal:
-              AWS:
-                - !ImportValue
-                    'Fn::Sub': '${AWS::Region}-bootstrap-CfServiceRoleArn'
-                - !Ref AdminRoleArn
+              AWS: !Ref AdminRoleArns
             Action:
               - "kms:Create*"
               - "kms:Describe*"


### PR DESCRIPTION
Following least privilege best practice, Instead of giving a role access
to the KMS key we give specific users access to the key.