### PR TITLE
[SC-304] Deprecate product versions

### DIFF
--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-docker.yaml
@@ -10,6 +10,8 @@ dependencies:
   - "prod/sc-ec2-actions.yaml"
 parameters:
   ProductName: "EC2: Linux Docker"
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -8,6 +8,9 @@ dependencies:
   - "prod/sc-portfolio-ec2.yaml"
   - "prod/sc-ec2-actions.yaml"
   - "prod/sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml"
+parameters:
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -7,6 +7,9 @@ stack_tags:
 dependencies:
   - "prod/sc-portfolio-ec2.yaml"
   - "prod/sc-ec2-actions.yaml"
+parameters:
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud.yaml
@@ -8,6 +8,9 @@ dependencies:
   - "prod/sc-portfolio-ec2.yaml"
   - "prod/sc-portfolio-ec2-external.yaml"
   - "prod/sc-ec2-actions.yaml"
+parameters:
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/prod/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-windows-jumpcloud.yaml
@@ -7,6 +7,9 @@ stack_tags:
 dependencies:
   - "prod/sc-portfolio-ec2.yaml"
   - "prod/sc-ec2-actions.yaml"
+parameters:
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/prod/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/prod/sc-product-s3-private-enc.yaml
@@ -6,6 +6,9 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 dependencies:
   - "prod/sc-portfolio-s3-basic.yaml"
+parameters:
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/prod/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/prod/sc-product-s3-synapse.yaml
@@ -6,6 +6,9 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 dependencies:
   - "prod/sc-portfolio-s3-basic.yaml"
+parameters:
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-docker.yaml
@@ -10,6 +10,8 @@ dependencies:
   - "strides/sc-ec2-actions.yaml"
 parameters:
   ProductName: "EC2: Linux Docker"
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -8,6 +8,9 @@ dependencies:
   - "strides/sc-portfolio-ec2.yaml"
   - "strides/sc-ec2-actions.yaml"
   - "strides/sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml"
+parameters:
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -7,6 +7,9 @@ stack_tags:
 dependencies:
   - "strides/sc-portfolio-ec2.yaml"
   - "strides/sc-ec2-actions.yaml"
+parameters:
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud.yaml
@@ -8,6 +8,9 @@ dependencies:
   - "strides/sc-portfolio-ec2.yaml"
   - "strides/sc-ec2-actions.yaml"
   - "strides/sc-portfolio-ec2-external.yaml"
+parameters:
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/strides/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-windows-jumpcloud.yaml
@@ -7,6 +7,9 @@ stack_tags:
 dependencies:
   - "strides/sc-portfolio-ec2.yaml"
   - "strides/sc-ec2-actions.yaml"
+parameters:
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/strides/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/strides/sc-product-s3-private-enc.yaml
@@ -6,6 +6,9 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 dependencies:
   - "strides/sc-portfolio-s3-basic.yaml"
+parameters:
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/strides/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/strides/sc-product-s3-synapse.yaml
@@ -6,6 +6,9 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 dependencies:
   - "strides/sc-portfolio-s3-basic.yaml"
+parameters:
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/templates/sc-product-ec2-linux-docker.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-linux-docker.j2
@@ -9,7 +9,36 @@ Parameters:
     Type: String
     Description: "Whether to keep or replace the provisioning artifact identifier on update"
     Default: 'false'
