### PR TITLE
[SC-360] Update EC2 products

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-docker.yaml
@@ -23,7 +23,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.19/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.19'
-    - Description: 'Reduce instance types. {{ range(1, 10000) | random }}'
+    - Description: 'Reduce instance types'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.21'
+    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.22'

--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -70,7 +70,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.17/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.17'
-    - Description: 'Reduce instance types. {{ range(1, 10000) | random }}'
+    - Description: 'Reduce instance types'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.21'
+    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.1.22'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
@@ -22,7 +22,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.19/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.19'
-    - Description: 'Reduce instance types. {{ range(1, 10000) | random }}'
+    - Description: 'Reduce instance types'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.21'
+    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.22'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud.yaml
@@ -59,7 +59,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.14/ec2/sc-ec2-linux-jumpcloud.yaml'
       Name: 'v1.1.14'
-    - Description: 'Reduce instance types. {{ range(1, 10000) | random }}'
+    - Description: 'Reduce instance types.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-jumpcloud.yaml'
       Name: 'v1.1.21'
+    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-jumpcloud.yaml'
+      Name: 'v1.1.22'

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-docker.yaml
@@ -23,7 +23,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.19/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.19'
-    - Description: 'Reduce instance types. {{ range(1, 10000) | random }}'
+    - Description: 'Reduce instance types.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.21'
+    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.22'

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud.yaml
@@ -58,7 +58,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.14/ec2/sc-ec2-linux-jumpcloud.yaml'
       Name: 'v1.1.14'
-    - Description: 'Reduce instance types. {{ range(1, 10000) | random }}'
+    - Description: 'Reduce instance types.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-jumpcloud.yaml'
       Name: 'v1.1.21'
+    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-jumpcloud.yaml'
+      Name: 'v1.1.22'

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-docker.yaml
@@ -23,7 +23,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.19/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.19'
-    - Description: 'Decrease instance types. {{ range(1, 10000) | random }}'
+    - Description: 'Decrease instance types.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.21'
+    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.22'

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud.yaml
@@ -58,7 +58,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.14/ec2/sc-ec2-linux-jumpcloud.yaml'
       Name: 'v1.1.14'
-    - Description: 'Decrease instance types. {{ range(1, 10000) | random }}'
+    - Description: 'Decrease instance types.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-jumpcloud.yaml'
       Name: 'v1.1.21'
+    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-jumpcloud.yaml'
+      Name: 'v1.1.22'


### PR DESCRIPTION
Update service catalog EC2 products to allow provisioning
x2gd, g4dn and i3en instances.

depends on https://github.com/Sage-Bionetworks/service-catalog-library/pull/257