### PR TITLE
refactor: replace hooks with template handler

### DIFF
--- a/sceptre/bridge/config/develop/AccountAlertTopics.yaml
+++ b/sceptre/bridge/config/develop/AccountAlertTopics.yaml
@@ -1,5 +1,5 @@
 template:
-  typ: http
+  type: http
   url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: AccountAlertTopics
 dependencies:

--- a/sceptre/bridge/config/develop/AccountAlertTopics.yaml
+++ b/sceptre/bridge/config/develop/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: remote/AccountAlertTopics.yaml
+template:
+  typ: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: AccountAlertTopics
 dependencies:
   - develop/bootstrap.yaml
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm /infra/SlackWebhookUrl
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/bridge/config/develop/BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/develop/BridgeServer2-vpc.yaml
@@ -1,10 +1,9 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: BridgeServer2-vpc
 dependencies:
   - develop/bootstrap.yaml
 parameters:
   VpcName: BridgeServer2-develop-vpc
   VpcSubnetPrefix: "172.48"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/bridge/config/develop/bootstrap.yaml
+++ b/sceptre/bridge/config/develop/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: remote/bootstrap.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: bootstrap
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/bridge/config/develop/bridge-aux.yaml
+++ b/sceptre/bridge/config/develop/bridge-aux.yaml
@@ -1,10 +1,9 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: bridge-aux
 dependencies:
   - develop/bridge.yaml
 parameters:
   VpcSubnetPrefix: "172.51"
   VpcName: bridge-aux
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/bridge/config/develop/bridge.yaml
+++ b/sceptre/bridge/config/develop/bridge.yaml
@@ -1,4 +1,5 @@
-template_path: bridge.yaml
+template:
+  path: bridge.yaml
 stack_name: bridge
 dependencies:
   - develop/essentials.yaml

--- a/sceptre/bridge/config/develop/peer-vpn-BridgeServer2-develop.yaml
+++ b/sceptre/bridge/config/develop/peer-vpn-BridgeServer2-develop.yaml
@@ -1,4 +1,6 @@
-template_path: remote/peer-route-config.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml
 stack_name: peer-vpn-BridgeServer2-develop
 dependencies:
   - develop/BridgeServer2-vpc.yaml
@@ -7,6 +9,3 @@ parameters:
   VpcPrivateRouteTable: rtb-011def3defa2902a7
   VpcPublicRouteTable: rtb-0b8c6e99798ff3d90
   VpnCidr: 10.1.0.0/16
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/bridge/config/develop/peer-vpn-bridge-aux.yaml
+++ b/sceptre/bridge/config/develop/peer-vpn-bridge-aux.yaml
@@ -1,4 +1,6 @@
-template_path: remote/peer-route-config.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml
 stack_name: peer-vpn-bridge-aux
 dependencies:
   - develop/bridge-aux.yaml
@@ -7,6 +9,3 @@ parameters:
   VpcPrivateRouteTable: rtb-5053332c
   VpcPublicRouteTable: rtb-5343232f
   VpnCidr: 10.1.0.0/16
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/bridge/config/develop/rotate-credentials.yaml
+++ b/sceptre/bridge/config/develop/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: remote/rotate-credentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: rotate-credentials
 dependencies:
   - develop/bootstrap.yaml
@@ -7,6 +9,3 @@ parameters:
   SendEmail: 'true'
   SenderEmail: 'it@sagebase.org'
   SendReport: 'true'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/imagecentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/imagecentral/config/prod/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/AccountAlertTopics.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: "AccountAlertTopics"
 dependencies:
   - "prod/bootstrap.yaml"
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm "/infra/SlackWebhookUrl"
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/imagecentral/config/prod/bootstrap.yaml
+++ b/sceptre/imagecentral/config/prod/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: remote/bootstrap.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: bootstrap
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/imagecentral/config/prod/ec2-image-builder.yaml
+++ b/sceptre/imagecentral/config/prod/ec2-image-builder.yaml
@@ -1,4 +1,5 @@
-template_path: "ec2-image-builder.yaml"
+template:
+  path: "ec2-image-builder.yaml"
 stack_name: "ec2-image-builder"
 dependencies:
   - "prod/service-linked-roles.yaml"

--- a/sceptre/imagecentral/config/prod/essentials.yaml
+++ b/sceptre/imagecentral/config/prod/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: "remote/essentials.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/imagecentral/config/prod/rotate-credentials.yaml
+++ b/sceptre/imagecentral/config/prod/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/rotate-credentials.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: "rotate-credentials"
 dependencies:
   - "prod/bootstrap.yaml"
@@ -7,6 +9,3 @@ parameters:
   SendEmail: "true"
   SenderEmail: "it@sagebase.org"
   SendReport: "true"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/imagecentral/config/prod/service-accounts.yaml