-
+  ProvisioningArtifactActive:
+    Description: >-
+      Indicates whether the product version is active. Inactive provisioning artifacts
+      are invisible to end users. End users cannot launch or update a provisioned product
+      from an inactive provisioning artifact
+    Type: String
+    AllowedValues:
+      - "True"
+      - "False"
+    ConstraintDescription: "Valid values are True|False"
+    Default: "true"
+  ProvisioningArtifactGuidance:
+    Description: 'The value to apply to the product version guidance'
+    Type: String
+    AllowedValues:
+      - "DEFAULT"
+      - "DEPRECATED"
+    ConstraintDescription: "Valid values are DEFAULT|DEPRECATED"
+    Default: "DEFAULT"
+  ProvisioningArtifactAction:
+    Description: >-
+        The action type used to apply ProvisioningArtifactActive and ProvisioningArtifactGuidance
+        to provisioning artifacts. ALL to apply to all artifacts, ALL_EXCEPT_LATEST to apply to
+        all except the latest artifact
+    Type: String
+    AllowedValues:
+      - "ALL"
+      - "ALL_EXCEPT_LATEST"
+    ConstraintDescription: "Valid values are ALL|ALL_EXCEPT_LATEST"
+    DEFAULT: "ALL
 Resources:
   scec2linuxproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -60,6 +89,15 @@ Resources:
       ProductId: !Ref 'scec2linuxproduct'
       RoleArn: !ImportValue
         'Fn::Sub': '${AWS::Region}-sc-ec2vpc-launchrole-LaunchRoleArn'
+  UpdateProductVersions:
+    Type: Custom::ProductProvider
+    Properties:
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
+      ProductId: !Ref scec2linuxproduct
+      ProvisioningArtifactActive: !Ref ProvisioningArtifactActive
+      ProvisioningArtifactGuidance: !Ref ProvisioningArtifactGuidance
+      ProvisioningArtifactAction: !Ref ProvisioningArtifactAction
 Outputs:
   ProductId:
     Value: !Ref 'scec2linuxproduct'

--- a/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud-notebook.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud-notebook.j2
@@ -9,6 +9,36 @@ Parameters:
     Type: String
     Description: "Whether to keep or replace the provisioning artifact identifier on update"
     Default: 'false'
+  ProvisioningArtifactActive:
+    Description: >-
+      Indicates whether the product version is active. Inactive provisioning artifacts
+      are invisible to end users. End users cannot launch or update a provisioned product
+      from an inactive provisioning artifact
+    Type: String
+    AllowedValues:
+      - "True"
+      - "False"
+    ConstraintDescription: "Valid values are True|False"
+    Default: "true"
+  ProvisioningArtifactGuidance:
+    Description: 'The value to apply to the product version guidance'
+    Type: String
+    AllowedValues:
+      - "DEFAULT"
+      - "DEPRECATED"
+    ConstraintDescription: "Valid values are DEFAULT|DEPRECATED"
+    Default: "DEFAULT"
+  ProvisioningArtifactAction:
+    Description: >-
+        The action type used to apply ProvisioningArtifactActive and ProvisioningArtifactGuidance
+        to provisioning artifacts. ALL to apply to all artifacts, ALL_EXCEPT_LATEST to apply to
+        all except the latest artifact
+    Type: String
+    AllowedValues:
+      - "ALL"
+      - "ALL_EXCEPT_LATEST"
+    ConstraintDescription: "Valid values are ALL|ALL_EXCEPT_LATEST"
+    DEFAULT: "ALL
 Resources:
   ScEc2LinuxJumpcloudNotebookProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -60,6 +90,15 @@ Resources:
       ProductId: !Ref 'ScEc2LinuxJumpcloudNotebookProduct'
       RoleArn: !ImportValue
         'Fn::Sub': '${AWS::Region}-sc-ec2vpc-launchrole-LaunchRoleArn'
+  UpdateProductVersions:
+    Type: Custom::ProductProvider
+    Properties:
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
+      ProductId: !Ref scec2linuxproduct
+      ProvisioningArtifactActive: !Ref ProvisioningArtifactActive
+      ProvisioningArtifactGuidance: !Ref ProvisioningArtifactGuidance
+      ProvisioningArtifactAction: !Ref ProvisioningArtifactAction
 Outputs:
   ProductId:
     Value: !Ref 'ScEc2LinuxJumpcloudNotebookProduct'

--- a/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud-workflows.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud-workflows.j2
@@ -9,6 +9,36 @@ Parameters:
     Type: String
     Description: "Whether to keep or replace the provisioning artifact identifier on update"
     Default: 'false'
