### PR TITLE
[SC-251] Access to SSM AWS-StartPortForwardingSession doc

### DIFF
--- a/sceptre/scipool/templates/sc-enduser-iam.yaml
+++ b/sceptre/scipool/templates/sc-enduser-iam.yaml
@@ -68,6 +68,7 @@ Resources:
               - ssm:StartSession
             Resource:
               - "arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell"
+              - "arn:aws:ssm:*:*:document/AWS-StartPortForwardingSession"
               - "arn:aws:ssm:*:*:document/AWS-StartSSHSession"
               - "arn:aws:ssm:*:*:document/AWS-StartInteractiveCommand"
               - "arn:aws:ssm:*:*:document/AWS-StartNonInteractiveCommand"


### PR DESCRIPTION
Allow SC end user role access to AWS-StartPortForwardingSession
document.

```
➜  ~ aws ssm start-session  \
                      --target i-0f83034f048d33a16 \
                      --document-name AWS-StartPortForwardingSession \
                      --parameters '{"portNumber":["80"],"localPortNumber":["9090"]}'

An error occurred (AccessDeniedException) when calling the StartSession
operation: User: arn:aws:sts::237179673806:assumed-role/ServiceCatalogEndusers/3377358
is not authorized to perform: ssm:StartSession on resource:
arn:aws:ssm:us-east-1::document/AWS-StartPortForwardingSession
```