+++ b/sceptre/imagecentral/config/prod/service-accounts.yaml
@@ -1,4 +1,5 @@
-template_path: service-accounts.yaml
+template:
+  path: service-accounts.yaml
 stack_name: service-accounts
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/imagecentral/config/prod/service-linked-roles.yaml
+++ b/sceptre/imagecentral/config/prod/service-linked-roles.yaml
@@ -1,4 +1,5 @@
-template_path: "service-linked-roles.yaml"
+template:
+  path: "service-linked-roles.yaml"
 stack_name: "service-linked-roles"
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/logcentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/logcentral/config/prod/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: remote/AccountAlertTopics.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: AccountAlertTopics
 dependencies:
   - prod/bootstrap.yaml
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm /infra/SlackWebhookUrl
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/logcentral/config/prod/bootstrap.yaml
+++ b/sceptre/logcentral/config/prod/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: remote/bootstrap.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: bootstrap
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/logcentral/config/prod/essentials.yaml
+++ b/sceptre/logcentral/config/prod/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: remote/essentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/logcentral/config/prod/rotate-credentials.yaml
+++ b/sceptre/logcentral/config/prod/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: remote/rotate-credentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: rotate-credentials
 dependencies:
   - prod/bootstrap.yaml
@@ -7,6 +9,3 @@ parameters:
   SendEmail: 'true'
   SenderEmail: 'it@sagebase.org'
   SendReport: 'true'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/logcentral/config/prod/sumologic-role-s3cloudtrail.yaml
+++ b/sceptre/logcentral/config/prod/sumologic-role-s3cloudtrail.yaml
@@ -1,4 +1,6 @@
-template_path: remote/sumologic-role.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/sumologic-role.yaml
 stack_name: sumologic-role-s3cloudtrail
 dependencies:
   - prod/essentials.yaml
@@ -6,6 +8,3 @@ parameters:
   ExternalID: !ssm /infra/SumologicExternalID
   Actions: 's3:GetObject,s3:GetObjectVersion,s3:ListBucketVersions,s3:ListBucket'
   Resource: !stack_output_external essentials::AWSS3CloudtrailBucketArn
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/sumologic-role.yaml -O templates/remote/sumologic-role.yaml"

--- a/sceptre/logcentral/config/prod/sumologic-role-s3config.yaml
+++ b/sceptre/logcentral/config/prod/sumologic-role-s3config.yaml
@@ -1,4 +1,6 @@
-template_path: remote/sumologic-role.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/sumologic-role.yaml
 stack_name: sumologic-role-s3config
 dependencies:
   - prod/essentials.yaml
@@ -6,6 +8,3 @@ parameters:
   ExternalID: !ssm /infra/SumologicExternalID
   Actions: 's3:GetObject,s3:GetObjectVersion,s3:ListBucketVersions,s3:ListBucket'
   Resource: !stack_output_external essentials::AWSS3ConfigBucketArn
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/sumologic-role.yaml -O templates/remote/sumologic-role.yaml"

--- a/sceptre/organizations/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/organizations/config/prod/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/AccountAlertTopics.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: "AccountAlertTopics"
 dependencies:
   - "prod/bootstrap.yaml"
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm "/infra/SlackWebhookUrl"
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/organizations/config/prod/bootstrap.yaml
+++ b/sceptre/organizations/config/prod/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: "remote/bootstrap.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: "bootstrap"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/organizations/config/prod/essentials.yaml
+++ b/sceptre/organizations/config/prod/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: "remote/essentials.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
   VpcPeeringRequesterAwsAccountId: !ssm "/infra/AdmincentralAwsAccountId"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/organizations/config/prod/rotate-credentials.yaml
+++ b/sceptre/organizations/config/prod/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/rotate-credentials.yaml"
+template:
+  type: http
+  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: "rotate-credentials"
 dependencies:
   - "prod/bootstrap.yaml"
@@ -7,6 +9,3 @@ parameters:
   SendEmail: "true"
   SenderEmail: "it@sagebase.org"
   SendReport: "true"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/organizations/config/prod/rotate-credentials.yaml
+++ b/sceptre/organizations/config/prod/rotate-credentials.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: "rotate-credentials"
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/sageit/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/sageit/config/prod/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: remote/AccountAlertTopics.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: AccountAlertTopics
 dependencies:
   - prod/bootstrap.yaml
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm /infra/SlackWebhookUrl
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/sageit/config/prod/accounts.yaml
+++ b/sceptre/sageit/config/prod/accounts.yaml
@@ -1,4 +1,5 @@
-template_path: accounts.yaml
+template:
+  path: accounts.yaml
 stack_name: accounts
 dependencies:
   - prod/essentials.yaml

--- a/sceptre/sageit/config/prod/bootstrap.yaml
+++ b/sceptre/sageit/config/prod/bootstrap.yaml
@@ -1,4 +1,4 @@
 template:
   type: http
-  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: bootstrap

--- a/sceptre/sageit/config/prod/bootstrap.yaml
+++ b/sceptre/sageit/config/prod/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: remote/bootstrap.yaml
+template:
+  type: http
+  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: bootstrap
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/sageit/config/prod/bsmnredirect.yaml
+++ b/sceptre/sageit/config/prod/bsmnredirect.yaml
@@ -1,5 +1,4 @@
 template:
-  type: http
   path: s3webredirect.yaml
 stack_name: bsmnredirect
 stack_tags:

--- a/sceptre/sageit/config/prod/bsmnredirect.yaml
+++ b/sceptre/sageit/config/prod/bsmnredirect.yaml
@@ -1,4 +1,6 @@
-template_path: s3webredirect.yaml
+template:
+  type: http
+  path: s3webredirect.yaml
 stack_name: bsmnredirect
 stack_tags:
   Department: IT

