### PR TITLE
Fix shared templates references

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -81,6 +81,7 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/organizations
+          mkdir -p templates/remote
           sceptre launch prod --yes
   sceptre-transit:
     if: github.event_name == 'push'
@@ -114,6 +115,7 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/transit
+          mkdir -p templates/remote
           sceptre launch prod --yes
   sceptre-admincentral:
     if: github.event_name == 'push'
@@ -147,6 +149,7 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/admincentral
+          mkdir -p templates/remote
           sceptre launch prod --yes
   sceptre-itsandbox:
     if: github.event_name == 'push'
@@ -180,6 +183,7 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/itsandbox
+          mkdir -p templates/remote
           sceptre launch prod --yes
   sceptre-sandbox:
     if: github.event_name == 'push'
@@ -213,6 +217,7 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/sandbox
+          mkdir -p templates/remote
           sceptre launch prod --yes
   sceptre-scicomp:
     if: github.event_name == 'push'
@@ -246,6 +251,7 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/scicomp
+          mkdir -p templates/remote
           sceptre launch prod --yes
   sceptre-strides:
     if: github.event_name == 'push'
@@ -280,6 +286,7 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/strides
+          mkdir -p templates/remote
           sceptre launch prod --yes
   sceptre-scipooldev:
     if: github.event_name == 'push'
@@ -349,6 +356,7 @@ jobs:
         # SC-26 & SC-219 workaround: dis-associate and re-associate SC actions on every deploy
         run: |
           cd sceptre/scipool
+          mkdir -p templates/remote
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-workflows.yaml
@@ -390,6 +398,7 @@ jobs:
         # SC-26 & SC-219 workaround: dis-associate and re-associate SC actions on every deploy
         run: |
           cd sceptre/scipool
+          mkdir -p templates/remote
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-workflows.yaml
@@ -427,10 +436,12 @@ jobs:
       - name: Deploy staging with sceptre
         run: |
           cd $GITHUB_WORKSPACE/sceptre/sageit
+          mkdir -p templates/remote
           sceptre launch staging --yes
       - name: Deploy prod with sceptre
         run: |
           cd $GITHUB_WORKSPACE/sceptre/sageit
+          mkdir -p templates/remote
           sceptre launch prod --yes
   sceptre-logcentral:
     if: github.event_name == 'push'
@@ -465,6 +476,7 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/logcentral
+          mkdir -p templates/remote
           sceptre launch prod --yes
   sceptre-synapsedw:
     if: github.event_name == 'push'
@@ -498,6 +510,7 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/synapsedw
+          mkdir -p templates/remote
           sceptre launch prod --yes
   sceptre-synapsedev:
     if: github.event_name == 'push'
@@ -531,6 +544,7 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/synapsedev
+          mkdir -p templates/remote
           sceptre launch prod --yes
   sceptre-synapseprod:
     if: github.event_name == 'push'
@@ -564,6 +578,7 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/synapseprod
+          mkdir -p templates/remote
           sceptre launch prod --yes
   sceptre-securitycentral:
     if: github.event_name == 'push'
@@ -597,6 +612,7 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/securitycentral
+          mkdir -p templates/remote
           sceptre launch prod --yes
   sceptre-bridgedev:
     if: github.event_name == 'push'
@@ -630,6 +646,7 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/bridge
+          mkdir -p templates/remote
           sceptre launch develop --yes
   sceptre-bridgeprod:
     if: github.event_name == 'push'
@@ -663,6 +680,7 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/bridge
+          mkdir -p templates/remote
           sceptre launch prod --yes
   sceptre-imagecentral:
     if: github.event_name == 'push'
@@ -696,4 +714,5 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd sceptre/imagecentral
+          mkdir -p templates/remote
           sceptre launch prod --yes

