### PR TITLE
fix TowerViewer group permission

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -488,7 +488,6 @@ SsoWorkflowNextflowTowerViewer:
     principalId: !Ref workflowNextflowTowerViewerGroup
     permissionSetName: 'TowerViewer'
     sessionDuration: 'PT12H'
-    masterAccountId: !Ref MasterAccount
     inlinePolicy: >-
       {
         "Version": "2012-10-17",


### PR DESCRIPTION
The TowerViewer SSO group was getting added to organizations account.
Fix so that it only appears in nextflow accounts