--- a/sceptre/sageit/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/sageit/config/prod/cfn-s3objects-macro.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/sageit/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/sageit/config/prod/cfn-s3objects-macro.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-s3objects-macro.yaml"
+template:
+  type: http
+  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "prod/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/sageit/config/prod/defaultvpc.yaml
+++ b/sceptre/sageit/config/prod/defaultvpc.yaml
@@ -1,4 +1,6 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: defaultvpc
 dependencies:
   - prod/bootstrap.yaml
@@ -7,6 +9,3 @@ parameters:
   PrivateSubnetZones: "us-east-1c, us-east-1d, us-east-1e"
   PublicSubnetZones: "us-east-1c, us-east-1d, us-east-1e"
   VpcName: sagedefaultvpc
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/sageit/config/prod/essentials.yaml
+++ b/sceptre/sageit/config/prod/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: remote/essentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/sageit/config/prod/gha-svc-account.yaml
+++ b/sceptre/sageit/config/prod/gha-svc-account.yaml
@@ -1,4 +1,6 @@
-template_path: remote/service-account.yaml
+template:
+  type: http
+  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/IAM/service-account.yaml
 stack_name: gha-svc-account
 parameters:
   PolicyDocument: >-
@@ -22,6 +24,3 @@ parameters:
         }
       ]
     }
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/IAM/service-account.yaml -O templates/remote/service-account.yaml"

--- a/sceptre/sageit/config/prod/gha-svc-account.yaml
+++ b/sceptre/sageit/config/prod/gha-svc-account.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/IAM/service-account.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/IAM/service-account.yaml
 stack_name: gha-svc-account
 parameters:
   PolicyDocument: >-

--- a/sceptre/sageit/config/prod/peer-defaultvpc-admincentral.yaml
+++ b/sceptre/sageit/config/prod/peer-defaultvpc-admincentral.yaml
@@ -1,4 +1,6 @@
-template_path: remote/peer-route-config.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml
 stack_name: peer-defaultvpc-admincentral
 dependencies:
   - prod/defaultvpc.yaml
@@ -7,6 +9,3 @@ parameters:
   VpcPrivateRouteTable: rtb-3df21042
   VpcPublicRouteTable: rtb-2eec0e51
   VpnCidr: 10.1.0.0/16
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/sageit/config/prod/prod-csbc-pson-s3web.yaml
+++ b/sceptre/sageit/config/prod/prod-csbc-pson-s3web.yaml
@@ -1,4 +1,6 @@
-template_path: remote/managed-s3WebCloudfront.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/managed-s3WebCloudfront.yaml
 stack_name: prod-csbc-pson-s3webcf
 parameters:
   DomainName: csbc-pson.synapse.org
@@ -7,6 +9,3 @@ parameters:
   Department: Oncology
   Project: CSBC-PSON
   OwnerEmail: michael.lee@sagebionetworks.org
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/managed-s3WebCloudfront.yaml -O templates/remote/managed-s3WebCloudfront.yaml"

--- a/sceptre/sageit/config/prod/rotate-credentials.yaml
+++ b/sceptre/sageit/config/prod/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: remote/rotate-credentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: rotate-credentials
 dependencies:
   - prod/bootstrap.yaml
@@ -7,6 +9,3 @@ parameters:
   SendEmail: 'true'
   SenderEmail: 'it@sagebase.org'
   SendReport: 'true'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/sageit/config/prod/sageit-org-acm-cert.yaml
+++ b/sceptre/sageit/config/prod/sageit-org-acm-cert.yaml
@@ -1,4 +1,6 @@
-template_path: remote/acm-certificate.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/acm-certificate.yaml
 stack_name: sageit-org-acm-cert
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
@@ -9,6 +11,3 @@ parameters:
   OwnerEmail: 'khai.do@sagebase.org'
   # The domain name (i.e. acme.org)
   DnsDomainName: "sageit.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/acm-certificate.yaml -O templates/remote/acm-certificate.yaml"

--- a/sceptre/sageit/config/prod/vpn-sageit-org-redirector.yaml
+++ b/sceptre/sageit/config/prod/vpn-sageit-org-redirector.yaml
@@ -1,4 +1,6 @@
-template_path: remote/s3-redirector.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/s3-redirector.yaml
 stack_name: vpn-sageit-org-redirector
 dependencies:
   - prod/sageit-org-acm-cert.yaml
@@ -16,6 +18,3 @@ parameters:
   TargetHostName: "self-service.clientvpn.amazonaws.com"
   # and a path to our specific config
   TargetKey: "endpoints/cvpn-endpoint-055bd9db65af09d63"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/s3-redirector.yaml -O templates/remote/s3-redirector.yaml"

--- a/sceptre/sandbox/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/sandbox/config/prod/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: remote/AccountAlertTopics.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: AccountAlertTopics
 dependencies:
   - prod/bootstrap.yaml
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm /infra/SlackWebhookUrl
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/sandbox/config/prod/accounts.yaml
+++ b/sceptre/sandbox/config/prod/accounts.yaml
@@ -1,4 +1,5 @@
-template_path: accounts.yaml
+template:
+  path: accounts.yaml
 stack_name: accounts
 dependencies:
   - prod/essentials.yaml

--- a/sceptre/sandbox/config/prod/bootstrap.yaml
+++ b/sceptre/sandbox/config/prod/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: remote/bootstrap.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: bootstrap
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/sandbox/config/prod/cfn-explode-macro.yaml
+++ b/sceptre/sandbox/config/prod/cfn-explode-macro.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-explode-macro.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-explode-macro/master/cfn-explode-macro.yaml
 stack_name: "cfn-explode-macro"
 dependencies:
   - "prod/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-explode-macro/master/cfn-explode-macro.yaml -O templates/remote/cfn-explode-macro.yaml"