--- a/sceptre/admincentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/admincentral/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/admincentral/config/prod/bootstrap.yaml
+++ b/sceptre/admincentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/admincentral/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/admincentral/config/prod/cfn-s3objects-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/admincentral/config/prod/essentials.yaml
+++ b/sceptre/admincentral/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   LambdaBucketVersioning: Enabled
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/admincentral/config/prod/rotate-credentials.yaml
+++ b/sceptre/admincentral/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/bridge/config/develop/AccountAlertTopics.yaml
+++ b/sceptre/bridge/config/develop/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/bridge/config/develop/BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/develop/BridgeServer2-vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcSubnetPrefix: "172.48"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/bridge/config/develop/bootstrap.yaml
+++ b/sceptre/bridge/config/develop/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/bridge/config/develop/bridge-aux.yaml
+++ b/sceptre/bridge/config/develop/bridge-aux.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: bridge-aux
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/bridge/config/develop/peer-vpn-BridgeServer2-develop.yaml
+++ b/sceptre/bridge/config/develop/peer-vpn-BridgeServer2-develop.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/bridge/config/develop/peer-vpn-bridge-aux.yaml
+++ b/sceptre/bridge/config/develop/peer-vpn-bridge-aux.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/bridge/config/develop/rotate-credentials.yaml
+++ b/sceptre/bridge/config/develop/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/bridge/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/bridge/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/bridge/config/prod/BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/BridgeServer2-vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcSubnetPrefix: "172.32"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/bridge/config/prod/bootstrap.yaml
+++ b/sceptre/bridge/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/bridge/config/prod/peer-vpn-BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/peer-vpn-BridgeServer2-vpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/bridge/config/prod/rotate-credentials.yaml
+++ b/sceptre/bridge/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/bridge/config/prod/tgw-spoke-BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/tgw-spoke-BridgeServer2-vpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/imagecentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/imagecentral/config/prod/AccountAlertTopics.yaml
@@ -11,6 +11,6 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_create:
-    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
   before_update:
-    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/imagecentral/config/prod/bootstrap.yaml
+++ b/sceptre/imagecentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_update:
-    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/imagecentral/config/prod/essentials.yaml
+++ b/sceptre/imagecentral/config/prod/essentials.yaml
@@ -6,6 +6,6 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_create:
-    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
   before_update:
-    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/imagecentral/config/prod/rotate-credentials.yaml
+++ b/sceptre/imagecentral/config/prod/rotate-credentials.yaml
@@ -9,6 +9,6 @@ parameters:
   SendReport: "true"
 hooks:
   before_create:
-    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"
   before_update:
-    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/itsandbox/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/itsandbox/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/itsandbox/config/prod/bootstrap.yaml
+++ b/sceptre/itsandbox/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/itsandbox/config/prod/dustbunnyvpc.yaml
+++ b/sceptre/itsandbox/config/prod/dustbunnyvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: "dustbunnyvpc"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/itsandbox/config/prod/essentials.yaml
+++ b/sceptre/itsandbox/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm "/infra/AdmincentralAwsAccountId"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/itsandbox/config/prod/rotate-credentials.yaml
+++ b/sceptre/itsandbox/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/itsandbox/config/prod/sage-tgw-spoke.yaml
+++ b/sceptre/itsandbox/config/prod/sage-tgw-spoke.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/logcentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/logcentral/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/logcentral/config/prod/bootstrap.yaml
+++ b/sceptre/logcentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/logcentral/config/prod/essentials.yaml
+++ b/sceptre/logcentral/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/logcentral/config/prod/rotate-credentials.yaml
+++ b/sceptre/logcentral/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/logcentral/config/prod/sumologic-role-s3cloudtrail.yaml
+++ b/sceptre/logcentral/config/prod/sumologic-role-s3cloudtrail.yaml
@@ -8,4 +8,4 @@ parameters:
   Resource: !stack_output_external essentials::AWSS3CloudtrailBucketArn
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -O templates/remote/sumologic-role.yaml"

--- a/sceptre/logcentral/config/prod/sumologic-role-s3config.yaml
+++ b/sceptre/logcentral/config/prod/sumologic-role-s3config.yaml
@@ -8,4 +8,4 @@ parameters:
   Resource: !stack_output_external essentials::AWSS3ConfigBucketArn
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -O templates/remote/sumologic-role.yaml"

--- a/sceptre/organizations/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/organizations/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/organizations/config/prod/bootstrap.yaml
+++ b/sceptre/organizations/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/organizations/config/prod/essentials.yaml
+++ b/sceptre/organizations/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm "/infra/AdmincentralAwsAccountId"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/organizations/config/prod/rotate-credentials.yaml
+++ b/sceptre/organizations/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/sageit/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/sageit/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/sageit/config/prod/bootstrap.yaml
+++ b/sceptre/sageit/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/sageit/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/sageit/config/prod/cfn-s3objects-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/sageit/config/prod/defaultvpc.yaml
+++ b/sceptre/sageit/config/prod/defaultvpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpcName: sagedefaultvpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/sageit/config/prod/essentials.yaml
+++ b/sceptre/sageit/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/sageit/config/prod/gha-svc-account.yaml
+++ b/sceptre/sageit/config/prod/gha-svc-account.yaml
@@ -24,4 +24,4 @@ parameters:
     }
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/IAM/service-account.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/IAM/service-account.yaml -O templates/remote/service-account.yaml"

