### PR TITLE
[SC-251] Fix SSM document policy

### DIFF
--- a/sceptre/scipool/templates/sc-enduser-iam.yaml
+++ b/sceptre/scipool/templates/sc-enduser-iam.yaml
@@ -67,8 +67,14 @@ Resources:
             Action:
               - ssm:StartSession
             Resource:
-              - !Sub "arn:aws:ssm:*:${AWS::AccountId}:document/AWS-StartSSHSession"
-              - !Sub "arn:aws:ssm:*:${AWS::AccountId}:document/AWS-StartInteractiveCommand"
+              - !Sub "arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell"
+              - !Sub "arn:aws:ssm:*:*:document/AWS-StartSSHSession"
+              - !Sub "arn:aws:ssm:*:*:document/AWS-StartInteractiveCommand"
+              - !Sub "arn:aws:ssm:*:*:document/AWS-StartNonInteractiveCommand"
+          - Effect: Allow
+            Action:
+              - ssm:StartSession
+            Resource:
               - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
             Condition:
               StringLike:

--- a/sceptre/scipool/templates/sc-enduser-iam.yaml
+++ b/sceptre/scipool/templates/sc-enduser-iam.yaml
@@ -67,10 +67,10 @@ Resources:
             Action:
               - ssm:StartSession
             Resource:
-              - !Sub "arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell"
-              - !Sub "arn:aws:ssm:*:*:document/AWS-StartSSHSession"
-              - !Sub "arn:aws:ssm:*:*:document/AWS-StartInteractiveCommand"
-              - !Sub "arn:aws:ssm:*:*:document/AWS-StartNonInteractiveCommand"
+              - "arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell"
+              - "arn:aws:ssm:*:*:document/AWS-StartSSHSession"
+              - "arn:aws:ssm:*:*:document/AWS-StartInteractiveCommand"
+              - "arn:aws:ssm:*:*:document/AWS-StartNonInteractiveCommand"
           - Effect: Allow
             Action:
               - ssm:StartSession


### PR DESCRIPTION
The SC user gets access denied when attempting to start a session
with SSM dcouments.  The problem was due to the SC user policy.

Mixing SSM document with the policy to restrict users to instances
does not work due to the resource tag condition on the policy.
We need to split the policy up so that the condition does not
apply to the SSM documents.

This PR also allows users to start an command on an instance without
having to open a shell to it by starting the session with
AWS-StartNonInteractiveCommand document.