### PR TITLE
Pin versions

### DIFF
--- a/org-formation/010-scps/_tasks.yaml
+++ b/org-formation/010-scps/_tasks.yaml
@@ -3,7 +3,7 @@ Parameters:
 
 PreventDisableGuardDuty:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/prevent-disable-guardduty.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.0/templates/SCP/prevent-disable-guardduty.yaml
   StackName: !Sub '${resourcePrefix}-prevent-disable-guardduty'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
@@ -20,7 +20,7 @@ PreventDisableGuardDuty:
 
 PreventDisableCloudtrail:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/prevent-disable-cloudtrail.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.0/templates/SCP/prevent-disable-cloudtrail.yaml
   StackName: !Sub '${resourcePrefix}-prevent-disable-cloudtrail'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
@@ -37,7 +37,7 @@ PreventDisableCloudtrail:
 
 PreventDisableCloudwatchConfigs:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/prevent-disable-cloudwatch-configs.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.0/templates/SCP/prevent-disable-cloudwatch-configs.yaml
   StackName: !Sub '${resourcePrefix}-prevent-disable-cloudwatch-configs'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
@@ -54,7 +54,7 @@ PreventDisableCloudwatchConfigs:
 
 DenyAllRegionsOutsideUsEast1:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/deny-all-regions-outside-us-east-1.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.0/templates/SCP/deny-all-regions-outside-us-east-1.yaml
   StackName: !Sub '${resourcePrefix}-deny-all-regions-outside-us-east-1'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
@@ -67,7 +67,7 @@ DenyAllRegionsOutsideUsEast1:
 
 DenyAllRegionsOutsideUs:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/SCP/deny-all-regions-outside-us.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.0/templates/SCP/deny-all-regions-outside-us.yaml
   StackName: !Sub '${resourcePrefix}-deny-all-regions-outside-us'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:

--- a/sceptre/admincentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/admincentral/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/admincentral/config/prod/bootstrap.yaml
+++ b/sceptre/admincentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/admincentral/config/prod/essentials.yaml
+++ b/sceptre/admincentral/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   LambdaBucketVersioning: Enabled
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/bridge/config/develop/AccountAlertTopics.yaml
+++ b/sceptre/bridge/config/develop/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/bridge/config/develop/BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/develop/BridgeServer2-vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcSubnetPrefix: "172.48"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/bridge/config/develop/bootstrap.yaml
+++ b/sceptre/bridge/config/develop/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/bridge/config/develop/bridge-aux.yaml
+++ b/sceptre/bridge/config/develop/bridge-aux.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: bridge-aux
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/bridge/config/develop/peer-vpn-BridgeServer2-develop.yaml
+++ b/sceptre/bridge/config/develop/peer-vpn-BridgeServer2-develop.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/bridge/config/develop/peer-vpn-bridge-aux.yaml
+++ b/sceptre/bridge/config/develop/peer-vpn-bridge-aux.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/bridge/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/bridge/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/bridge/config/prod/BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/BridgeServer2-vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcSubnetPrefix: "172.32"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/bridge/config/prod/bootstrap.yaml
+++ b/sceptre/bridge/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/bridge/config/prod/peer-vpn-BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/peer-vpn-BridgeServer2-vpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/bridge/config/prod/tgw-spoke-BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/tgw-spoke-BridgeServer2-vpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/imagecentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/imagecentral/config/prod/AccountAlertTopics.yaml
@@ -10,7 +10,5 @@ parameters:
   SlackWebhookURL: !ssm "/infra/SlackWebhookUrl"
   SlackChannel: "#infra-notices"
 hooks:
-  before_create:
-    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
-  before_update:
+  before_launch:
     - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/imagecentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/imagecentral/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/imagecentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/imagecentral/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/imagecentral/config/prod/bootstrap.yaml
+++ b/sceptre/imagecentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/imagecentral/config/prod/bootstrap.yaml
+++ b/sceptre/imagecentral/config/prod/bootstrap.yaml
@@ -1,5 +1,5 @@
 template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
