### PR TITLE
[SC-360] Add x2gd, g4dn and i3en instance types to notebook product

### DIFF
--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -69,7 +69,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.17/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.17'
-    - Description: 'Allow more simultaneously open files. Reduce instance types. {{ range(1, 10000) | random }}'
+    - Description: 'Allow more simultaneously open files.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.21'
+    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.1.22'

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -70,7 +70,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.17/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.17'
-    - Description: 'Reduce instance types. {{ range(1, 10000) | random }}'
+    - Description: 'Reduce instance types.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.21'
+    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.1.22'

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -70,7 +70,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.17/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.17'
-    - Description: 'Reduce instance types. {{ range(1, 10000) | random }}'
+    - Description: 'Reduce instance types.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.21'
+    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.1.22'


### PR DESCRIPTION
Forgot to update the notebook product in PR #288  this is to add
the new EC2 instances to the SC notebook product.
