### PR TITLE
Update python version of VPC peering lambda

### DIFF
--- a/sceptre/admincentral/templates/VPCPeer.yaml
+++ b/sceptre/admincentral/templates/VPCPeer.yaml
@@ -120,7 +120,7 @@ Resources:
             - '    return False'
             - '  cfnresponse.send(event, context, cfnresponse.SUCCESS, PayLoad, vpcrequest.id)'
             - '  return PayLoad'
-      Runtime: python2.7
+      Runtime: python3.7
       Timeout: 10
   LambdaExecutionRole:
     Type: 'AWS::IAM::Role'


### PR DESCRIPTION
Update python version to accomodate this linter error..

W2531 EOL runtime (python2.7) specified. Runtime is EOL since 2021-07-15 and updating
will be disabled at 2021-09-30. Please consider updating to python3.8
sceptre/admincentral/templates/VPCPeer.yaml:123:7