-  before_update:
+  before_launch:
     - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/imagecentral/config/prod/bootstrap.yaml
+++ b/sceptre/imagecentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/imagecentral/config/prod/essentials.yaml
+++ b/sceptre/imagecentral/config/prod/essentials.yaml
@@ -5,7 +5,5 @@ dependencies:
 parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
-  before_create:
-    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
-  before_update:
+  before_launch:
     - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/imagecentral/config/prod/essentials.yaml
+++ b/sceptre/imagecentral/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/imagecentral/config/prod/essentials.yaml
+++ b/sceptre/imagecentral/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:
-    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/imagecentral/config/prod/rotate-credentials.yaml
+++ b/sceptre/imagecentral/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/imagecentral/config/prod/rotate-credentials.yaml
+++ b/sceptre/imagecentral/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/imagecentral/config/prod/rotate-credentials.yaml
+++ b/sceptre/imagecentral/config/prod/rotate-credentials.yaml
@@ -8,7 +8,5 @@ parameters:
   SenderEmail: "it@sagebase.org"
   SendReport: "true"
 hooks:
-  before_create:
-    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"
-  before_update:
+  before_launch:
     - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/itsandbox/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/itsandbox/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/itsandbox/config/prod/bootstrap.yaml
+++ b/sceptre/itsandbox/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/itsandbox/config/prod/dustbunnyvpc.yaml
+++ b/sceptre/itsandbox/config/prod/dustbunnyvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: "dustbunnyvpc"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/itsandbox/config/prod/essentials.yaml
+++ b/sceptre/itsandbox/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm "/infra/AdmincentralAwsAccountId"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/itsandbox/config/prod/sage-tgw-spoke.yaml
+++ b/sceptre/itsandbox/config/prod/sage-tgw-spoke.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/logcentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/logcentral/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/logcentral/config/prod/bootstrap.yaml
+++ b/sceptre/logcentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/logcentral/config/prod/essentials.yaml
+++ b/sceptre/logcentral/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/logcentral/config/prod/sumologic-role-s3cloudtrail.yaml
+++ b/sceptre/logcentral/config/prod/sumologic-role-s3cloudtrail.yaml
@@ -8,4 +8,4 @@ parameters:
   Resource: !stack_output_external essentials::AWSS3CloudtrailBucketArn
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -O templates/remote/sumologic-role.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/sumologic-role.yaml -O templates/remote/sumologic-role.yaml"

--- a/sceptre/logcentral/config/prod/sumologic-role-s3config.yaml
+++ b/sceptre/logcentral/config/prod/sumologic-role-s3config.yaml
@@ -8,4 +8,4 @@ parameters:
   Resource: !stack_output_external essentials::AWSS3ConfigBucketArn
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -O templates/remote/sumologic-role.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/sumologic-role.yaml -O templates/remote/sumologic-role.yaml"

--- a/sceptre/organizations/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/organizations/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/organizations/config/prod/bootstrap.yaml
+++ b/sceptre/organizations/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/organizations/config/prod/essentials.yaml
+++ b/sceptre/organizations/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm "/infra/AdmincentralAwsAccountId"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/sageit/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/sageit/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/sageit/config/prod/bootstrap.yaml
+++ b/sceptre/sageit/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/sageit/config/prod/defaultvpc.yaml
+++ b/sceptre/sageit/config/prod/defaultvpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpcName: sagedefaultvpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/sageit/config/prod/essentials.yaml
+++ b/sceptre/sageit/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/sageit/config/prod/gha-svc-account.yaml
+++ b/sceptre/sageit/config/prod/gha-svc-account.yaml
@@ -24,4 +24,4 @@ parameters:
     }
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/IAM/service-account.yaml -O templates/remote/service-account.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/IAM/service-account.yaml -O templates/remote/service-account.yaml"

