### PR TITLE
refactor: replace hooks with template handler

### DIFF
--- a/sceptre/admincentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/admincentral/config/prod/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: remote/AccountAlertTopics.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: AccountAlertTopics
 dependencies:
   - prod/bootstrap.yaml
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm /infra/SlackWebhookUrl
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/admincentral/config/prod/bootstrap.yaml
+++ b/sceptre/admincentral/config/prod/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: remote/bootstrap.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: bootstrap
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/admincentral/config/prod/cfn-ec2-instance-types-snippet.yaml
+++ b/sceptre/admincentral/config/prod/cfn-ec2-instance-types-snippet.yaml
@@ -1,4 +1,5 @@
-template_path: cfn-ec2-instance-types-snippet.yaml
+template:
+  path: cfn-ec2-instance-types-snippet.yaml
 stack_name: cfn-ec2-instance-types-snippet
 dependencies:
   - prod/cfn-s3objects-macro.yaml

--- a/sceptre/admincentral/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/admincentral/config/prod/cfn-s3objects-macro.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-s3objects-macro.yaml"
+template:
+  type: http
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml"
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "prod/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/admincentral/config/prod/cfn-service-catalog-snippets.yaml
+++ b/sceptre/admincentral/config/prod/cfn-service-catalog-snippets.yaml
@@ -1,4 +1,5 @@
-template_path: cfn-service-catalog-snippets.yaml
+template:
+  path: cfn-service-catalog-snippets.yaml
 stack_name: cfn-service-catalog-snippets
 dependencies:
   - prod/cfn-s3objects-macro.yaml

--- a/sceptre/admincentral/config/prod/cfn-snippets-bucket.yaml
+++ b/sceptre/admincentral/config/prod/cfn-snippets-bucket.yaml
@@ -1,4 +1,5 @@
-template_path: cfn-snippets-bucket.yaml
+template:
+  path: cfn-snippets-bucket.yaml
 stack_name: cfn-snippets-bucket
 dependencies:
   - prod/cfn-s3objects-macro.yaml

--- a/sceptre/admincentral/config/prod/essentials.yaml
+++ b/sceptre/admincentral/config/prod/essentials.yaml
@@ -1,10 +1,9 @@
-template_path: remote/essentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
   LambdaBucketVersioning: Enabled
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/admincentral/config/prod/iam-policies.yaml
+++ b/sceptre/admincentral/config/prod/iam-policies.yaml
@@ -1,4 +1,5 @@
-template_path: iam-policies.yaml
+template:
+  path: iam-policies.yaml
 stack_name: iam-policies
 dependencies:
   - prod/essentials.yaml

--- a/sceptre/admincentral/config/prod/peering-bridge-aux.yaml
+++ b/sceptre/admincentral/config/prod/peering-bridge-aux.yaml
@@ -1,4 +1,5 @@
-template_path: VPCPeer.yaml
+template:
+  path: VPCPeer.yaml
 stack_name: peering-bridge-aux
 parameters:
   PeerVPC: vpc-e9335a92

--- a/sceptre/admincentral/config/prod/peering-bridge-develop.yaml
+++ b/sceptre/admincentral/config/prod/peering-bridge-develop.yaml
@@ -1,4 +1,5 @@
-template_path: VPCPeer.yaml
+template:
+  path: VPCPeer.yaml
 stack_name: peering-bridge-develop
 parameters:
   PeerVPC: vpc-08ad2ebc1c49963b8

--- a/sceptre/admincentral/config/prod/peering-bridge-prod.yaml
+++ b/sceptre/admincentral/config/prod/peering-bridge-prod.yaml
@@ -1,4 +1,5 @@
-template_path: VPCPeer.yaml
+template:
+  path: VPCPeer.yaml
 stack_name: peering-bridge-prod
 parameters:
   PeerVPC: vpc-9c70bbf9

--- a/sceptre/admincentral/config/prod/peering-bridgeserver2-develop-vpc.yaml
+++ b/sceptre/admincentral/config/prod/peering-bridgeserver2-develop-vpc.yaml
@@ -1,4 +1,5 @@
-template_path: VPCPeer.yaml
+template:
+  path: VPCPeer.yaml
 stack_name: peering-bridgeserver2-develop-vpc
 parameters:
   PeerVPC: vpc-08ad2ebc1c49963b8

--- a/sceptre/admincentral/config/prod/peering-bridgeserver2-vpc.yaml
+++ b/sceptre/admincentral/config/prod/peering-bridgeserver2-vpc.yaml
@@ -1,4 +1,5 @@
-template_path: VPCPeer.yaml
+template:
+  path: VPCPeer.yaml
 stack_name: peering-bridgeserver2-vpc
 parameters:
   PeerVPC: vpc-0818659c21d92f2a3

--- a/sceptre/admincentral/config/prod/peering-cesspoolvpc.yaml
+++ b/sceptre/admincentral/config/prod/peering-cesspoolvpc.yaml
@@ -1,4 +1,5 @@
-template_path: VPCPeer.yaml
+template:
+  path: VPCPeer.yaml
 stack_name: peering-cesspoolvpc
 parameters:
   PeerVPC: "vpc-0c1c1404c18d7d984"   # cesspoolvpc ID

