### PR TITLE
Fix SSO setup for tower viewer user

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -487,6 +487,8 @@ SsoWorkflowNextflowTowerViewer:
     instanceArn: !Ref instanceArn
     principalId: !Ref workflowNextflowTowerViewerGroup
     permissionSetName: 'TowerViewer'
+    sessionDuration: 'PT12H'
+    masterAccountId: !Ref MasterAccount
     inlinePolicy: >-
       {
         "Version": "2012-10-17",


### PR DESCRIPTION
The failure seems to indicate that we missed passing in
masterAccountId.  This attempts to fix that error.