--- a/sceptre/sandbox/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/sandbox/config/prod/cfn-s3objects-macro.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/sandbox/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/sandbox/config/prod/cfn-s3objects-macro.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-s3objects-macro.yaml"
+template:
+  type: http
+  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "prod/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/sandbox/config/prod/cfn-ssm-param-macro.yaml
+++ b/sceptre/sandbox/config/prod/cfn-ssm-param-macro.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-macro-ssm-param.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml
 stack_name: "cfn-macro-ssm-param"
 dependencies:
   - "prod/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -O templates/remote/cfn-macro-ssm-param.yaml"

--- a/sceptre/sandbox/config/prod/essentials.yaml
+++ b/sceptre/sandbox/config/prod/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: remote/essentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/sandbox/config/prod/park-my-cloud.yaml
+++ b/sceptre/sandbox/config/prod/park-my-cloud.yaml
@@ -1,9 +1,8 @@
-template_path: remote/ParkMyCloud.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/ParkMyCloud.yaml
 stack_name: park-my-cloud
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   PMCExternalID: !ssm /infra/PMCExternalID
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/ParkMyCloud.yaml -O templates/remote/ParkMyCloud.yaml"

--- a/sceptre/sandbox/config/prod/peer-vpn-sandcastlevpc.yaml
+++ b/sceptre/sandbox/config/prod/peer-vpn-sandcastlevpc.yaml
@@ -1,4 +1,6 @@
-template_path: remote/peer-route-config.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml
 stack_name: peer-vpn-sandcastlevpc
 dependencies:
   - prod/sandcastlevpc.yaml
@@ -7,6 +9,3 @@ parameters:
   VpcPrivateRouteTable: rtb-03749e8c822352561
   VpcPublicRouteTable: rtb-0707730d3016e2737
   VpnCidr: 10.1.0.0/16
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/sandbox/config/prod/rotate-credentials.yaml
+++ b/sceptre/sandbox/config/prod/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: remote/rotate-credentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: rotate-credentials
 dependencies:
   - prod/bootstrap.yaml
@@ -7,6 +9,3 @@ parameters:
   SendEmail: 'true'
   SenderEmail: 'it@sagebase.org'
   SendReport: 'true'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/sandbox/config/prod/s3-gateway-vpc-endpoint.yaml
+++ b/sceptre/sandbox/config/prod/s3-gateway-vpc-endpoint.yaml
@@ -1,10 +1,9 @@
-template_path: remote/gateway-vpc-endpoint.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml
 stack_name: s3-gateway-vpc-endpoint
 dependencies:
   - prod/sandcastlevpc.yaml
 parameters:
   VpcName: sandcastlevpc
   ServiceName: com.amazonaws.us-east-1.s3
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/sandbox/config/prod/sage-tgw-spoke.yaml
+++ b/sceptre/sandbox/config/prod/sage-tgw-spoke.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/transit-gateway-spoke.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml
 stack_name: "tgw-spoke-sandcastlevpc"
 stack_tags:
   Department: "Platform"
@@ -16,6 +18,3 @@ parameters:
     - !stack_output_external sandcastlevpc::PrivateSubnet2
   # shared TGW, https://github.com/Sage-Bionetworks/transit-infra/blob/master/templates/transit-gateway.j2
   TransitGatewayId: "tgw-0004e7e3454cacac5"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/sandbox/config/prod/sandcastlevpc.yaml
+++ b/sceptre/sandbox/config/prod/sandcastlevpc.yaml
@@ -1,10 +1,9 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: sandcastlevpc
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   VpcSubnetPrefix: "10.23"
   VpcName: sandcastlevpc
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/sandbox/config/prod/service-linked-roles.yaml
+++ b/sceptre/sandbox/config/prod/service-linked-roles.yaml
@@ -1,7 +1,6 @@
-template_path: remote/service-linked-roles.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/service-linked-roles.yaml
 stack_name: service-linked-roles
 dependencies:
   - prod/bootstrap.yaml
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/service-linked-roles.yaml -O templates/remote/service-linked-roles.yaml"

--- a/sceptre/scicomp/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/scicomp/config/prod/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: remote/AccountAlertTopics.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: AccountAlertTopics
 dependencies:
   - prod/bootstrap.yaml
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm /infra/SlackWebhookUrl
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/scicomp/config/prod/bootstrap.yaml
+++ b/sceptre/scicomp/config/prod/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: remote/bootstrap.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: bootstrap
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/scicomp/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/scicomp/config/prod/cfn-s3objects-macro.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-s3objects-macro.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "prod/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
+++ b/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
@@ -1,8 +1,7 @@
-template_path: "remote/cloudwatch-cross-account-sharing.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cloudwatch-cross-account-sharing.yaml
 stack_name: "cloudwatch-cross-account-sharing"
 parameters:
   MonitoringAccountIds:
     - "563295687221"  # org-sagebase-sandbox
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cloudwatch-cross-account-sharing.yaml -O templates/remote/cloudwatch-cross-account-sharing.yaml"

