### PR TITLE
[SC-304] apply actions workaround to docker product

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -358,6 +358,7 @@ jobs:
         run: |
           cd sceptre/scipool
           mkdir -p templates/remote
+          sceptre delete --yes prod/sc-product-ec2-linux-docker.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-workflows.yaml
@@ -400,6 +401,7 @@ jobs:
         run: |
           cd sceptre/scipool
           mkdir -p templates/remote
+          sceptre delete --yes prod/sc-product-ec2-linux-docker.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-workflows.yaml

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -358,7 +358,7 @@ jobs:
         run: |
           cd sceptre/scipool
           mkdir -p templates/remote
-          sceptre delete --yes prod/sc-product-ec2-linux-docker.yaml
+          sceptre delete --yes prod/sc-product-assoc-ec2-linux-docker.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-workflows.yaml
@@ -401,7 +401,7 @@ jobs:
         run: |
           cd sceptre/scipool
           mkdir -p templates/remote
-          sceptre delete --yes strides/sc-product-ec2-linux-docker.yaml
+          sceptre delete --yes strides/sc-product-assoc-ec2-linux-docker.yaml
           sceptre delete --yes strides/sc-product-assoc-ec2-linux-jumpcloud.yaml
           sceptre delete --yes strides/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
           sceptre delete --yes strides/sc-product-assoc-ec2-linux-jumpcloud-workflows.yaml

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -401,11 +401,11 @@ jobs:
         run: |
           cd sceptre/scipool
           mkdir -p templates/remote
-          sceptre delete --yes prod/sc-product-ec2-linux-docker.yaml
-          sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud.yaml
-          sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
-          sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-workflows.yaml
-          sceptre delete --yes prod/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
+          sceptre delete --yes strides/sc-product-ec2-linux-docker.yaml
+          sceptre delete --yes strides/sc-product-assoc-ec2-linux-jumpcloud.yaml
+          sceptre delete --yes strides/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
+          sceptre delete --yes strides/sc-product-assoc-ec2-linux-jumpcloud-workflows.yaml
+          sceptre delete --yes strides/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
           sceptre launch strides --yes
   sceptre-sageit:
     if: github.event_name == 'push'


### PR DESCRIPTION
We need to apply the workaround to dis-associate and re-associate
SC actions on every deploy to all products.  We missed doing this
in PR #228

Also fixed references to strides account