--- a/sceptre/sageit/config/prod/peer-defaultvpc-admincentral.yaml
+++ b/sceptre/sageit/config/prod/peer-defaultvpc-admincentral.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/sageit/config/prod/prod-csbc-pson-s3web.yaml
+++ b/sceptre/sageit/config/prod/prod-csbc-pson-s3web.yaml
@@ -9,4 +9,4 @@ parameters:
   OwnerEmail: michael.lee@sagebionetworks.org
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-s3WebCloudfront.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-s3WebCloudfront.yaml -O templates/remote/managed-s3WebCloudfront.yaml"

--- a/sceptre/sageit/config/prod/rotate-credentials.yaml
+++ b/sceptre/sageit/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/sageit/config/prod/sageit-org-acm-cert.yaml
+++ b/sceptre/sageit/config/prod/sageit-org-acm-cert.yaml
@@ -11,4 +11,4 @@ parameters:
   DnsDomainName: "sageit.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml -O templates/remote/acm-certificate.yaml"

--- a/sceptre/sageit/config/prod/vpn-sageit-org-redirector.yaml
+++ b/sceptre/sageit/config/prod/vpn-sageit-org-redirector.yaml
@@ -18,4 +18,4 @@ parameters:
   TargetKey: "endpoints/cvpn-endpoint-055bd9db65af09d63"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/s3-redirector.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/s3-redirector.yaml -O templates/remote/s3-redirector.yaml"

--- a/sceptre/sageit/config/staging/staging-csbc-pson-s3web.yaml
+++ b/sceptre/sageit/config/staging/staging-csbc-pson-s3web.yaml
@@ -9,4 +9,4 @@ parameters:
   OwnerEmail: michael.lee@sagebionetworks.org
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-s3WebCloudfront.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-s3WebCloudfront.yaml -O templates/remote/managed-s3WebCloudfront.yaml"

--- a/sceptre/sandbox/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/sandbox/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/sandbox/config/prod/bootstrap.yaml
+++ b/sceptre/sandbox/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/sandbox/config/prod/cfn-explode-macro.yaml
+++ b/sceptre/sandbox/config/prod/cfn-explode-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-explode-macro/master/cfn-explode-macro.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-explode-macro/master/cfn-explode-macro.yaml -O templates/remote/cfn-explode-macro.yaml"

--- a/sceptre/sandbox/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/sandbox/config/prod/cfn-s3objects-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/sandbox/config/prod/cfn-sc-actions-provider.yaml
+++ b/sceptre/sandbox/config/prod/cfn-sc-actions-provider.yaml
@@ -8,4 +8,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-sc-actions-provider.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-sc-actions-provider.yaml -O templates/remote/cfn-sc-actions-provider.yaml"

--- a/sceptre/sandbox/config/prod/cfn-ssm-param-macro.yaml
+++ b/sceptre/sandbox/config/prod/cfn-ssm-param-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -O templates/remote/cfn-macro-ssm-param.yaml"

--- a/sceptre/sandbox/config/prod/essentials.yaml
+++ b/sceptre/sandbox/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/sandbox/config/prod/park-my-cloud.yaml
+++ b/sceptre/sandbox/config/prod/park-my-cloud.yaml
@@ -6,4 +6,4 @@ parameters:
   PMCExternalID: !ssm /infra/PMCExternalID
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml -O templates/remote/ParkMyCloud.yaml"

--- a/sceptre/sandbox/config/prod/peer-vpn-sandcastlevpc.yaml
+++ b/sceptre/sandbox/config/prod/peer-vpn-sandcastlevpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/sandbox/config/prod/rotate-credentials.yaml
+++ b/sceptre/sandbox/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/sandbox/config/prod/s3-gateway-vpc-endpoint.yaml
+++ b/sceptre/sandbox/config/prod/s3-gateway-vpc-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/sandbox/config/prod/sage-tgw-spoke.yaml
+++ b/sceptre/sandbox/config/prod/sage-tgw-spoke.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/sandbox/config/prod/sandcastlevpc.yaml
+++ b/sceptre/sandbox/config/prod/sandcastlevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: sandcastlevpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/sandbox/config/prod/service-linked-roles.yaml
+++ b/sceptre/sandbox/config/prod/service-linked-roles.yaml
@@ -4,4 +4,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml -O templates/remote/service-linked-roles.yaml"

