### PR TITLE
Update Sceptre install

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -274,7 +274,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
-          pip install git+git://github.com/Sceptre/sceptre-file-resolver.git
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -309,7 +308,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver sceptre-date-resolver
-          pip install git+git://github.com/Sceptre/sceptre-file-resolver.git
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -344,7 +342,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver sceptre-date-resolver
-          pip install git+git://github.com/Sceptre/sceptre-file-resolver.git
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -387,7 +384,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver sceptre-date-resolver
-          pip install git+git://github.com/Sceptre/sceptre-file-resolver.git
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
The latest release of Sceptre (v2.6.0)[1] includes the sceptre-file-resolver[2]
and the sceptre-cmd-resolver[3] as core resolvers so we no longer need to install
those in a separate step.

[1] https://github.com/Sceptre/sceptre/blob/master/CHANGELOG.md#260-20210729
[2] https://pypi.org/project/sceptre-file-resolver/
[3] https://pypi.org/project/sceptre-cmd-resolver/