### PR TITLE
fix syntax error in policy for SsoWorkflowNextflowTowerViewer

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -551,7 +551,7 @@ SsoWorkflowNextflowTowerViewer:
               "iam:GetAccountSummary",
               "iam:GetLoginProfile",
               "lambda:List*",
-              "logs:Describe*",
+              "logs:Describe*"
             ],
             "Effect": "Allow",
             "Resource": "*"


### PR DESCRIPTION
fix this https://github.com/Sage-Bionetworks-IT/organizations-infra/runs/3488456389?check_suite_focus=true#step:8:779

```
ERROR: Resource PermissionSet failed because 1 validation error detected: Value 'Invalid PermissionsPolicy JSON {
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "TowerViewOnlyAccess",
      "Action": [
        "autoscaling:Describe*",
        "batch:ListJobs",
        "cloudformation:List*",
       ..
       ..
```
