### PR TITLE
[SC-326] Update S3 product version

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-s3-private-enc.yaml
@@ -36,7 +36,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.10/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.10'
-    - Description:  'Include option to restrict bucket downloads to same region. {{ range(1, 10000) | random }}'
+    - Description:  'Include option to restrict bucket downloads to same region.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.15/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.15'
+    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.23'

--- a/sceptre/scipool/config/bmgfki/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-s3-synapse.yaml
@@ -48,7 +48,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.15/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.15'
-    - Description:  'Fix cross account access. {{ range(1, 10000) | random }}'
+    - Description:  'Fix cross account access.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.20/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.20'
+    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.23'

--- a/sceptre/scipool/config/develop/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/develop/sc-product-s3-private-enc.yaml
@@ -33,7 +33,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.10/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.10'
-    - Description:  'Include option to restrict bucket downloads to same region. {{ range(1, 10000) | random }}'
+    - Description:  'Include option to restrict bucket downloads to same region.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.15/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.15'
+    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.23'

--- a/sceptre/scipool/config/develop/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/develop/sc-product-s3-synapse.yaml
@@ -45,7 +45,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.15/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.15'
-    - Description:  'Fix cross account access. {{ range(1, 10000) | random }}'
+    - Description:  'Fix cross account access.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.20/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.20'
+    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.23'

--- a/sceptre/scipool/config/prod/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/prod/sc-product-s3-private-enc.yaml
@@ -36,7 +36,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.10/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.10'
-    - Description: 'Include option to restrict bucket downloads to same region. {{ range(1, 10000) | random }}'
+    - Description: 'Include option to restrict bucket downloads to same region.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.15/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.15'
+    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.23'

--- a/sceptre/scipool/config/prod/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/prod/sc-product-s3-synapse.yaml
@@ -48,7 +48,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.15/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.15'
-    - Description:  'Fix cross account access. {{ range(1, 10000) | random }}'
+    - Description:  'Fix cross account access.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.20/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.20'
+    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.23'

--- a/sceptre/scipool/config/strides/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/strides/sc-product-s3-private-enc.yaml
@@ -36,7 +36,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.10/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.10'
-    - Description:  'Include option to restrict bucket downloads to same region. {{ range(1, 10000) | random }}'
+    - Description:  'Include option to restrict bucket downloads to same region.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.15/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.15'
+    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.23'

--- a/sceptre/scipool/config/strides/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/strides/sc-product-s3-synapse.yaml
@@ -48,7 +48,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.15/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.15'
-    - Description:  'Fix cross account access. {{ range(1, 10000) | random }}'
+    - Description:  'Fix cross account access.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.20/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.20'
+    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.23'


### PR DESCRIPTION
Update S3 product version to retain bucket on SC product termination

depends on https://github.com/Sage-Bionetworks/service-catalog-library/pull/259
