### PR TITLE
[SC-363] update SC S3 bucket product

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-s3-private-enc.yaml
@@ -40,7 +40,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.15/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.15'
-    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+    - Description:  'Retain bucket on SC product termination.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.23'
+    - Description:  'Enable intelligent tiering. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.24/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.24'

--- a/sceptre/scipool/config/bmgfki/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-s3-synapse.yaml
@@ -52,7 +52,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.20/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.20'
-    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+    - Description:  'Retain bucket on SC product termination.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.23'
+    - Description:  'Enable intelligent tiering. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.24/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.24'

--- a/sceptre/scipool/config/develop/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/develop/sc-product-s3-private-enc.yaml
@@ -37,7 +37,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.15/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.15'
-    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+    - Description:  'Retain bucket on SC product termination.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.23'
+    - Description:  'Enable intelligent tiering. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.24/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.24'

--- a/sceptre/scipool/config/develop/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/develop/sc-product-s3-synapse.yaml
@@ -49,7 +49,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.20/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.20'
-    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+    - Description:  'Retain bucket on SC product termination.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.23'
+    - Description:  'Enable intelligent tiering. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.24/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.24'

--- a/sceptre/scipool/config/prod/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/prod/sc-product-s3-private-enc.yaml
@@ -40,7 +40,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.15/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.15'
-    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+    - Description:  'Retain bucket on SC product termination.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.23'
+    - Description:  'Enable intelligent tiering. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.24/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.24'

--- a/sceptre/scipool/config/prod/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/prod/sc-product-s3-synapse.yaml
@@ -52,7 +52,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.20/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.20'
-    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+    - Description:  'Retain bucket on SC product termination.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.23'
+    - Description:  'Enable intelligent tiering. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.24/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.24'

--- a/sceptre/scipool/config/strides/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/strides/sc-product-s3-private-enc.yaml
@@ -40,7 +40,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.15/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.15'
-    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+    - Description:  'Retain bucket on SC product termination.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.23'
+    - Description:  'Enable intelligent tiering. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.24/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.24'

--- a/sceptre/scipool/config/strides/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/strides/sc-product-s3-synapse.yaml
@@ -52,7 +52,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.20/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.20'
-    - Description:  'Retain bucket on SC product termination. {{ range(1, 10000) | random }}'
+    - Description:  'Retain bucket on SC product termination.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.23'
+    - Description:  'Enable intelligent tiering. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.24/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.24'


### PR DESCRIPTION
Update S3 bucket product to enable S3 intelligent tiering

depends on https://github.com/Sage-Bionetworks/service-catalog-library/pull/261
