### PR TITLE
Update SC end user policy for SSM

### DIFF
--- a/sceptre/scipool/templates/sc-enduser-iam.yaml
+++ b/sceptre/scipool/templates/sc-enduser-iam.yaml
@@ -84,7 +84,12 @@ Resources:
             Action:
               - ssm:DescribeSessions
               - ssm:GetConnectionStatus
+              - ssm:DescribeDocument
+              - ssm:DescribeDocumentParameters
+              - ssm:ListDocuments
               - ssm:DescribeInstanceProperties
+              - ssm:DescribeInstanceInformation
+              - ssm:ListTagsForResource
               - ec2:DescribeInstances
             Resource: "*"
           - Effect: Allow


### PR DESCRIPTION
Give SC users the ability to list and get info about SSM documents[1]
(i.e. AWS-StartInteractiveCommand,  AWS-StartPortForwardingSession,
etc..).  Also give SC users the ability to list running instances so
they can get the instance ID[2]

[1] https://docs.aws.amazon.com/cli/latest/reference/ssm/describe-document.html
[2] https://docs.aws.amazon.com/cli/latest/reference/ssm/describe-instance-information.html