--- a/sceptre/sageit/config/prod/peer-defaultvpc-admincentral.yaml
+++ b/sceptre/sageit/config/prod/peer-defaultvpc-admincentral.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/sageit/config/prod/prod-csbc-pson-s3web.yaml
+++ b/sceptre/sageit/config/prod/prod-csbc-pson-s3web.yaml
@@ -9,4 +9,4 @@ parameters:
   OwnerEmail: michael.lee@sagebionetworks.org
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-s3WebCloudfront.yaml -O templates/remote/managed-s3WebCloudfront.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/managed-s3WebCloudfront.yaml -O templates/remote/managed-s3WebCloudfront.yaml"

--- a/sceptre/sageit/config/prod/sageit-org-acm-cert.yaml
+++ b/sceptre/sageit/config/prod/sageit-org-acm-cert.yaml
@@ -11,4 +11,4 @@ parameters:
   DnsDomainName: "sageit.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml -O templates/remote/acm-certificate.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/acm-certificate.yaml -O templates/remote/acm-certificate.yaml"

--- a/sceptre/sageit/config/prod/vpn-sageit-org-redirector.yaml
+++ b/sceptre/sageit/config/prod/vpn-sageit-org-redirector.yaml
@@ -18,4 +18,4 @@ parameters:
   TargetKey: "endpoints/cvpn-endpoint-055bd9db65af09d63"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/s3-redirector.yaml -O templates/remote/s3-redirector.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/s3-redirector.yaml -O templates/remote/s3-redirector.yaml"

--- a/sceptre/sageit/config/staging/staging-csbc-pson-s3web.yaml
+++ b/sceptre/sageit/config/staging/staging-csbc-pson-s3web.yaml
@@ -9,4 +9,4 @@ parameters:
   OwnerEmail: michael.lee@sagebionetworks.org
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-s3WebCloudfront.yaml -O templates/remote/managed-s3WebCloudfront.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/managed-s3WebCloudfront.yaml -O templates/remote/managed-s3WebCloudfront.yaml"

--- a/sceptre/sandbox/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/sandbox/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/sandbox/config/prod/bootstrap.yaml
+++ b/sceptre/sandbox/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/sandbox/config/prod/cfn-sc-actions-provider.yaml
+++ b/sceptre/sandbox/config/prod/cfn-sc-actions-provider.yaml
@@ -8,4 +8,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-sc-actions-provider.yaml -O templates/remote/cfn-sc-actions-provider.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cfn-sc-actions-provider.yaml -O templates/remote/cfn-sc-actions-provider.yaml"

--- a/sceptre/sandbox/config/prod/essentials.yaml
+++ b/sceptre/sandbox/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/sandbox/config/prod/park-my-cloud.yaml
+++ b/sceptre/sandbox/config/prod/park-my-cloud.yaml
@@ -6,4 +6,4 @@ parameters:
   PMCExternalID: !ssm /infra/PMCExternalID
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml -O templates/remote/ParkMyCloud.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/ParkMyCloud.yaml -O templates/remote/ParkMyCloud.yaml"

--- a/sceptre/sandbox/config/prod/peer-vpn-sandcastlevpc.yaml
+++ b/sceptre/sandbox/config/prod/peer-vpn-sandcastlevpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/sandbox/config/prod/s3-gateway-vpc-endpoint.yaml
+++ b/sceptre/sandbox/config/prod/s3-gateway-vpc-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/sandbox/config/prod/sage-tgw-spoke.yaml
+++ b/sceptre/sandbox/config/prod/sage-tgw-spoke.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/sandbox/config/prod/sandcastlevpc.yaml
+++ b/sceptre/sandbox/config/prod/sandcastlevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: sandcastlevpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/sandbox/config/prod/service-linked-roles.yaml
+++ b/sceptre/sandbox/config/prod/service-linked-roles.yaml
@@ -4,4 +4,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml -O templates/remote/service-linked-roles.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/service-linked-roles.yaml -O templates/remote/service-linked-roles.yaml"