--- a/sceptre/scicomp/config/prod/computevpc.yaml
+++ b/sceptre/scicomp/config/prod/computevpc.yaml
@@ -1,8 +1,7 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: computevpc
 parameters:
   VpcSubnetPrefix: "10.5"
   VpcName: computevpc
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scicomp/config/prod/essentials.yaml
+++ b/sceptre/scicomp/config/prod/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: remote/essentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/scicomp/config/prod/maintenance.yaml
+++ b/sceptre/scicomp/config/prod/maintenance.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml
 stack_name: prod-default-maintenance-window
 stack_tags:
   Department: "Platform"

--- a/sceptre/scicomp/config/prod/maintenance.yaml
+++ b/sceptre/scicomp/config/prod/maintenance.yaml
@@ -6,6 +6,3 @@ stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml -O templates/remote/maintenance.yaml"

--- a/sceptre/scicomp/config/prod/maintenance.yaml
+++ b/sceptre/scicomp/config/prod/maintenance.yaml
@@ -1,4 +1,6 @@
-template_path: remote/maintenance.yaml
+template:
+  type: http
+  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml
 stack_name: prod-default-maintenance-window
 stack_tags:
   Department: "Platform"

--- a/sceptre/scicomp/config/prod/park-my-cloud.yaml
+++ b/sceptre/scicomp/config/prod/park-my-cloud.yaml
@@ -1,9 +1,8 @@
-template_path: remote/ParkMyCloud.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/ParkMyCloud.yaml
 stack_name: park-my-cloud
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   PMCExternalID: !ssm /infra/PMCExternalID
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/ParkMyCloud.yaml -O templates/remote/ParkMyCloud.yaml"

--- a/sceptre/scicomp/config/prod/peer-vpn-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/peer-vpn-computevpc.yaml
@@ -7,6 +7,3 @@ parameters:
   VpcPrivateRouteTable: rtb-5f73c623
   VpcPublicRouteTable: rtb-6e7fca12
   VpnCidr: 10.1.0.0/16
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scicomp/config/prod/peer-vpn-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/peer-vpn-computevpc.yaml
@@ -1,4 +1,6 @@
-template_path: remote/peer-route-config.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml
 stack_name: peer-vpn-computevpc
 parameters:
   PeeringConnectionId: pcx-7e3bec16

--- a/sceptre/scicomp/config/prod/peer-vpn-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/peer-vpn-snowflakevpc.yaml
@@ -1,10 +1,9 @@
-template_path: remote/peer-route-config.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml
 stack_name: peer-vpn-snowflakevpc
 parameters:
   PeeringConnectionId: pcx-08470a7f8d2a734e7
   VpcPrivateRouteTable: rtb-01e3641c8ed3c91c6
   VpcPublicRouteTable: rtb-020046b1a7632fb61
   VpnCidr: 10.1.0.0/16
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scicomp/config/prod/rotate-credentials.yaml
+++ b/sceptre/scicomp/config/prod/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: remote/rotate-credentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: rotate-credentials
 dependencies:
   - prod/bootstrap.yaml
@@ -7,6 +9,3 @@ parameters:
   SendEmail: 'true'
   SenderEmail: 'it@sagebase.org'
   SendReport: 'true'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/scicomp/config/prod/s3-computevpc-gateway-endpoint.yaml
+++ b/sceptre/scicomp/config/prod/s3-computevpc-gateway-endpoint.yaml
@@ -1,10 +1,9 @@
-template_path: remote/gateway-vpc-endpoint.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml
 stack_name: s3-computevpc-gateway-vpc-endpoint
 dependencies:
   - prod/computevpc.yaml
 parameters:
   VpcName: computevpc
   ServiceName: com.amazonaws.us-east-1.s3
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scicomp/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
+++ b/sceptre/scicomp/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
@@ -1,10 +1,9 @@
-template_path: remote/gateway-vpc-endpoint.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml
 stack_name: s3-snowflakevpc-gateway-vpc-endpoint
 dependencies:
   - prod/snowflakevpc.yaml
 parameters:
   VpcName: snowflakevpc
   ServiceName: com.amazonaws.us-east-1.s3
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scicomp/config/prod/sage-tgw-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/sage-tgw-computevpc.yaml
@@ -1,10 +1,9 @@
-template_path: "remote/transit-gateway-attachment.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-attachment.yaml
 stack_name: "sage-tgw-computevpc"
 dependencies:
   - "prod/computevpc.yaml"
 parameters:
   VpcName: "computevpc"
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-attachment.yaml -O templates/remote/transit-gateway-attachment.yaml"

--- a/sceptre/scicomp/config/prod/sage-tgw-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/sage-tgw-snowflakevpc.yaml
@@ -1,10 +1,9 @@
-template_path: "remote/transit-gateway-attachment.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-attachment.yaml
 stack_name: "sage-tgw-snowflakevpc"
 dependencies:
   - "prod/snowflakevpc.yaml"
 parameters:
   VpcName: "snowflakevpc"
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-attachment.yaml -O templates/remote/transit-gateway-attachment.yaml"

--- a/sceptre/scicomp/config/prod/sagebionetworks-org-acm-cert.yaml
+++ b/sceptre/scicomp/config/prod/sagebionetworks-org-acm-cert.yaml
@@ -1,4 +1,6 @@
-template_path: remote/acm-certificate.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/acm-certificate.yaml
 stack_name: sagebionetworks-org-acm-cert
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
@@ -9,6 +11,3 @@ parameters:
   OwnerEmail: 'khai.do@sagebase.org'
   # The domain name (i.e. acme.org)
   DnsDomainName: "sagebionetworks.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/acm-certificate.yaml -O templates/remote/acm-certificate.yaml"