--- a/sceptre/scicomp/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/scicomp/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/scicomp/config/prod/bootstrap.yaml
+++ b/sceptre/scicomp/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/scicomp/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/scicomp/config/prod/cfn-s3objects-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
+++ b/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
@@ -5,4 +5,4 @@ parameters:
     - "563295687221"  # org-sagebase-sandbox
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cloudwatch-cross-account-sharing.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cloudwatch-cross-account-sharing.yaml -O templates/remote/cloudwatch-cross-account-sharing.yaml"

--- a/sceptre/scicomp/config/prod/computevpc.yaml
+++ b/sceptre/scicomp/config/prod/computevpc.yaml
@@ -5,4 +5,4 @@ parameters:
   VpcName: computevpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scicomp/config/prod/essentials.yaml
+++ b/sceptre/scicomp/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/scicomp/config/prod/maintenance.yaml
+++ b/sceptre/scicomp/config/prod/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -O templates/remote/maintenance.yaml"

--- a/sceptre/scicomp/config/prod/park-my-cloud.yaml
+++ b/sceptre/scicomp/config/prod/park-my-cloud.yaml
@@ -6,4 +6,4 @@ parameters:
   PMCExternalID: !ssm /infra/PMCExternalID
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml -O templates/remote/ParkMyCloud.yaml"

--- a/sceptre/scicomp/config/prod/peer-vpn-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/peer-vpn-computevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scicomp/config/prod/peer-vpn-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/peer-vpn-snowflakevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scicomp/config/prod/rotate-credentials.yaml
+++ b/sceptre/scicomp/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/scicomp/config/prod/s3-computevpc-gateway-endpoint.yaml
+++ b/sceptre/scicomp/config/prod/s3-computevpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scicomp/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
+++ b/sceptre/scicomp/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scicomp/config/prod/sage-tgw-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/sage-tgw-computevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml -O templates/remote/transit-gateway-attachment.yaml"

--- a/sceptre/scicomp/config/prod/sage-tgw-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/sage-tgw-snowflakevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml -O templates/remote/transit-gateway-attachment.yaml"

--- a/sceptre/scicomp/config/prod/sagebionetworks-org-acm-cert.yaml
+++ b/sceptre/scicomp/config/prod/sagebionetworks-org-acm-cert.yaml
@@ -11,4 +11,4 @@ parameters:
   DnsDomainName: "sagebionetworks.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml -O templates/remote/acm-certificate.yaml"

--- a/sceptre/scicomp/config/prod/service-linked-roles.yaml
+++ b/sceptre/scicomp/config/prod/service-linked-roles.yaml
@@ -4,4 +4,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml -O templates/remote/service-linked-roles.yaml"

--- a/sceptre/scicomp/config/prod/snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/snowflakevpc.yaml
@@ -5,4 +5,4 @@ parameters:
   VpcName: snowflakevpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scicomp/config/prod/sumologic-role.yaml
+++ b/sceptre/scicomp/config/prod/sumologic-role.yaml
@@ -8,4 +8,4 @@ parameters:
   Resource: !ssm /infra/BeanstalkBucketArn
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -O templates/remote/sumologic-role.yaml"

--- a/sceptre/scicomp/config/prod/tgw-spoke-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/tgw-spoke-computevpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/scicomp/config/prod/tgw-spoke-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/tgw-spoke-snowflakevpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/scipool/config/develop/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/develop/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/scipool/config/develop/bootstrap.yaml
+++ b/sceptre/scipool/config/develop/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/scipool/config/develop/cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/cesspoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: "cesspoolvpc"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
@@ -13,4 +13,4 @@ parameters:
   OidcClientId: '100055'
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml -O templates/remote/cfn-cr-alb-rule.yaml"

--- a/sceptre/scipool/config/develop/cfn-cr-sc-actions-provider.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-sc-actions-provider.yaml
@@ -8,4 +8,4 @@ dependencies:
   - develop/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml -O templates/remote/cfn-cr-sc-actions-provider.yaml"

