### PR TITLE
Lower budget alarm threshold for Nextflow accounts

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -350,7 +350,7 @@ Organization:
         <<: !Include ./_default_org_tags.yaml
         Department: IBC
         Project: Infrastructure
-        budget-alarm-threshold: 10000
+        budget-alarm-threshold: 3000
         budget-alarm-threshold-email-recipient: aws-workflows-nextflow-prod@sagebase.org
 
   WorkflowsNextflowDevAccount:
@@ -363,5 +363,5 @@ Organization:
         <<: !Include ./_default_org_tags.yaml
         Department: IBC
         Project: Infrastructure
-        budget-alarm-threshold: 10000
+        budget-alarm-threshold: 3000
         budget-alarm-threshold-email-recipient: aws-workflows-nextflow-dev@sagebase.org


### PR DESCRIPTION
I propose that we lower our budget alert thresholds until we implement more granular alerts with IT-1478 (_e.g._ splitting compute vs non-compute costs). I'll also adjust the threshold in future PRs as we increase the amount of compute. 