--- a/sceptre/scicomp/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/scicomp/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/scicomp/config/prod/bootstrap.yaml
+++ b/sceptre/scicomp/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
+++ b/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
@@ -5,4 +5,4 @@ parameters:
     - "563295687221"  # org-sagebase-sandbox
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cloudwatch-cross-account-sharing.yaml -O templates/remote/cloudwatch-cross-account-sharing.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cloudwatch-cross-account-sharing.yaml -O templates/remote/cloudwatch-cross-account-sharing.yaml"

--- a/sceptre/scicomp/config/prod/computevpc.yaml
+++ b/sceptre/scicomp/config/prod/computevpc.yaml
@@ -5,4 +5,4 @@ parameters:
   VpcName: computevpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scicomp/config/prod/essentials.yaml
+++ b/sceptre/scicomp/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/scicomp/config/prod/maintenance.yaml
+++ b/sceptre/scicomp/config/prod/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -O templates/remote/maintenance.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml -O templates/remote/maintenance.yaml"

--- a/sceptre/scicomp/config/prod/park-my-cloud.yaml
+++ b/sceptre/scicomp/config/prod/park-my-cloud.yaml
@@ -6,4 +6,4 @@ parameters:
   PMCExternalID: !ssm /infra/PMCExternalID
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml -O templates/remote/ParkMyCloud.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/ParkMyCloud.yaml -O templates/remote/ParkMyCloud.yaml"

--- a/sceptre/scicomp/config/prod/peer-vpn-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/peer-vpn-computevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scicomp/config/prod/peer-vpn-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/peer-vpn-snowflakevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scicomp/config/prod/s3-computevpc-gateway-endpoint.yaml
+++ b/sceptre/scicomp/config/prod/s3-computevpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scicomp/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
+++ b/sceptre/scicomp/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scicomp/config/prod/sage-tgw-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/sage-tgw-computevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml -O templates/remote/transit-gateway-attachment.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-attachment.yaml -O templates/remote/transit-gateway-attachment.yaml"

--- a/sceptre/scicomp/config/prod/sage-tgw-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/sage-tgw-snowflakevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml -O templates/remote/transit-gateway-attachment.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-attachment.yaml -O templates/remote/transit-gateway-attachment.yaml"

--- a/sceptre/scicomp/config/prod/sagebionetworks-org-acm-cert.yaml
+++ b/sceptre/scicomp/config/prod/sagebionetworks-org-acm-cert.yaml
@@ -11,4 +11,4 @@ parameters:
   DnsDomainName: "sagebionetworks.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml -O templates/remote/acm-certificate.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/acm-certificate.yaml -O templates/remote/acm-certificate.yaml"

--- a/sceptre/scicomp/config/prod/service-linked-roles.yaml
+++ b/sceptre/scicomp/config/prod/service-linked-roles.yaml
@@ -4,4 +4,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml -O templates/remote/service-linked-roles.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/service-linked-roles.yaml -O templates/remote/service-linked-roles.yaml"

--- a/sceptre/scicomp/config/prod/snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/snowflakevpc.yaml
@@ -5,4 +5,4 @@ parameters:
   VpcName: snowflakevpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scicomp/config/prod/sumologic-role.yaml
+++ b/sceptre/scicomp/config/prod/sumologic-role.yaml
@@ -8,4 +8,4 @@ parameters:
   Resource: !ssm /infra/BeanstalkBucketArn
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml -O templates/remote/sumologic-role.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/sumologic-role.yaml -O templates/remote/sumologic-role.yaml"

--- a/sceptre/scicomp/config/prod/tgw-spoke-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/tgw-spoke-computevpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/scicomp/config/prod/tgw-spoke-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/tgw-spoke-snowflakevpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/scipool/config/bmgfki/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/bmgfki/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/scipool/config/bmgfki/bootstrap.yaml
+++ b/sceptre/scipool/config/bmgfki/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/scipool/config/bmgfki/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-tag-instance-policy.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "bmgfki/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"

--- a/sceptre/scipool/config/bmgfki/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/bmgfki/docker-runner-efs-vpc.yaml
@@ -4,4 +4,4 @@ dependencies:
   - bmgfki/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"
