### PR TITLE
Leverage new 5-TB limit in Docker and Workflows EC2 SC products

### DIFF
--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
@@ -14,7 +14,11 @@ parameters:
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |
-    - Description: 'Baseline release. {{ range(1, 10000) | random }}'
+    - Description: 'Baseline release.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.18/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.18'
+    - Description: 'Increase EBS volume size limit to 5 TB. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.19/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.19'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -64,7 +64,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.13/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
       Name: 'v1.1.13'
-    - Description: 'Restore set_env_var. {{ range(1, 10000) | random }}'
+    - Description: 'Restore set_env_var.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.14/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
       Name: 'v1.1.14'
+    - Description: 'Increase EBS volume size limit to 5 TB. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.19/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
+      Name: 'v1.1.19'

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-docker.yaml
@@ -15,7 +15,11 @@ parameters:
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |
-    - Description: 'Baseline release. {{ range(1, 10000) | random }}'
+    - Description: 'Baseline release.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.18/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.18'
+    - Description: 'Increase EBS volume size limit to 5 TB. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.19/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.19'

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -65,7 +65,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.13/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
       Name: 'v1.1.13'
-    - Description: 'Restore set_env_var. {{ range(1, 10000) | random }}'
+    - Description: 'Restore set_env_var.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.14/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
       Name: 'v1.1.14'
+    - Description: 'Increase EBS volume size limit to 5 TB. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.19/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
+      Name: 'v1.1.19'

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-docker.yaml
@@ -15,7 +15,11 @@ parameters:
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |
-    - Description: 'Baseline release. {{ range(1, 10000) | random }}'
+    - Description: 'Baseline release.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.18/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.18'
+    - Description: 'Increase EBS volume size limit to 5 TB. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.19/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.19'

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -65,7 +65,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.13/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
       Name: 'v1.1.13'
-    - Description: 'Restore set_env_var. {{ range(1, 10000) | random }}'
+    - Description: 'Restore set_env_var.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.14/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
       Name: 'v1.1.14'
+    - Description: 'Increase EBS volume size limit to 5 TB. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.19/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
+      Name: 'v1.1.19'


### PR DESCRIPTION
Do we add the new versions to the `develop` stack group first and if that deploys fine, perform the same change for `prod` and `strides` in a separate PR? 