### PR TITLE
[SC-350] Deprecate general EC2 and workflow products

### DIFF
--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -9,6 +9,8 @@ dependencies:
   - "develop/sc-ec2-actions.yaml"
 parameters:
   ReplaceProvisioningArtifacts: "true"
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud.yaml
@@ -10,6 +10,8 @@ dependencies:
   - "develop/sc-ec2-actions.yaml"
 parameters:
   ReplaceProvisioningArtifacts: "true"
+  ProvisioningArtifactGuidance: "DEPRECATED"
+  ProvisioningArtifactAction: "ALL"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -9,7 +9,7 @@ dependencies:
   - "prod/sc-ec2-actions.yaml"
 parameters:
   ProvisioningArtifactGuidance: "DEPRECATED"
-  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
+  ProvisioningArtifactAction: "ALL"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud.yaml
@@ -10,7 +10,7 @@ dependencies:
   - "prod/sc-ec2-actions.yaml"
 parameters:
   ProvisioningArtifactGuidance: "DEPRECATED"
-  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
+  ProvisioningArtifactAction: "ALL"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -9,7 +9,7 @@ dependencies:
   - "strides/sc-ec2-actions.yaml"
 parameters:
   ProvisioningArtifactGuidance: "DEPRECATED"
-  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
+  ProvisioningArtifactAction: "ALL"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud.yaml
@@ -10,7 +10,7 @@ dependencies:
   - "strides/sc-portfolio-ec2-external.yaml"
 parameters:
   ProvisioningArtifactGuidance: "DEPRECATED"
-  ProvisioningArtifactAction: "ALL_EXCEPT_LATEST"
+  ProvisioningArtifactAction: "ALL"
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |


### PR DESCRIPTION
Based on feedback, we intend to maintain support for the Docker and RStudio
products and deprecate the Workflows and General products.  The Docker
product is just the General Product + Docker, and the Workflow product
can be supported through Docker images.