### PR TITLE
Update AMI Librarian access

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -505,7 +505,9 @@ SsoImageCentralAmiLibrarian:
     instanceArn: !Ref instanceArn
     principalId: !Ref imageCentralAmiLibrarianGroup
     permissionSetName: 'AMI-Librarian'
-    managedPolicies: [ 'arn:aws:iam::aws:policy/AmazonEC2FullAccess' ]
+    managedPolicies:
+      - 'arn:aws:iam::aws:policy/AmazonEC2FullAccess'
+      - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
     sessionDuration: 'PT12H'
 
 SsoBridgeDevAdmin:


### PR DESCRIPTION
Packer will create EC2 instances so it to make AMIs.  The AMI librarian
needs to be able to start SSM sessions to EC2 instances on the
ImageCentral account to allow debugging the instances.