--- a/sceptre/scipool/config/develop/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-sc-bucket-policy.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/master/cfn-cr-sc-bucket-policy.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/master/cfn-cr-sc-bucket-policy.yaml -O templates/remote/cfn-cr-sc-bucket-policy.yaml"

--- a/sceptre/scipool/config/develop/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-synapse-tagger.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml -O templates/remote/cfn-cr-synapse-tagger.yaml"

--- a/sceptre/scipool/config/develop/cfn-macro-ssm-param.yaml
+++ b/sceptre/scipool/config/develop/cfn-macro-ssm-param.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "develop/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -O templates/remote/cfn-macro-ssm-param.yaml"

--- a/sceptre/scipool/config/develop/cfn-s3objects-macro.yaml
+++ b/sceptre/scipool/config/develop/cfn-s3objects-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "develop/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/scipool/config/develop/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/develop/cfn-tag-instance-policy.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "develop/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"

--- a/sceptre/scipool/config/develop/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/develop/docker-runner-efs-vpc.yaml
@@ -4,4 +4,4 @@ dependencies:
   - develop/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/VPC/efs-vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/VPC/efs-vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scipool/config/develop/essentials.yaml
+++ b/sceptre/scipool/config/develop/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/scipool/config/develop/lambda-budgets.yaml
+++ b/sceptre/scipool/config/develop/lambda-budgets.yaml
@@ -10,4 +10,4 @@ parameters:
   Thresholds: !file_contents templates/develop/lambda-budgets/thresholds.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml -O templates/remote/lambda-budgets.yaml"

--- a/sceptre/scipool/config/develop/lambda-send-budget-alert.yaml
+++ b/sceptre/scipool/config/develop/lambda-send-budget-alert.yaml
@@ -10,4 +10,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml -O templates/remote/lambda-send-budget-alert.yaml"

--- a/sceptre/scipool/config/develop/maintenance.yaml
+++ b/sceptre/scipool/config/develop/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -O templates/remote/maintenance.yaml"

--- a/sceptre/scipool/config/develop/peer-vpn-cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/peer-vpn-cesspoolvpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: "10.1.0.0/16"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scipool/config/develop/rotate-credentials.yaml
+++ b/sceptre/scipool/config/develop/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/scipool/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scipool/config/develop/synapse-oidc-idp.yaml
+++ b/sceptre/scipool/config/develop/synapse-oidc-idp.yaml
@@ -10,4 +10,4 @@ parameters:
   ThumbprintList: "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml -O templates/remote/cfn-cr-oidc-idp.yaml"

--- a/sceptre/scipool/config/develop/tgw-spoke-cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/tgw-spoke-cesspoolvpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/scipool/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/scipool/config/prod/bootstrap.yaml
+++ b/sceptre/scipool/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/scipool/config/prod/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-alb-rule.yaml
@@ -13,4 +13,4 @@ parameters:
   OidcClientId: '100053'
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml -O templates/remote/cfn-cr-alb-rule.yaml"

--- a/sceptre/scipool/config/prod/cfn-cr-sc-actions-provider.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-sc-actions-provider.yaml
@@ -8,4 +8,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml -O templates/remote/cfn-cr-sc-actions-provider.yaml"

--- a/sceptre/scipool/config/prod/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-sc-bucket-policy.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/master/cfn-cr-sc-bucket-policy.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/master/cfn-cr-sc-bucket-policy.yaml -O templates/remote/cfn-cr-sc-bucket-policy.yaml"

--- a/sceptre/scipool/config/prod/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-synapse-tagger.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml -O templates/remote/cfn-cr-synapse-tagger.yaml"

--- a/sceptre/scipool/config/prod/cfn-macro-ssm-param.yaml
+++ b/sceptre/scipool/config/prod/cfn-macro-ssm-param.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -O templates/remote/cfn-macro-ssm-param.yaml"

--- a/sceptre/scipool/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/scipool/config/prod/cfn-s3objects-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/scipool/config/prod/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/prod/cfn-tag-instance-policy.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"

