### PR TITLE
[SC-251] allow SSM AWS-StartInteractiveCommand & AWS-StartSSHSession docs

### DIFF
--- a/sceptre/scipool/templates/sc-enduser-iam.yaml
+++ b/sceptre/scipool/templates/sc-enduser-iam.yaml
@@ -66,7 +66,9 @@ Resources:
           - Effect: Allow
             Action:
               - ssm:StartSession
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource:
+              - !Sub "arn:aws:ssm:*:${AWS::AccountId}:document/AWS-StartInteractiveCommand"
+              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
             Condition:
               StringLike:
                 "ssm:ResourceTag/Protected/AccessApprovedCaller": "${aws:userid}"

--- a/sceptre/scipool/templates/sc-enduser-iam.yaml
+++ b/sceptre/scipool/templates/sc-enduser-iam.yaml
@@ -67,6 +67,7 @@ Resources:
             Action:
               - ssm:StartSession
             Resource:
+              - !Sub "arn:aws:ssm:*:${AWS::AccountId}:document/AWS-StartSSHSession"
               - !Sub "arn:aws:ssm:*:${AWS::AccountId}:document/AWS-StartInteractiveCommand"
               - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
             Condition:


### PR DESCRIPTION
Allow SC users to use the SSM start-session and AWS-StartSSHSession
command to start a session with a specific command. This, for example,
will let the user start a session with the `bash` shell instead of the default `sh`
shell.  The command would be..

```
aws ssm start-session --target <INSTANCE_ID> \
                      --document-name AWS-StartInteractiveCommand
                      --parameters command="bash -l"
```
more info here: https://aws.amazon.com/blogs/mt/limit-ssm-interactive-session-commands-by-users/

The AWS-StartSSHSession allows users to start an SSH session with
which will allow users to secure copy from local machine and their instance.

more info here: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html

documentation update here: https://sagebionetworks.jira.com/wiki/spaces/IT/pages/938836322/Service+Catalog+Provisioning#SSM-access-with-custom-commands