+  ProvisioningArtifactActive:
+    Description: >-
+      Indicates whether the product version is active. Inactive provisioning artifacts
+      are invisible to end users. End users cannot launch or update a provisioned product
+      from an inactive provisioning artifact
+    Type: String
+    AllowedValues:
+      - "True"
+      - "False"
+    ConstraintDescription: "Valid values are True|False"
+    Default: "true"
+  ProvisioningArtifactGuidance:
+    Description: 'The value to apply to the product version guidance'
+    Type: String
+    AllowedValues:
+      - "DEFAULT"
+      - "DEPRECATED"
+    ConstraintDescription: "Valid values are DEFAULT|DEPRECATED"
+    Default: "DEFAULT"
+  ProvisioningArtifactAction:
+    Description: >-
+        The action type used to apply ProvisioningArtifactActive and ProvisioningArtifactGuidance
+        to provisioning artifacts. ALL to apply to all artifacts, ALL_EXCEPT_LATEST to apply to
+        all except the latest artifact
+    Type: String
+    AllowedValues:
+      - "ALL"
+      - "ALL_EXCEPT_LATEST"
+    ConstraintDescription: "Valid values are ALL|ALL_EXCEPT_LATEST"
+    DEFAULT: "ALL
 Resources:
   ScEc2LinuxJumpcloudWorkflowsProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -60,6 +90,15 @@ Resources:
       ProductId: !Ref 'ScEc2LinuxJumpcloudWorkflowsProduct'
       RoleArn: !ImportValue
         'Fn::Sub': '${AWS::Region}-sc-ec2vpc-launchrole-LaunchRoleArn'
+  UpdateProductVersions:
+    Type: Custom::ProductProvider
+    Properties:
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
+      ProductId: !Ref scec2linuxproduct
+      ProvisioningArtifactActive: !Ref ProvisioningArtifactActive
+      ProvisioningArtifactGuidance: !Ref ProvisioningArtifactGuidance
+      ProvisioningArtifactAction: !Ref ProvisioningArtifactAction
 Outputs:
   ProductId:
     Value: !Ref 'ScEc2LinuxJumpcloudWorkflowsProduct'

--- a/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud.j2
@@ -9,7 +9,36 @@ Parameters:
     Type: String
     Description: "Whether to keep or replace the provisioning artifact identifier on update"
     Default: 'false'
-
+  ProvisioningArtifactActive:
+    Description: >-
+      Indicates whether the product version is active. Inactive provisioning artifacts
+      are invisible to end users. End users cannot launch or update a provisioned product
+      from an inactive provisioning artifact
+    Type: String
+    AllowedValues:
+      - "True"
+      - "False"
+    ConstraintDescription: "Valid values are True|False"
+    Default: "true"
+  ProvisioningArtifactGuidance:
+    Description: 'The value to apply to the product version guidance'
+    Type: String
+    AllowedValues:
+      - "DEFAULT"
+      - "DEPRECATED"
+    ConstraintDescription: "Valid values are DEFAULT|DEPRECATED"
+    Default: "DEFAULT"
+  ProvisioningArtifactAction:
+    Description: >-
+        The action type used to apply ProvisioningArtifactActive and ProvisioningArtifactGuidance
+        to provisioning artifacts. ALL to apply to all artifacts, ALL_EXCEPT_LATEST to apply to
+        all except the latest artifact
+    Type: String
+    AllowedValues:
+      - "ALL"
+      - "ALL_EXCEPT_LATEST"
+    ConstraintDescription: "Valid values are ALL|ALL_EXCEPT_LATEST"
+    DEFAULT: "ALL
 Resources:
   scec2linuxproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -60,6 +89,15 @@ Resources:
       ProductId: !Ref 'scec2linuxproduct'
       RoleArn: !ImportValue
         'Fn::Sub': '${AWS::Region}-sc-ec2vpc-launchrole-LaunchRoleArn'