--- a/sceptre/scipool/config/prod/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/prod/docker-runner-efs-vpc.yaml
@@ -4,4 +4,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/VPC/efs-vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/VPC/efs-vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scipool/config/prod/essentials.yaml
+++ b/sceptre/scipool/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/scipool/config/prod/internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/internalpoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: internalpoolvpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scipool/config/prod/lambda-budgets.yaml
+++ b/sceptre/scipool/config/prod/lambda-budgets.yaml
@@ -10,4 +10,4 @@ parameters:
   Thresholds: !file_contents templates/prod/lambda-budgets/thresholds.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml -O templates/remote/lambda-budgets.yaml"

--- a/sceptre/scipool/config/prod/lambda-send-budget-alert.yaml
+++ b/sceptre/scipool/config/prod/lambda-send-budget-alert.yaml
@@ -10,4 +10,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml -O templates/remote/lambda-send-budget-alert.yaml"

--- a/sceptre/scipool/config/prod/maintenance.yaml
+++ b/sceptre/scipool/config/prod/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -O templates/remote/maintenance.yaml"

--- a/sceptre/scipool/config/prod/peer-vpn-internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/peer-vpn-internalpoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scipool/config/prod/rotate-credentials.yaml
+++ b/sceptre/scipool/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/scipool/config/prod/s3-internalpoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/prod/s3-internalpoolvpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scipool/config/prod/synapse-oidc-idp.yaml
+++ b/sceptre/scipool/config/prod/synapse-oidc-idp.yaml
@@ -10,4 +10,4 @@ parameters:
   ThumbprintList: "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml -O templates/remote/cfn-cr-oidc-idp.yaml"

--- a/sceptre/scipool/config/prod/tgw-spoke-internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/tgw-spoke-internalpoolvpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/scipool/config/strides/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/strides/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/scipool/config/strides/bootstrap.yaml
+++ b/sceptre/scipool/config/strides/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/scipool/config/strides/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-alb-rule.yaml
@@ -13,4 +13,4 @@ parameters:
   OidcClientId: '100063'
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml -O templates/remote/cfn-cr-alb-rule.yaml"

--- a/sceptre/scipool/config/strides/cfn-cr-saml-provider.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -O templates/remote/cfn-cr-saml-provider.yaml"

--- a/sceptre/scipool/config/strides/cfn-cr-sc-actions-provider.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-sc-actions-provider.yaml
@@ -8,4 +8,4 @@ dependencies:
   - strides/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml -O templates/remote/cfn-cr-sc-actions-provider.yaml"

--- a/sceptre/scipool/config/strides/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-sc-bucket-policy.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/master/cfn-cr-sc-bucket-policy.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/master/cfn-cr-sc-bucket-policy.yaml -O templates/remote/cfn-cr-sc-bucket-policy.yaml"

--- a/sceptre/scipool/config/strides/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-synapse-tagger.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml -O templates/remote/cfn-cr-synapse-tagger.yaml"

--- a/sceptre/scipool/config/strides/cfn-macro-ssm-param.yaml
+++ b/sceptre/scipool/config/strides/cfn-macro-ssm-param.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "strides/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -O templates/remote/cfn-macro-ssm-param.yaml"

--- a/sceptre/scipool/config/strides/cfn-s3objects-macro.yaml
+++ b/sceptre/scipool/config/strides/cfn-s3objects-macro.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "strides/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/scipool/config/strides/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/strides/cfn-tag-instance-policy.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "strides/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"

--- a/sceptre/scipool/config/strides/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/strides/docker-runner-efs-vpc.yaml
@@ -4,4 +4,4 @@ dependencies:
   - strides/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/VPC/efs-vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/VPC/efs-vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scipool/config/strides/essentials.yaml
+++ b/sceptre/scipool/config/strides/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"  # org-sagebase-admincentral
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/scipool/config/strides/lambda-budgets.yaml
+++ b/sceptre/scipool/config/strides/lambda-budgets.yaml
@@ -10,4 +10,4 @@ parameters:
   Thresholds: !file_contents templates/strides/lambda-budgets/thresholds.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml -O templates/remote/lambda-budgets.yaml"

--- a/sceptre/scipool/config/strides/lambda-send-budget-alert.yaml
+++ b/sceptre/scipool/config/strides/lambda-send-budget-alert.yaml
@@ -10,4 +10,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml -O templates/remote/lambda-send-budget-alert.yaml"

--- a/sceptre/scipool/config/strides/maintenance.yaml
+++ b/sceptre/scipool/config/strides/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -O templates/remote/maintenance.yaml"