+    - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.0/templates/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"

--- a/sceptre/scipool/config/bmgfki/essentials.yaml
+++ b/sceptre/scipool/config/bmgfki/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"  # org-sagebase-admincentral
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/scipool/config/bmgfki/gatespoolvpc.yaml
+++ b/sceptre/scipool/config/bmgfki/gatespoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: gatespoolvpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scipool/config/bmgfki/maintenance.yaml
+++ b/sceptre/scipool/config/bmgfki/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -O templates/remote/maintenance.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml -O templates/remote/maintenance.yaml"

--- a/sceptre/scipool/config/bmgfki/rotate-credentials.yaml
+++ b/sceptre/scipool/config/bmgfki/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/scipool/config/bmgfki/s3-gatespoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/bmgfki/s3-gatespoolvpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scipool/config/develop/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/develop/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/scipool/config/develop/bootstrap.yaml
+++ b/sceptre/scipool/config/develop/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/scipool/config/develop/cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/cesspoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: "cesspoolvpc"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scipool/config/develop/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/develop/cfn-tag-instance-policy.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "develop/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"

--- a/sceptre/scipool/config/develop/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/develop/docker-runner-efs-vpc.yaml
@@ -4,4 +4,4 @@ dependencies:
   - develop/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/templates/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/templates/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"

--- a/sceptre/scipool/config/develop/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/develop/docker-runner-efs-vpc.yaml
@@ -4,4 +4,4 @@ dependencies:
   - develop/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/templates/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"

--- a/sceptre/scipool/config/develop/essentials.yaml
+++ b/sceptre/scipool/config/develop/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/scipool/config/develop/maintenance.yaml
+++ b/sceptre/scipool/config/develop/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -O templates/remote/maintenance.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml -O templates/remote/maintenance.yaml"

--- a/sceptre/scipool/config/develop/peer-vpn-cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/peer-vpn-cesspoolvpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: "10.1.0.0/16"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scipool/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scipool/config/develop/tgw-spoke-cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/tgw-spoke-cesspoolvpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/scipool/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/scipool/config/prod/bootstrap.yaml
+++ b/sceptre/scipool/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/scipool/config/prod/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/prod/cfn-tag-instance-policy.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"

--- a/sceptre/scipool/config/prod/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/prod/docker-runner-efs-vpc.yaml
@@ -4,4 +4,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/templates/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/templates/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"

--- a/sceptre/scipool/config/prod/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/prod/docker-runner-efs-vpc.yaml
@@ -4,4 +4,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/templates/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"

--- a/sceptre/scipool/config/prod/essentials.yaml
+++ b/sceptre/scipool/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/scipool/config/prod/internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/internalpoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: internalpoolvpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scipool/config/prod/maintenance.yaml
+++ b/sceptre/scipool/config/prod/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -O templates/remote/maintenance.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml -O templates/remote/maintenance.yaml"

--- a/sceptre/scipool/config/prod/peer-vpn-internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/peer-vpn-internalpoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scipool/config/prod/s3-internalpoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/prod/s3-internalpoolvpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scipool/config/prod/tgw-spoke-internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/tgw-spoke-internalpoolvpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/scipool/config/strides/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/strides/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/scipool/config/strides/bootstrap.yaml
+++ b/sceptre/scipool/config/strides/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/scipool/config/strides/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/strides/cfn-tag-instance-policy.yaml
@@ -4,4 +4,4 @@ dependencies:
   - "strides/bootstrap.yaml"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"

--- a/sceptre/scipool/config/strides/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/strides/docker-runner-efs-vpc.yaml
@@ -4,4 +4,4 @@ dependencies:
   - strides/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/templates/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"

--- a/sceptre/scipool/config/strides/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/strides/docker-runner-efs-vpc.yaml
@@ -4,4 +4,4 @@ dependencies:
   - strides/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/templates/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/templates/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"