+  UpdateProductVersions:
+    Type: Custom::ProductProvider
+    Properties:
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
+      ProductId: !Ref scec2linuxproduct
+      ProvisioningArtifactActive: !Ref ProvisioningArtifactActive
+      ProvisioningArtifactGuidance: !Ref ProvisioningArtifactGuidance
+      ProvisioningArtifactAction: !Ref ProvisioningArtifactAction
 Outputs:
   ProductId:
     Value: !Ref 'scec2linuxproduct'

--- a/sceptre/scipool/templates/sc-product-ec2-windows-jumpcloud.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-windows-jumpcloud.j2
@@ -9,6 +9,36 @@ Parameters:
     Type: String
     Description: "Whether to keep or replace the provisioning artifact identifier on update"
     Default: 'false'
+  ProvisioningArtifactActive:
+    Description: >-
+      Indicates whether the product version is active. Inactive provisioning artifacts
+      are invisible to end users. End users cannot launch or update a provisioned product
+      from an inactive provisioning artifact
+    Type: String
+    AllowedValues:
+      - "True"
+      - "False"
+    ConstraintDescription: "Valid values are True|False"
+    Default: "true"
+  ProvisioningArtifactGuidance:
+    Description: 'The value to apply to the product version guidance'
+    Type: String
+    AllowedValues:
+      - "DEFAULT"
+      - "DEPRECATED"
+    ConstraintDescription: "Valid values are DEFAULT|DEPRECATED"
+    Default: "DEFAULT"
+  ProvisioningArtifactAction:
+    Description: >-
+        The action type used to apply ProvisioningArtifactActive and ProvisioningArtifactGuidance
+        to provisioning artifacts. ALL to apply to all artifacts, ALL_EXCEPT_LATEST to apply to
+        all except the latest artifact
+    Type: String
+    AllowedValues:
+      - "ALL"
+      - "ALL_EXCEPT_LATEST"
+    ConstraintDescription: "Valid values are ALL|ALL_EXCEPT_LATEST"
+    DEFAULT: "ALL
 Resources:
   scec2windowsproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -45,6 +75,15 @@ Resources:
       ProductId: !Ref 'scec2windowsproduct'
       RoleArn: !ImportValue
         'Fn::Sub': '${AWS::Region}-sc-ec2vpc-launchrole-LaunchRoleArn'
+  UpdateProductVersions:
+    Type: Custom::ProductProvider
+    Properties:
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
+      ProductId: !Ref scec2linuxproduct
+      ProvisioningArtifactActive: !Ref ProvisioningArtifactActive
+      ProvisioningArtifactGuidance: !Ref ProvisioningArtifactGuidance
+      ProvisioningArtifactAction: !Ref ProvisioningArtifactAction
 Outputs:
   ProductId:
     Value: !Ref 'scec2windowsproduct'

--- a/sceptre/scipool/templates/sc-product-s3-private-enc.j2
+++ b/sceptre/scipool/templates/sc-product-s3-private-enc.j2
@@ -5,6 +5,36 @@ Parameters:
     Type: String
     Description: Name of the product that will be visible to the end user
     Default: 'S3: Private Encrypted Bucket'
+  ProvisioningArtifactActive:
+    Description: >-
+      Indicates whether the product version is active. Inactive provisioning artifacts
+      are invisible to end users. End users cannot launch or update a provisioned product
+      from an inactive provisioning artifact
+    Type: String
+    AllowedValues:
+      - "True"
+      - "False"
+    ConstraintDescription: "Valid values are True|False"
+    Default: "true"
+  ProvisioningArtifactGuidance:
+    Description: 'The value to apply to the product version guidance'
+    Type: String
+    AllowedValues:
+      - "DEFAULT"
+      - "DEPRECATED"
+    ConstraintDescription: "Valid values are DEFAULT|DEPRECATED"
+    Default: "DEFAULT"
+  ProvisioningArtifactAction:
+    Description: >-
+        The action type used to apply ProvisioningArtifactActive and ProvisioningArtifactGuidance
+        to provisioning artifacts. ALL to apply to all artifacts, ALL_EXCEPT_LATEST to apply to
+        all except the latest artifact
+    Type: String
+    AllowedValues:
+      - "ALL"
+      - "ALL_EXCEPT_LATEST"
+    ConstraintDescription: "Valid values are ALL|ALL_EXCEPT_LATEST"
+    DEFAULT: "ALL
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -40,6 +70,15 @@ Resources:
       ProductId: !Ref 'scs3product'
       RoleArn: !ImportValue
         'Fn::Sub': '${AWS::Region}-sc-s3-launchrole-LaunchRoleArn'