--- a/sceptre/scicomp/config/prod/service-linked-roles.yaml
+++ b/sceptre/scicomp/config/prod/service-linked-roles.yaml
@@ -1,7 +1,6 @@
-template_path: remote/service-linked-roles.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/service-linked-roles.yaml
 stack_name: service-linked-roles
 dependencies:
   - prod/bootstrap.yaml
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/service-linked-roles.yaml -O templates/remote/service-linked-roles.yaml"

--- a/sceptre/scicomp/config/prod/snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/snowflakevpc.yaml
@@ -1,8 +1,7 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: snowflakevpc
 parameters:
   VpcSubnetPrefix: "10.25"
   VpcName: snowflakevpc
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scicomp/config/prod/sumologic-role.yaml
+++ b/sceptre/scicomp/config/prod/sumologic-role.yaml
@@ -1,4 +1,6 @@
-template_path: remote/sumologic-role.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/sumologic-role.yaml
 stack_name: sumologic-role
 dependencies:
   - prod/essentials.yaml
@@ -6,6 +8,3 @@ parameters:
   ExternalID: !ssm /infra/SumologicExternalID
   Actions: 's3:GetObject,s3:GetObjectVersion,s3:ListBucketVersions,s3:ListBucket'
   Resource: !ssm /infra/BeanstalkBucketArn
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/sumologic-role.yaml -O templates/remote/sumologic-role.yaml"

--- a/sceptre/scicomp/config/prod/tgw-spoke-computevpc.yaml
+++ b/sceptre/scicomp/config/prod/tgw-spoke-computevpc.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/transit-gateway-spoke.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml
 stack_name: "tgw-spoke-computevpc"
 stack_tags:
   Department: "Platform"
@@ -16,6 +18,3 @@ parameters:
     - !stack_output_external computevpc::PrivateSubnet2
   # shared TGW, https://github.com/Sage-Bionetworks/transit-infra/blob/master/templates/transit-gateway.j2
   TransitGatewayId: "tgw-0004e7e3454cacac5"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/scicomp/config/prod/tgw-spoke-snowflakevpc.yaml
+++ b/sceptre/scicomp/config/prod/tgw-spoke-snowflakevpc.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/transit-gateway-spoke.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml
 stack_name: "tgw-spoke-snowflakevpc"
 stack_tags:
   Department: "Platform"
@@ -16,6 +18,3 @@ parameters:
     - !stack_output_external snowflakevpc::PrivateSubnet2
   # shared TGW, https://github.com/Sage-Bionetworks/transit-infra/blob/master/templates/transit-gateway.j2
   TransitGatewayId: "tgw-0004e7e3454cacac5"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/securitycentral/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/securitycentral/config/prod/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: remote/AccountAlertTopics.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: AccountAlertTopics
 dependencies:
   - prod/bootstrap.yaml
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm /infra/SlackWebhookUrl
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/securitycentral/config/prod/bootstrap.yaml
+++ b/sceptre/securitycentral/config/prod/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: remote/bootstrap.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: bootstrap
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/securitycentral/config/prod/essentials.yaml
+++ b/sceptre/securitycentral/config/prod/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: remote/essentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/securitycentral/config/prod/rotate-credentials.yaml
+++ b/sceptre/securitycentral/config/prod/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: remote/rotate-credentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: rotate-credentials
 dependencies:
   - prod/bootstrap.yaml
@@ -7,6 +9,3 @@ parameters:
   SendEmail: 'true'
   SenderEmail: 'it@sagebase.org'
   SendReport: 'true'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/strides/config/prod/aws-config.yaml
+++ b/sceptre/strides/config/prod/aws-config.yaml
@@ -1,4 +1,5 @@
-template_path: "aws-config.yaml"
+template:
+  path: "aws-config.yaml"
 stack_name: "aws-config"
 stack_tags:
   Department: "Platform"

--- a/sceptre/strides/config/prod/cloudtrail.yaml
+++ b/sceptre/strides/config/prod/cloudtrail.yaml
@@ -1,4 +1,5 @@
-template_path: "cloudtrail.yaml"
+template:
+  path: "cloudtrail.yaml"
 stack_name: "cloudtrail"
 stack_tags:
   Department: "Platform"

--- a/sceptre/strides/config/prod/guardduty.yaml
+++ b/sceptre/strides/config/prod/guardduty.yaml
@@ -1,5 +1,6 @@
 # setup AWS guard duty member
-template_path: "guardduty.yaml"
+template:
+  path: "guardduty.yaml"
 stack_name: "guardduty"
 parameters:
   accountId: "140124849929"       # org-sagebase-securitycentral

--- a/sceptre/synapsedev/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapsedev/config/prod/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: remote/AccountAlertTopics.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: AccountAlertTopics
 dependencies:
   - prod/bootstrap.yaml
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm /infra/SlackWebhookUrl
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/synapsedev/config/prod/accounts.yaml
+++ b/sceptre/synapsedev/config/prod/accounts.yaml
@@ -1,4 +1,5 @@
-template_path: accounts.yaml
+template:
+  path: accounts.yaml
 stack_name: accounts
 dependencies:
   - prod/essentials.yaml

