### PR TITLE
[SC-362] Enable bucket cleanup schedule

### DIFF
--- a/sceptre/scipool/config/bmgfki/lambda-bucket-cleanup.yaml
+++ b/sceptre/scipool/config/bmgfki/lambda-bucket-cleanup.yaml
@@ -1,7 +1,7 @@
 template_path: remote/lambda-sc-bucket-cleanup.yaml
 stack_name: lambda-sc-bucket-cleanup
 parameters:
-  EnableSchedule: "false"
+  EnableSchedule: "true"
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"

--- a/sceptre/scipool/config/prod/lambda-bucket-cleanup.yaml
+++ b/sceptre/scipool/config/prod/lambda-bucket-cleanup.yaml
@@ -1,7 +1,7 @@
 template_path: remote/lambda-sc-bucket-cleanup.yaml
 stack_name: lambda-sc-bucket-cleanup
 parameters:
-  EnableSchedule: "false"
+  EnableSchedule: "true"
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"

--- a/sceptre/scipool/config/strides/lambda-bucket-cleanup.yaml
+++ b/sceptre/scipool/config/strides/lambda-bucket-cleanup.yaml
@@ -1,7 +1,7 @@
 template_path: remote/lambda-sc-bucket-cleanup.yaml
 stack_name: lambda-sc-bucket-cleanup
 parameters:
-  EnableSchedule: "false"
+  EnableSchedule: "true"
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"


### PR DESCRIPTION
This is a follow on to PR #294.  Testing of the lambda has been
completed.  We can now enable it on all SC accounts. The default
archive period and schedule parameters are set in the lambda's
[template file](https://github.com/Sage-Bionetworks-IT/lambda-sc-bucket-cleanup/blob/master/template.yaml#L12)
