### PR TITLE
[SC-347] Allow access to EC2 monitoring info

### DIFF
--- a/sceptre/scipool/templates/sc-enduser-iam.yaml
+++ b/sceptre/scipool/templates/sc-enduser-iam.yaml
@@ -54,6 +54,7 @@ Resources:
             Action:
               - organizations:DescribeOrganization
               - servicecatalog:DescribeProvisionedProduct
+              - cloudwatch:GetMetricData  # access to EC2 monitoring info
             Resource: "*"
   SCEnduserRemoteAccessPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
Give users access to the EC2 monitoring metrics in the AWS console.