+  UpdateProductVersions:
+    Type: Custom::ProductProvider
+    Properties:
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
+      ProductId: !Ref scec2linuxproduct
+      ProvisioningArtifactActive: !Ref ProvisioningArtifactActive
+      ProvisioningArtifactGuidance: !Ref ProvisioningArtifactGuidance
+      ProvisioningArtifactAction: !Ref ProvisioningArtifactAction
 Outputs:
   ProductId:
     Value: !Ref 'scs3product'

--- a/sceptre/scipool/templates/sc-product-s3-synapse.j2
+++ b/sceptre/scipool/templates/sc-product-s3-synapse.j2
@@ -5,6 +5,36 @@ Parameters:
     Type: String
     Description: Name of the product that will be visible to the end user
     Default: 'S3: Synapse Bucket'
+  ProvisioningArtifactActive:
+    Description: >-
+      Indicates whether the product version is active. Inactive provisioning artifacts
+      are invisible to end users. End users cannot launch or update a provisioned product
+      from an inactive provisioning artifact
+    Type: String
+    AllowedValues:
+      - "True"
+      - "False"
+    ConstraintDescription: "Valid values are True|False"
+    Default: "true"
+  ProvisioningArtifactGuidance:
+    Description: 'The value to apply to the product version guidance'
+    Type: String
+    AllowedValues:
+      - "DEFAULT"
+      - "DEPRECATED"
+    ConstraintDescription: "Valid values are DEFAULT|DEPRECATED"
+    Default: "DEFAULT"
+  ProvisioningArtifactAction:
+    Description: >-
+        The action type used to apply ProvisioningArtifactActive and ProvisioningArtifactGuidance
+        to provisioning artifacts. ALL to apply to all artifacts, ALL_EXCEPT_LATEST to apply to
+        all except the latest artifact
+    Type: String
+    AllowedValues:
+      - "ALL"
+      - "ALL_EXCEPT_LATEST"
+    ConstraintDescription: "Valid values are ALL|ALL_EXCEPT_LATEST"
+    DEFAULT: "ALL
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -40,6 +70,15 @@ Resources:
       ProductId: !Ref 'scs3product'
       RoleArn: !ImportValue
         'Fn::Sub': '${AWS::Region}-sc-s3-launchrole-LaunchRoleArn'
+  UpdateProductVersions:
+    Type: Custom::ProductProvider
+    Properties:
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
+      ProductId: !Ref scec2linuxproduct
+      ProvisioningArtifactActive: !Ref ProvisioningArtifactActive
+      ProvisioningArtifactGuidance: !Ref ProvisioningArtifactGuidance
+      ProvisioningArtifactAction: !Ref ProvisioningArtifactAction
 Outputs:
   ProductId:
     Value: !Ref 'scs3product'


### PR DESCRIPTION
AWS cloudformation does not support product deprecation so we've been
doing it manually however that's been an error prone process.  This PR
uses the cloudformation product provider custom resource[1] to
automatically deprecate all versions of a product except for the latest
version.  Users will only be allowed to provision with the latest version
of a product in production environments which prevents confusion and
users provisioning with old version that may have bugs in them.

[1] https://github.com/Sage-Bionetworks-IT/cfn-cr-sc-product-provider

depends on #227