### PR TITLE
Update cfn-cf-synapse-tagger

### DIFF
--- a/sceptre/scipool/config/develop/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-synapse-tagger.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.0.10/cfn-cr-synapse-tagger.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/prod/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-synapse-tagger.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.0.10/cfn-cr-synapse-tagger.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml -N -P templates/remote"

--- a/sceptre/scipool/config/strides/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-synapse-tagger.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.0.10/cfn-cr-synapse-tagger.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml -N -P templates/remote"


### PR DESCRIPTION
We removed the experimental marketplace cost meter feature from the
cfn-cf-synapse-tagger and now update to the new version to remove
it from the SC.