### PR TITLE
Update imagecnetral service account access

### DIFF
--- a/sceptre/imagecentral/templates/service-accounts.yaml
+++ b/sceptre/imagecentral/templates/service-accounts.yaml
@@ -13,6 +13,7 @@ Resources:
       Path: "/"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonEC2FullAccess
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:


### PR DESCRIPTION
The service account needs to be able to query for the latest AMI
ID which is in the SSM.  This gives the service account access to
SSM parameters.