### PR TITLE
shorten permissionSetName

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -420,7 +420,7 @@ SsoWorkflowNextflowDevDeveloper:
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref workflowNextflowDevDeveloperGroup
-    permissionSetName: 'Developer-Allow-Resource-Name-Contrained-IAM-Actions'
+    permissionSetName: 'Developer-Nextflow-IAM-Contrained'
     managedPolicies: [ 'arn:aws:iam::aws:policy/PowerUserAccess' ]
     inlinePolicy: >-
       {


### PR DESCRIPTION
Fix build error..

ERROR: Resource PermissionSet failed because Resource handler
returned message: "Model validation failed
(#/Name: expected maxLength: 32, actual: 52)"