### PR TITLE
[IT-1391] Setup guardduty on science accounts

### DIFF
--- a/org-formation/070-guard-duty/_tasks.yaml
+++ b/org-formation/070-guard-duty/_tasks.yaml
@@ -28,6 +28,8 @@ GuardDuty:
         - !Ref ScicompAccount
         - !Ref ScipoolProdAccount
         - !Ref SynapseProdAccount
+        - !Ref WorkflowsNextflowDevAccount
+        - !Ref WorkflowsNextflowProdAccount
       IncludeMasterAccount: false
     AllBinding:
       Account:
@@ -37,6 +39,8 @@ GuardDuty:
         - !Ref ScicompAccount
         - !Ref ScipoolProdAccount
         - !Ref SynapseProdAccount
+        - !Ref WorkflowsNextflowDevAccount
+        - !Ref WorkflowsNextflowProdAccount
       IncludeMasterAccount: false
   Parameters:
     resourcePrefix: !Ref resourcePrefix


### PR DESCRIPTION
There is a request to have guardduty enabled on some of the
scientific AWS accounts.
