### PR TITLE
Remove cost meter lambda

### DIFF
--- a/sceptre/scipool/config/develop/lambda-sc-cost-meter.yaml
+++ b/sceptre/scipool/config/develop/lambda-sc-cost-meter.yaml
@@ -1,9 +1,0 @@
-template_path: remote/lambda-sc-cost-meter.yaml
-stack_name: lambda-sc-cost-meter
-stack_tags:
-  Department: "Platform"
-  Project: "Infrastructure"
-  OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-cost-meter/master/lambda-sc-cost-meter.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/lambda-sc-cost-meter.yaml
+++ b/sceptre/scipool/config/prod/lambda-sc-cost-meter.yaml
@@ -1,9 +1,0 @@
-template_path: remote/lambda-sc-cost-meter.yaml
-stack_name: lambda-sc-cost-meter
-stack_tags:
-  Department: "Platform"
-  Project: "Infrastructure"
-  OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-cost-meter/master/lambda-sc-cost-meter.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/lambda-sc-cost-meter.yaml
+++ b/sceptre/scipool/config/strides/lambda-sc-cost-meter.yaml
@@ -1,9 +1,0 @@
-template_path: remote/lambda-sc-cost-meter.yaml
-stack_name: lambda-sc-cost-meter
-stack_tags:
-  Department: "Platform"
-  Project: "Infrastructure"
-  OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-cost-meter/master/lambda-sc-cost-meter.yaml -N -P templates/remote"


### PR DESCRIPTION
Remove the lamba-sc-cost-meter[1], we've decided to not go with the
experimental AWS marketplace integration to keep track of customer
spend.

[1] https://github.com/Sage-Bionetworks-IT/lambda-sc-cost-meter