### PR TITLE
[SC-251] EC2 Docker product

### DIFF
--- a/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-docker.yaml
@@ -1,0 +1,10 @@
+template_path: "sc-ec2-action-associations.yaml"
+stack_name: "sc-product-assoc-ec2-linux-docker"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "develop/sc-product-ec2-linux-docker.yaml"
+parameters:
+  ProductId: !stack_output_external sc-product-ec2-linux-docker::ProductId

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
@@ -1,0 +1,19 @@
+template_path: "sc-product-ec2-linux-docker.j2"
+stack_name: "sc-product-ec2-linux-docker"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "develop/sc-portfolio-ec2.yaml"
+  - "develop/sc-portfolio-ec2-external.yaml"
+  - "develop/sc-ec2-actions.yaml"
+parameters:
+  ReplaceProvisioningArtifacts: "true"
+sceptre_user_data:
+  # force cloudformation to update stack by setting a random number to the latest product's description
+  ProvisioningArtifactParameters: |
+    - Description: 'Initial release. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.0.0'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
@@ -13,7 +13,7 @@ parameters:
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |
-    - Description: 'Initial release. {{ range(1, 10000) | random }}'
+    - Description: 'Baseline release. {{ range(1, 10000) | random }}'
       Info:
-        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/ec2/sc-ec2-linux-docker.yaml'
-      Name: 'v1.0.0'
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.18/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.18'

--- a/sceptre/scipool/templates/sc-product-ec2-linux-docker.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-linux-docker.j2
@@ -1,0 +1,67 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Linux EC2 ServiceCatalog product
+Parameters:
+  ProductName:
+    Type: String
+    Description: Name of the product that will be visible to the end user
+    Default: 'EC2: Linux'
+  ReplaceProvisioningArtifacts:
+    Type: String
+    Description: "Whether to keep or replace the provisioning artifact identifier on update"
+    Default: 'false'
+
+Resources:
+  scec2linuxproduct:
+    Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002  # missing `owner` property error -> it's inside of included products.yaml
+            - E3003  # invalid property `Fn::Transform` error -> cfn-lint bug
+    Properties:
+      Name: !Ref ProductName
+      Description: "This product builds one Amazon Linux EC2 instance"
+      ProvisioningArtifactParameters:
+        {{ sceptre_user_data.ProvisioningArtifactParameters|indent(8) }}
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          # source: https://github.com/Sage-Bionetworks/admincentral-infra/blob/master/templates/cfn-snippets-bucket.yaml
+          Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipool/products.yaml"
+      ReplaceProvisioningArtifacts: !Ref ReplaceProvisioningArtifacts
+  Associateec2linux:
+    Type: AWS::ServiceCatalog::PortfolioProductAssociation
+    Properties:
+      PortfolioId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-ec2-SCEC2portfolioId'
+      ProductId: !Ref 'scec2linuxproduct'
+  constraintec2linux:
+    Type: AWS::ServiceCatalog::LaunchRoleConstraint
+    DependsOn: Associateec2linux
+    Properties:
+      PortfolioId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-ec2-SCEC2portfolioId'
+      ProductId: !Ref 'scec2linuxproduct'
+      RoleArn: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-ec2vpc-launchrole-LaunchRoleArn'
+  AssociatesExternalPortfolio:
+    Type: AWS::ServiceCatalog::PortfolioProductAssociation
+    Properties:
+      PortfolioId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-ec2-external-SCEC2portfolioId'
+      ProductId: !Ref 'scec2linuxproduct'
+  ConstraintExternalPortfolio:
+    Type: AWS::ServiceCatalog::LaunchRoleConstraint
+    DependsOn: AssociatesExternalPortfolio
+    Properties:
+      PortfolioId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-ec2-external-SCEC2portfolioId'
+      ProductId: !Ref 'scec2linuxproduct'
+      RoleArn: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-ec2vpc-launchrole-LaunchRoleArn'
+Outputs:
+  ProductId:
+    Value: !Ref 'scec2linuxproduct'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ProductId'


### PR DESCRIPTION
Create an EC2 docker product for the Service Catalog.  The product
will be placed into the EC2 portfolio.

Note: This PR only installs into scipooldev for testing.

Depends on https://github.com/Sage-Bionetworks/service-catalog-library/pull/247