--- a/sceptre/synapsedev/config/prod/bootstrap.yaml
+++ b/sceptre/synapsedev/config/prod/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: remote/bootstrap.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: bootstrap
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/synapsedev/config/prod/client-integration-test-resources.yaml
+++ b/sceptre/synapsedev/config/prod/client-integration-test-resources.yaml
@@ -1,5 +1,6 @@
 # resources for supporting client integration tests in synapse dev account
 
 # http://docs.synapse.org/articles/custom_storage_location.html
-template_path: client-integration-test-resources.yaml
+template:
+  path: client-integration-test-resources.yaml
 stack_name: client-integration-test-resources

--- a/sceptre/synapsedev/config/prod/essentials.yaml
+++ b/sceptre/synapsedev/config/prod/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: remote/essentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/synapsedev/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapsedev/config/prod/peer-vpc-admincentral.yaml
@@ -1,10 +1,9 @@
-template_path: remote/peer-route-config.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml
 stack_name: peer-vpc-admincentral
 parameters:
   PeeringConnectionId: pcx-9fcc09f7
   VpcPrivateRouteTable: rtb-0093237c
   VpcPublicRouteTable: rtb-f0aa1a8c
   VpnCidr: 10.1.0.0/16
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/synapsedev/config/prod/rotate-credentials.yaml
+++ b/sceptre/synapsedev/config/prod/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: remote/rotate-credentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: rotate-credentials
 dependencies:
   - prod/bootstrap.yaml
@@ -7,6 +9,3 @@ parameters:
   SendEmail: 'true'
   SenderEmail: 'it@sagebase.org'
   SendReport: 'true'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/synapsedev/config/prod/vpc.yaml
+++ b/sceptre/synapsedev/config/prod/vpc.yaml
@@ -1,10 +1,9 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: vpc
 parameters:
   VpcSubnetPrefix: "10.11"
   VpcName: sagevpc
   PrivateSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/synapsedw/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapsedw/config/prod/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: remote/AccountAlertTopics.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: AccountAlertTopics
 dependencies:
   - prod/bootstrap.yaml
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm /infra/SlackWebhookUrl
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/synapsedw/config/prod/accounts.yaml
+++ b/sceptre/synapsedw/config/prod/accounts.yaml
@@ -1,4 +1,5 @@
-template_path: accounts.yaml
+template:
+  path: accounts.yaml
 stack_name: accounts
 dependencies:
   - prod/essentials.yaml

--- a/sceptre/synapsedw/config/prod/bootstrap.yaml
+++ b/sceptre/synapsedw/config/prod/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: remote/bootstrap.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: bootstrap
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/synapsedw/config/prod/essentials.yaml
+++ b/sceptre/synapsedw/config/prod/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: remote/essentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/synapsedw/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapsedw/config/prod/peer-vpc-admincentral.yaml
@@ -1,10 +1,9 @@
-template_path: remote/peer-route-config.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml
 stack_name: peer-vpc-admincentral
 parameters:
   PeeringConnectionId: pcx-4904f521
   VpcPrivateRouteTable: rtb-3d932341
   VpcPublicRouteTable: rtb-c49d2db8
   VpnCidr: 10.1.0.0/16
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/synapsedw/config/prod/rotate-credentials.yaml
+++ b/sceptre/synapsedw/config/prod/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: remote/rotate-credentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: rotate-credentials
 dependencies:
   - prod/bootstrap.yaml
@@ -7,6 +9,3 @@ parameters:
   SendEmail: 'true'
   SenderEmail: 'it@sagebase.org'
   SendReport: 'true'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/synapsedw/config/prod/vpc.yaml
+++ b/sceptre/synapsedw/config/prod/vpc.yaml
@@ -1,10 +1,9 @@
-template_path: remote/vpc.yaml
+template:
+  type: https
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: vpc
 parameters:
   VpcSubnetPrefix: "10.12"
   VpcName: synapsedw-vpc
   PrivateSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/synapsedw/config/prod/vpc.yaml
+++ b/sceptre/synapsedw/config/prod/vpc.yaml
@@ -1,5 +1,5 @@
 template:
-  type: https
+  type: http
   url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: vpc
 parameters:

--- a/sceptre/synapseprod/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/synapseprod/config/prod/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: remote/AccountAlertTopics.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: AccountAlertTopics
 dependencies:
   - prod/bootstrap.yaml
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm /infra/SlackWebhookUrl
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/synapseprod/config/prod/accounts.yaml
+++ b/sceptre/synapseprod/config/prod/accounts.yaml
@@ -1,4 +1,5 @@
-template_path: accounts.yaml
+template:
+  path: accounts.yaml
 stack_name: accounts
 dependencies:
   - prod/essentials.yaml

--- a/sceptre/synapseprod/config/prod/bootstrap.yaml
+++ b/sceptre/synapseprod/config/prod/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: remote/bootstrap.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: bootstrap
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/synapseprod/config/prod/essentials.yaml
+++ b/sceptre/synapseprod/config/prod/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: remote/essentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/synapseprod/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapseprod/config/prod/peer-vpc-admincentral.yaml
@@ -1,4 +1,6 @@
-template_path: remote/peer-route-config.yaml
+template:
+  type: http
+  url: remote/peer-route-config.yaml
 stack_name: peer-vpc-admincentral
 parameters:
   PeeringConnectionId: pcx-3f28d957