--- a/sceptre/scipool/config/strides/peer-vpn-stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/peer-vpn-stridespoolvpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: !stack_output_external stridespoolvpc::VpnCidr      # org-sagebase-admincentral sophos-utm VPN CIDR
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scipool/config/strides/rotate-credentials.yaml
+++ b/sceptre/scipool/config/strides/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/scipool/config/strides/s3-stridespoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/strides/s3-stridespoolvpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scipool/config/strides/stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/stridespoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: stridespoolvpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scipool/config/strides/synapse-oidc-idp.yaml
+++ b/sceptre/scipool/config/strides/synapse-oidc-idp.yaml
@@ -10,4 +10,4 @@ parameters:
   ThumbprintList: "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml -O templates/remote/cfn-cr-oidc-idp.yaml"

--- a/sceptre/scipool/config/strides/tgw-spoke-stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/tgw-spoke-stridespoolvpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/securitycentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/securitycentral/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/securitycentral/config/prod/bootstrap.yaml
+++ b/sceptre/securitycentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/securitycentral/config/prod/essentials.yaml
+++ b/sceptre/securitycentral/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/securitycentral/config/prod/rotate-credentials.yaml
+++ b/sceptre/securitycentral/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/synapsedev/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapsedev/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/synapsedev/config/prod/bootstrap.yaml
+++ b/sceptre/synapsedev/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/synapsedev/config/prod/essentials.yaml
+++ b/sceptre/synapsedev/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/synapsedev/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapsedev/config/prod/peer-vpc-admincentral.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml service-account.yaml -O templates/remote/service-account.yaml templates/remote/peer-route-config.yaml"

--- a/sceptre/synapsedev/config/prod/rotate-credentials.yaml
+++ b/sceptre/synapsedev/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/synapsedev/config/prod/vpc.yaml
+++ b/sceptre/synapsedev/config/prod/vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/synapsedw/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapsedw/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/synapsedw/config/prod/bootstrap.yaml
+++ b/sceptre/synapsedw/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/synapsedw/config/prod/essentials.yaml
+++ b/sceptre/synapsedw/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/synapsedw/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapsedw/config/prod/peer-vpc-admincentral.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/synapsedw/config/prod/rotate-credentials.yaml
+++ b/sceptre/synapsedw/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/synapsedw/config/prod/vpc.yaml
+++ b/sceptre/synapsedw/config/prod/vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/synapseprod/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapseprod/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/synapseprod/config/prod/bootstrap.yaml
+++ b/sceptre/synapseprod/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/synapseprod/config/prod/essentials.yaml
+++ b/sceptre/synapseprod/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/synapseprod/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapseprod/config/prod/peer-vpc-admincentral.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/synapseprod/config/prod/rotate-credentials.yaml
+++ b/sceptre/synapseprod/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/synapseprod/config/prod/synapse-ops-vpc-v2.yaml
+++ b/sceptre/synapseprod/config/prod/synapse-ops-vpc-v2.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/synapseprod/config/prod/vpc.yaml
+++ b/sceptre/synapseprod/config/prod/vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-   - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+   - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/transit/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/transit/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/transit/config/prod/bootstrap.yaml
+++ b/sceptre/transit/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/transit/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/transit/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -O templates/remote/cfn-cr-saml-provider.yaml"

--- a/sceptre/transit/config/prod/essentials.yaml
+++ b/sceptre/transit/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/transit/config/prod/rotate-credentials.yaml
+++ b/sceptre/transit/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/transit/config/prod/unionstationvpc.yaml
+++ b/sceptre/transit/config/prod/unionstationvpc.yaml
@@ -8,4 +8,4 @@ parameters:
   VpnCidr: "10.50.0.0/16"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -N -P templates/remote"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"


### PR DESCRIPTION
wget when used without the -O option will not download
a file if it already exists. Since we have multiple
sceptre templates referencing different versions of a CFN
template it can download the 1st version then not download the
2nd version.

For example:

assume the following:

config/prod/a.yaml references v1.0 of x.yaml CFN template
config/prod/b.yaml references v2.0 of x.yaml CFN template
workflow:

sceptre runs config/prod/a.yaml and downloads v1.0 of x.yaml
sceptre runs config/prod/b.yaml but does not download v2.0 of x.yaml
becuase v1.0 of x.yaml already exists. sceptre will deploy with the old v1.0 of x.yaml
To force wget to download and overwrite the file we need to use
the -O option.