### PR TITLE
[SC-304] force update version on every deploy

### DIFF
--- a/sceptre/scipool/templates/sc-product-ec2-linux-docker.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-linux-docker.j2
@@ -92,6 +92,7 @@ Resources:
   UpdateProductVersions:
     Type: Custom::ProductProvider
     Properties:
+      ReDeploy: '{{ range(1, 10000) | random }}'  # force CFN to redeploy this resource
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
       ProductId: !Ref scec2linuxproduct

--- a/sceptre/scipool/templates/sc-product-ec2-linux-docker.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-linux-docker.j2
@@ -92,7 +92,7 @@ Resources:
   UpdateProductVersions:
     Type: Custom::ProductProvider
     Properties:
-      ReDeploy: '{{ range(1, 10000) | random }}'  # force CFN to redeploy this resource
+      ReDeploy: '{{ range(1, 1000000) | random }}'  # force CFN to redeploy this resource
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
       ProductId: !Ref scec2linuxproduct

--- a/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud-notebook.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud-notebook.j2
@@ -93,7 +93,7 @@ Resources:
   UpdateProductVersions:
     Type: Custom::ProductProvider
     Properties:
-      ReDeploy: '{{ range(1, 10000) | random }}'  # force CFN to redeploy this resource
+      ReDeploy: '{{ range(1, 1000000) | random }}'  # force CFN to redeploy this resource
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
       ProductId: !Ref ScEc2LinuxJumpcloudNotebookProduct

--- a/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud-notebook.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud-notebook.j2
@@ -93,6 +93,7 @@ Resources:
   UpdateProductVersions:
     Type: Custom::ProductProvider
     Properties:
+      ReDeploy: '{{ range(1, 10000) | random }}'  # force CFN to redeploy this resource
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
       ProductId: !Ref ScEc2LinuxJumpcloudNotebookProduct

--- a/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud-workflows.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud-workflows.j2
@@ -93,6 +93,7 @@ Resources:
   UpdateProductVersions:
     Type: Custom::ProductProvider
     Properties:
+      ReDeploy: '{{ range(1, 10000) | random }}'  # force CFN to redeploy this resource
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
       ProductId: !Ref ScEc2LinuxJumpcloudWorkflowsProduct

--- a/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud-workflows.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud-workflows.j2
@@ -93,7 +93,7 @@ Resources:
   UpdateProductVersions:
     Type: Custom::ProductProvider
     Properties:
-      ReDeploy: '{{ range(1, 10000) | random }}'  # force CFN to redeploy this resource
+      ReDeploy: '{{ range(1, 1000000) | random }}'  # force CFN to redeploy this resource
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
       ProductId: !Ref ScEc2LinuxJumpcloudWorkflowsProduct

--- a/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud.j2
@@ -92,6 +92,7 @@ Resources:
   UpdateProductVersions:
     Type: Custom::ProductProvider
     Properties:
+      ReDeploy: '{{ range(1, 10000) | random }}'  # force CFN to redeploy this resource
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
       ProductId: !Ref scec2linuxproduct

--- a/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-linux-jumpcloud.j2
@@ -92,7 +92,7 @@ Resources:
   UpdateProductVersions:
     Type: Custom::ProductProvider
     Properties:
-      ReDeploy: '{{ range(1, 10000) | random }}'  # force CFN to redeploy this resource
+      ReDeploy: '{{ range(1, 1000000) | random }}'  # force CFN to redeploy this resource
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
       ProductId: !Ref scec2linuxproduct

--- a/sceptre/scipool/templates/sc-product-ec2-windows-jumpcloud.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-windows-jumpcloud.j2
@@ -78,7 +78,7 @@ Resources:
   UpdateProductVersions:
     Type: Custom::ProductProvider
     Properties:
-      ReDeploy: '{{ range(1, 10000) | random }}'  # force CFN to redeploy this resource
+      ReDeploy: '{{ range(1, 1000000) | random }}'  # force CFN to redeploy this resource
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
       ProductId: !Ref scec2windowsproduct

--- a/sceptre/scipool/templates/sc-product-ec2-windows-jumpcloud.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-windows-jumpcloud.j2
@@ -78,6 +78,7 @@ Resources:
   UpdateProductVersions:
     Type: Custom::ProductProvider
     Properties:
+      ReDeploy: '{{ range(1, 10000) | random }}'  # force CFN to redeploy this resource
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
       ProductId: !Ref scec2windowsproduct

--- a/sceptre/scipool/templates/sc-product-s3-private-enc.j2
+++ b/sceptre/scipool/templates/sc-product-s3-private-enc.j2
@@ -73,7 +73,7 @@ Resources:
   UpdateProductVersions:
     Type: Custom::ProductProvider
     Properties:
-      ReDeploy: '{{ range(1, 10000) | random }}'  # force CFN to redeploy this resource
+      ReDeploy: '{{ range(1, 1000000) | random }}'  # force CFN to redeploy this resource
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
       ProductId: !Ref scs3product

--- a/sceptre/scipool/templates/sc-product-s3-private-enc.j2
+++ b/sceptre/scipool/templates/sc-product-s3-private-enc.j2
@@ -73,6 +73,7 @@ Resources:
   UpdateProductVersions:
     Type: Custom::ProductProvider
     Properties:
+      ReDeploy: '{{ range(1, 10000) | random }}'  # force CFN to redeploy this resource
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
       ProductId: !Ref scs3product

--- a/sceptre/scipool/templates/sc-product-s3-synapse.j2
+++ b/sceptre/scipool/templates/sc-product-s3-synapse.j2
@@ -73,7 +73,7 @@ Resources:
   UpdateProductVersions:
     Type: Custom::ProductProvider
     Properties:
-      ReDeploy: '{{ range(1, 10000) | random }}'  # force CFN to redeploy this resource
+      ReDeploy: '{{ range(1, 1000000) | random }}'  # force CFN to redeploy this resource
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
       ProductId: !Ref scs3product

--- a/sceptre/scipool/templates/sc-product-s3-synapse.j2
+++ b/sceptre/scipool/templates/sc-product-s3-synapse.j2
@@ -73,6 +73,7 @@ Resources:
   UpdateProductVersions:
     Type: Custom::ProductProvider
     Properties:
+      ReDeploy: '{{ range(1, 10000) | random }}'  # force CFN to redeploy this resource
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
       ProductId: !Ref scs3product


### PR DESCRIPTION
The lambda for UpdateProductVersions will not run if there aren't
any changes for the resource.  That's how cloudformation
idempotency works.

The problem is that when a new version of a product is added the
UpdateProductVersions lambda does not execute which means that
the previous version of the product will not get deprecated.
In this case we need to force a change to the resource so that
CFN will execute the lambda on every deployment.  That will make
sure that all previous versions of a product is deprecated.