--- a/sceptre/admincentral/config/prod/peering-computevpc.yaml
+++ b/sceptre/admincentral/config/prod/peering-computevpc.yaml
@@ -1,4 +1,5 @@
-template_path: VPCPeer.yaml
+template:
+  path: VPCPeer.yaml
 stack_name: peering-computevpc
 parameters:
   PeerVPC: vpc-e66bd19d

--- a/sceptre/admincentral/config/prod/peering-iatlasvpc.yaml
+++ b/sceptre/admincentral/config/prod/peering-iatlasvpc.yaml
@@ -1,4 +1,5 @@
-template_path: VPCPeer.yaml
+template:
+  path: VPCPeer.yaml
 stack_name: peering-atlasvpc
 parameters:
   PeerVPC: "vpc-0e5befad4ce267f67"   # iatlasvpc ID

--- a/sceptre/admincentral/config/prod/peering-internalpoolvpc.yaml
+++ b/sceptre/admincentral/config/prod/peering-internalpoolvpc.yaml
@@ -1,4 +1,5 @@
-template_path: VPCPeer.yaml
+template:
+  path: VPCPeer.yaml
 stack_name: peering-internalpoolvpc
 parameters:
   PeerVPC: "vpc-0d4b8ad691df536c6"

--- a/sceptre/admincentral/config/prod/peering-nlpsandbox.yaml
+++ b/sceptre/admincentral/config/prod/peering-nlpsandbox.yaml
@@ -1,4 +1,5 @@
-template_path: VPCPeer.yaml
+template:
+  path: VPCPeer.yaml
 stack_name: peering-nlpsandbox
 parameters:
   PeerVPC: vpc-0f809761f28e9e350    # nlpsandbox VPC ID

--- a/sceptre/admincentral/config/prod/peering-sandcastlevpc.yaml
+++ b/sceptre/admincentral/config/prod/peering-sandcastlevpc.yaml
@@ -1,4 +1,5 @@
-template_path: VPCPeer.yaml
+template:
+  path: VPCPeer.yaml
 stack_name: peering-sandcastlevpc
 parameters:
   PeerVPC: vpc-0e9b80dc470a797d5

--- a/sceptre/admincentral/config/prod/peering-snowflakevpc.yaml
+++ b/sceptre/admincentral/config/prod/peering-snowflakevpc.yaml
@@ -1,4 +1,5 @@
-template_path: VPCPeer.yaml
+template:
+  path: VPCPeer.yaml
 stack_name: peering-snowflakevpc
 parameters:
   PeerVPC: vpc-0317313f5c918456d

--- a/sceptre/admincentral/config/prod/peering-stridespoolvpc.yaml
+++ b/sceptre/admincentral/config/prod/peering-stridespoolvpc.yaml
@@ -1,4 +1,5 @@
-template_path: VPCPeer.yaml
+template:
+  path: VPCPeer.yaml
 stack_name: peering-stridespoolvpc
 parameters:
   PeerVPC: "vpc-025cba6a01d73d32b"  # org-sagebase-strides stridespoolvpc ID

--- a/sceptre/admincentral/config/prod/peering-synapsedev.yaml
+++ b/sceptre/admincentral/config/prod/peering-synapsedev.yaml
@@ -1,4 +1,5 @@
-template_path: VPCPeer.yaml
+template:
+  path: VPCPeer.yaml
 stack_name: peering-synapsedev
 parameters:
   PeerVPC: vpc-1362e468

--- a/sceptre/admincentral/config/prod/rotate-credentials.yaml
+++ b/sceptre/admincentral/config/prod/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: remote/rotate-credentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: rotate-credentials
 dependencies:
   - prod/bootstrap.yaml
@@ -7,6 +9,3 @@ parameters:
   SendEmail: 'true'
   SenderEmail: 'it@sagebase.org'
   SendReport: 'true'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/admincentral/config/prod/service-accounts.yaml
+++ b/sceptre/admincentral/config/prod/service-accounts.yaml
@@ -1,4 +1,5 @@
-template_path: service-accounts.yaml
+template:
+  path: service-accounts.yaml
 stack_name: service-accounts
 dependencies:
   - "prod/iam-policies.yaml"

--- a/sceptre/admincentral/config/prod/synapse-stack-dev-vpn-routes.yaml
+++ b/sceptre/admincentral/config/prod/synapse-stack-dev-vpn-routes.yaml
@@ -1,4 +1,5 @@
-template_path: synapse-stack-vpn-routes.yaml
+template:
+  path: synapse-stack-vpn-routes.yaml
 stack_name: synapse-stack-dev-vpn-routes
 parameters:
   # CIDR for the new Synapse dev stack

--- a/sceptre/admincentral/config/prod/synapse-stack-prod-vpn-routes.yaml
+++ b/sceptre/admincentral/config/prod/synapse-stack-prod-vpn-routes.yaml
@@ -1,4 +1,5 @@
-template_path: synapse-stack-vpn-routes.yaml
+template:
+  path: synapse-stack-vpn-routes.yaml
 stack_name: synapse-stack-prod-vpn-routes
 parameters:
   # CIDR for the new Synapse prod stack


### PR DESCRIPTION
Sceptre has template handlers[1] now so we can abandon the use of
hooks in favor of the http template handler to get templates
from our shared template repository. This is only to update
admincentral account.

[1] https://sceptre.cloudreach.com/dev/docs/template_handlers.html#template-handlers
