### PR TITLE
[SC-345] Fix missing actions

### DIFF
--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud.yaml
@@ -54,7 +54,7 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.13/ec2/sc-ec2-linux-jumpcloud.yaml'
       Name: 'v1.1.13'
-    - Description: !Sub 'Restore set_env_vars. {{ range(1, 10000) | random }}'
+    - Description: 'Restore set_env_vars. {{ range(1, 10000) | random }}'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.14/ec2/sc-ec2-linux-jumpcloud.yaml'
       Name: 'v1.1.14'

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud.yaml
@@ -54,7 +54,7 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.13/ec2/sc-ec2-linux-jumpcloud.yaml'
       Name: 'v1.1.13'
-    - Description: !Sub 'Restore set_env_vars. {{ range(1, 10000) | random }}'
+    - Description: 'Restore set_env_vars. {{ range(1, 10000) | random }}'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.14/ec2/sc-ec2-linux-jumpcloud.yaml'
       Name: 'v1.1.14'


### PR DESCRIPTION
This is a potential fix for missing actions buttons.
Evidence shows that missing actions are only hapenning with
general Linux EC2 products.  My theory is that the Sub in the
product description is causing a new version of the product to be created
on every deploy which would cause the association between actions
and product versions to become out of sync.
