### PR TITLE
[SC-307] setup AWS guardduty for BMGF KI account

### DIFF
--- a/org-formation/070-guard-duty/_tasks.yaml
+++ b/org-formation/070-guard-duty/_tasks.yaml
@@ -23,6 +23,7 @@ GuardDuty:
       Account: !Ref LogCentralAccount
     MemberBinding:
       Account:
+        - !Ref BmgfkiAccount
         - !Ref BridgeProdAccount
         - !Ref ScicompAccount
         - !Ref ScipoolProdAccount
@@ -31,6 +32,7 @@ GuardDuty:
     AllBinding:
       Account:
         - !Ref accountId
+        - !Ref BmgfkiAccount
         - !Ref BridgeProdAccount
         - !Ref ScicompAccount
         - !Ref ScipoolProdAccount


### PR DESCRIPTION
Enable Guardduty on the BMGF KI account and send security findings to
securitycentral account.

depends on #246