### PR TITLE
[SC-304] deploy cfn-cr-sc-product-provider

### DIFF
--- a/sceptre/scipool/config/develop/cfn-cr-sc-product-provider.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-sc-product-provider.yaml
@@ -1,0 +1,9 @@
+template_path: remote/cfn-cr-sc-product-provider.yaml
+stack_name: cfn-cr-sc-product-provider
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+hooks:
+  before_launch:
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-product-provider/1.0.0/cfn-cr-sc-product-provider.yaml -O templates/remote/cfn-cr-sc-product-provider.yaml"

--- a/sceptre/scipool/config/prod/cfn-cr-sc-product-provider.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-sc-product-provider.yaml
@@ -1,0 +1,9 @@
+template_path: remote/cfn-cr-sc-product-provider.yaml
+stack_name: cfn-cr-sc-product-provider
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+hooks:
+  before_launch:
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-product-provider/1.0.0/cfn-cr-sc-product-provider.yaml -O templates/remote/cfn-cr-sc-product-provider.yaml"

--- a/sceptre/scipool/config/strides/cfn-cr-sc-product-provider.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-sc-product-provider.yaml
@@ -1,0 +1,9 @@
+template_path: remote/cfn-cr-sc-product-provider.yaml
+stack_name: cfn-cr-sc-product-provider
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+hooks:
+  before_launch:
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-product-provider/1.0.0/cfn-cr-sc-product-provider.yaml -O templates/remote/cfn-cr-sc-product-provider.yaml"


### PR DESCRIPTION
Deploy the  cfn-cr-sc-product-provider[1] to allow us to
automate updating of product versions.  The main use case
for this custom resource is so that we can automate the
deprecation of products.

[1] https://github.com/Sage-Bionetworks-IT/cfn-cr-sc-product-provider