--- a/sceptre/synapseprod/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapseprod/config/prod/peer-vpc-admincentral.yaml
@@ -7,6 +7,3 @@ parameters:
   VpcPrivateRouteTable: rtb-63ce7e1f
   VpcPublicRouteTable: rtb-97ce7eeb
   VpnCidr: 10.1.0.0/16
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/synapseprod/config/prod/peer-vpc-admincentral.yaml
+++ b/sceptre/synapseprod/config/prod/peer-vpc-admincentral.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: remote/peer-route-config.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml
 stack_name: peer-vpc-admincentral
 parameters:
   PeeringConnectionId: pcx-3f28d957

--- a/sceptre/synapseprod/config/prod/rotate-credentials.yaml
+++ b/sceptre/synapseprod/config/prod/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: remote/rotate-credentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: rotate-credentials
 dependencies:
   - prod/bootstrap.yaml
@@ -7,6 +9,3 @@ parameters:
   SendEmail: 'true'
   SenderEmail: 'it@sagebase.org'
   SendReport: 'true'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/synapseprod/config/prod/synapse-ops-vpc-v2.yaml
+++ b/sceptre/synapseprod/config/prod/synapse-ops-vpc-v2.yaml
@@ -1,10 +1,9 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: synapse-ops-vpc-v2
 parameters:
   VpcSubnetPrefix: "10.30"
   VpcName: synapse-ops-vpc-v2
   PrivateSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/synapseprod/config/prod/vpc.yaml
+++ b/sceptre/synapseprod/config/prod/vpc.yaml
@@ -1,10 +1,9 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: vpc
 parameters:
   VpcSubnetPrefix: "10.10"
   VpcName: sage-default-vpc
   PrivateSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
-hooks:
-  before_launch:
-   - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/transit/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/transit/config/prod/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/AccountAlertTopics.yaml"
+template:
+  type: http
+  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: "AccountAlertTopics"
 dependencies:
   - "prod/bootstrap.yaml"
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm "/infra/SlackWebhookUrl"
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/transit/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/transit/config/prod/AccountAlertTopics.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: "AccountAlertTopics"
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/transit/config/prod/bootstrap.yaml
+++ b/sceptre/transit/config/prod/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: "remote/bootstrap.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: "bootstrap"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/transit/config/prod/cfn-cr-saml-provider.yaml
+++ b/sceptre/transit/config/prod/cfn-cr-saml-provider.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-saml-provider.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml
 stack_name: cfn-cr-saml-provider
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -O templates/remote/cfn-cr-saml-provider.yaml"

--- a/sceptre/transit/config/prod/essentials.yaml
+++ b/sceptre/transit/config/prod/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: "remote/essentials.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/transit/config/prod/jumpcloud-idp.yaml
+++ b/sceptre/transit/config/prod/jumpcloud-idp.yaml
@@ -1,4 +1,5 @@
-template_path: "jumpcloud-idp.yaml"
+template:
+  path: "jumpcloud-idp.yaml"
 stack_name: "jumpcloud-idp"
 stack_tags:
   Department: "Platform"

--- a/sceptre/transit/config/prod/rotate-credentials.yaml
+++ b/sceptre/transit/config/prod/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/rotate-credentials.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: "rotate-credentials"
 dependencies:
   - "prod/bootstrap.yaml"
@@ -7,6 +9,3 @@ parameters:
   SendEmail: "true"
   SenderEmail: "it@sagebase.org"
   SendReport: "true"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/transit/config/prod/sage-client-vpn.yaml
+++ b/sceptre/transit/config/prod/sage-client-vpn.yaml
@@ -1,4 +1,5 @@
-template_path: "client-vpn.j2"
+template:
+  path: "client-vpn.j2"
 stack_name: "sage-client-vpn"
 stack_tags:
   Department: "Platform"

--- a/sceptre/transit/config/prod/sage-tgw-routes.yaml
+++ b/sceptre/transit/config/prod/sage-tgw-routes.yaml
@@ -1,4 +1,5 @@
-template_path: "transit-gateway-routes.j2"
+template:
+  path: "transit-gateway-routes.j2"
 stack_name: "sage-tgw-routes"
 stack_tags:
   Department: "Platform"

--- a/sceptre/transit/config/prod/sage-tgw.yaml
+++ b/sceptre/transit/config/prod/sage-tgw.yaml
@@ -1,4 +1,5 @@
-template_path: "transit-gateway.j2"
+template:
+  path: "transit-gateway.j2"
 stack_name: "sage-tgw"
 stack_tags:
   Department: "Platform"

--- a/sceptre/transit/config/prod/unionstationvpc.yaml
+++ b/sceptre/transit/config/prod/unionstationvpc.yaml
@@ -1,4 +1,6 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: unionstationvpc
 dependencies:
   - "prod/essentials.yaml"
@@ -6,6 +8,3 @@ parameters:
   VpcSubnetPrefix: "10.50"
   VpcName: "unionstationvpc"
   VpnCidr: "10.50.0.0/16"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"


### PR DESCRIPTION
Sceptre has template handlers[1] now so we can abandon the use of
hooks in favor of the http template handler to get templates
from our shared template repository. This updates bridgedev,
bridgeprod,imagecentral, logcentral, sageit, admincentral account,
scicomp, sandbox, securitycentral, strides, synapseprod, synapsedev,
synapsedw, and transit accounts.  The only one left to do are the
scipool accounts.

[1] https://sceptre.cloudreach.com/dev/docs/template_handlers.html#template-handlers