--- a/sceptre/scipool/config/strides/essentials.yaml
+++ b/sceptre/scipool/config/strides/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"  # org-sagebase-admincentral
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/scipool/config/strides/maintenance.yaml
+++ b/sceptre/scipool/config/strides/maintenance.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/maintenance.yaml -O templates/remote/maintenance.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml -O templates/remote/maintenance.yaml"

--- a/sceptre/scipool/config/strides/peer-vpn-stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/peer-vpn-stridespoolvpc.yaml
@@ -9,4 +9,4 @@ parameters:
   VpnCidr: !stack_output_external stridespoolvpc::VpnCidr      # org-sagebase-admincentral sophos-utm VPN CIDR
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scipool/config/strides/rotate-credentials.yaml
+++ b/sceptre/scipool/config/strides/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/scipool/config/strides/s3-stridespoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/strides/s3-stridespoolvpc-gateway-endpoint.yaml
@@ -7,4 +7,4 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scipool/config/strides/stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/stridespoolvpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcName: stridespoolvpc
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scipool/config/strides/tgw-spoke-stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/tgw-spoke-stridespoolvpc.yaml
@@ -18,4 +18,4 @@ parameters:
   TransitGatewayId: "tgw-0004e7e3454cacac5"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/securitycentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/securitycentral/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/securitycentral/config/prod/bootstrap.yaml
+++ b/sceptre/securitycentral/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/securitycentral/config/prod/essentials.yaml
+++ b/sceptre/securitycentral/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/synapsedev/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapsedev/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/synapsedev/config/prod/bootstrap.yaml
+++ b/sceptre/synapsedev/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/synapsedev/config/prod/essentials.yaml
+++ b/sceptre/synapsedev/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/synapsedev/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapsedev/config/prod/peer-vpc-admincentral.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/synapsedev/config/prod/vpc.yaml
+++ b/sceptre/synapsedev/config/prod/vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/synapsedw/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapsedw/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/synapsedw/config/prod/bootstrap.yaml
+++ b/sceptre/synapsedw/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/synapsedw/config/prod/essentials.yaml
+++ b/sceptre/synapsedw/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/synapsedw/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapsedw/config/prod/peer-vpc-admincentral.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/synapsedw/config/prod/vpc.yaml
+++ b/sceptre/synapsedw/config/prod/vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/synapseprod/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapseprod/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/synapseprod/config/prod/bootstrap.yaml
+++ b/sceptre/synapseprod/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/synapseprod/config/prod/essentials.yaml
+++ b/sceptre/synapseprod/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/synapseprod/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapseprod/config/prod/peer-vpc-admincentral.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/synapseprod/config/prod/synapse-ops-vpc-v2.yaml
+++ b/sceptre/synapseprod/config/prod/synapse-ops-vpc-v2.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/synapseprod/config/prod/vpc.yaml
+++ b/sceptre/synapseprod/config/prod/vpc.yaml
@@ -7,4 +7,4 @@ parameters:
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
 hooks:
   before_launch:
-   - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+   - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/transit/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/transit/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/transit/config/prod/bootstrap.yaml
+++ b/sceptre/transit/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: "remote/bootstrap.yaml"
 stack_name: "bootstrap"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml -O templates/remote/bootstrap.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/transit/config/prod/essentials.yaml
+++ b/sceptre/transit/config/prod/essentials.yaml
@@ -6,4 +6,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml -O templates/remote/essentials.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/transit/config/prod/unionstationvpc.yaml
+++ b/sceptre/transit/config/prod/unionstationvpc.yaml
@@ -8,4 +8,4 @@ parameters:
   VpnCidr: "10.50.0.0/16"
 hooks:
   before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml -O templates/remote/vpc.yaml"
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"


### PR DESCRIPTION
Miscellaneous updates

* change sceptre hook to before_launch.  before_update & before_create is not needed.
* standardize all S3 references to template to pull from S3 bucket instead of github.
   we do this because some cloudformation references are only supported from S3 buckets.
* update S3 bucket url references to virtual host style references
* pin to specific versions of shared tempates