### PR TITLE
refactor: replace hooks with template handler

### DIFF
--- a/sceptre/scipool/config/bmgfki/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/bmgfki/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/AccountAlertTopics.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: "AccountAlertTopics"
 dependencies:
   - "bmgfki/bootstrap.yaml"
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm "/infra/SlackWebhookUrl"
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/scipool/config/bmgfki/alb-notebook-access-logsbucket.yaml
+++ b/sceptre/scipool/config/bmgfki/alb-notebook-access-logsbucket.yaml
@@ -1,2 +1,3 @@
-template_path: alb-notebook-access-logsbucket.yaml
+template:
+  path: alb-notebook-access-logsbucket.yaml
 stack_name: alb-notebook-access-logsbucket

--- a/sceptre/scipool/config/bmgfki/alb-notebook-access.yaml
+++ b/sceptre/scipool/config/bmgfki/alb-notebook-access.yaml
@@ -1,4 +1,5 @@
-template_path: alb-notebook-access.yaml
+template:
+  path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
 dependencies:
   - bmgfki/alb-notebook-access-logsbucket.yaml

--- a/sceptre/scipool/config/bmgfki/bootstrap.yaml
+++ b/sceptre/scipool/config/bmgfki/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: "remote/bootstrap.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: "bootstrap"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/scipool/config/bmgfki/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-cr-alb-rule.yaml
@@ -1,4 +1,6 @@
-template_path: remote/cfn-cr-alb-rule.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml
 stack_name: cfn-cr-alb-rule
 stack_tags:
   Department: "Platform"
@@ -11,6 +13,3 @@ parameters:
   OidcTokenEndpoint: 'https://repo-prod.prod.sagebase.org/auth/v1/oauth2/token'
   OidcUserInfoEndpoint: 'https://repo-prod.prod.sagebase.org/auth/v1/oauth2/userinfo'
   OidcClientId: '100105'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml -O templates/remote/cfn-cr-alb-rule.yaml"

--- a/sceptre/scipool/config/bmgfki/cfn-cr-saml-provider.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-cr-saml-provider.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-saml-provider.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml
 stack_name: cfn-cr-saml-provider
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -O templates/remote/cfn-cr-saml-provider.yaml"

--- a/sceptre/scipool/config/bmgfki/cfn-cr-sc-actions-provider.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-cr-sc-actions-provider.yaml
@@ -1,4 +1,6 @@
-template_path: remote/cfn-cr-sc-actions-provider.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml
 stack_name: cfn-cr-sc-actions-provider
 stack_tags:
   Department: "Platform"
@@ -6,6 +8,3 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 dependencies:
   - bmgfki/bootstrap.yaml
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml -O templates/remote/cfn-cr-sc-actions-provider.yaml"

--- a/sceptre/scipool/config/bmgfki/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-cr-sc-bucket-policy.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-sc-bucket-policy-1.0.2.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.2/cfn-cr-sc-bucket-policy.yaml
 stack_name: cfn-cr-sc-bucket-policy
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.2/cfn-cr-sc-bucket-policy.yaml -O templates/remote/cfn-cr-sc-bucket-policy-1.0.2.yaml"

--- a/sceptre/scipool/config/bmgfki/cfn-cr-sc-product-provider.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-cr-sc-product-provider.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-sc-product-provider.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-product-provider/1.0.0/cfn-cr-sc-product-provider.yaml
 stack_name: cfn-cr-sc-product-provider
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-product-provider/1.0.0/cfn-cr-sc-product-provider.yaml -O templates/remote/cfn-cr-sc-product-provider.yaml"

--- a/sceptre/scipool/config/bmgfki/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-cr-synapse-tagger.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-synapse-tagger.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml
 stack_name: cfn-cr-synapse-tagger
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml -O templates/remote/cfn-cr-synapse-tagger.yaml"

--- a/sceptre/scipool/config/bmgfki/cfn-macro-ssm-param.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-macro-ssm-param.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-macro-ssm-param.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml
 stack_name: "cfn-macro-ssm-param"
 dependencies:
   - "bmgfki/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -O templates/remote/cfn-macro-ssm-param.yaml"

--- a/sceptre/scipool/config/bmgfki/cfn-s3objects-macro.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-s3objects-macro.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-s3objects-macro.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "bmgfki/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/scipool/config/bmgfki/cfn-ssm-param-policy.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-ssm-param-policy.yaml
@@ -1,4 +1,5 @@
-template_path: "cfn-ssm-param-policy.yaml"
+template:
+  path: "cfn-ssm-param-policy.yaml"
 stack_name: "cfn-ssm-param-policy"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/bmgfki/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-tag-instance-policy.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-tag-instance-policy.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cfn-tag-instance-policy.yaml
 stack_name: "cfn-tag-instance-policy"
 dependencies:
   - "bmgfki/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"

--- a/sceptre/scipool/config/bmgfki/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/bmgfki/docker-runner-efs-vpc.yaml
@@ -1,7 +1,6 @@
-template_path: remote/efs-vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/VPC/efs-vpc.yaml
 stack_name: docker-runner-vpc
 dependencies:
   - bmgfki/bootstrap.yaml
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"

--- a/sceptre/scipool/config/bmgfki/essentials.yaml
+++ b/sceptre/scipool/config/bmgfki/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: "remote/essentials.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "bmgfki/bootstrap.yaml"
 parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"  # org-sagebase-admincentral
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/scipool/config/bmgfki/gatespoolvpc.yaml
+++ b/sceptre/scipool/config/bmgfki/gatespoolvpc.yaml
@@ -1,10 +1,9 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: gatespoolvpc
 dependencies:
   - bmgfki/bootstrap.yaml
 parameters:
   VpcSubnetPrefix: "10.67"
   VpcName: gatespoolvpc
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scipool/config/bmgfki/get-role-policy.yaml
+++ b/sceptre/scipool/config/bmgfki/get-role-policy.yaml
@@ -1,2 +1,3 @@
-template_path: "get-role-policy.yaml"
+template:
+  path: "get-role-policy.yaml"
 stack_name: "get-role-policy"

--- a/sceptre/scipool/config/bmgfki/lambda-bucket-cleanup.yaml
+++ b/sceptre/scipool/config/bmgfki/lambda-bucket-cleanup.yaml
@@ -1,4 +1,6 @@
-template_path: remote/lambda-sc-bucket-cleanup.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.2/lambda-sc-bucket-cleanup.yaml
 stack_name: lambda-sc-bucket-cleanup
 parameters:
   EnableSchedule: "true"
@@ -6,6 +8,3 @@ stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.2/lambda-sc-bucket-cleanup.yaml -O templates/remote/lambda-sc-bucket-cleanup.yaml"

--- a/sceptre/scipool/config/bmgfki/lambda-budgets.yaml
+++ b/sceptre/scipool/config/bmgfki/lambda-budgets.yaml
@@ -1,4 +1,6 @@
-template_path: remote/lambda-budgets.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml
 stack_name: lambda-budgets
 stack_tags:
   Department: "Platform"
@@ -10,6 +12,3 @@ parameters:
   EndUserRoleName: !stack_output_external sc-enduser-iam::ExternalEndUserRoleName
   BudgetRules: !file_contents templates/bmgfki/lambda-budgets/budget-rules.yaml
   Thresholds: !file_contents templates/bmgfki/lambda-budgets/thresholds.yaml
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml -O templates/remote/lambda-budgets.yaml"

--- a/sceptre/scipool/config/bmgfki/lambda-send-budget-alert.yaml
+++ b/sceptre/scipool/config/bmgfki/lambda-send-budget-alert.yaml
@@ -1,4 +1,6 @@
-template_path: remote/lambda-send-budget-alert.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml
 stack_name: lambda-send-budget-alert
 dependencies:
   - bmgfki/lambda-budgets.yaml
@@ -10,6 +12,3 @@ stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml -O templates/remote/lambda-send-budget-alert.yaml"

--- a/sceptre/scipool/config/bmgfki/maintenance.yaml
+++ b/sceptre/scipool/config/bmgfki/maintenance.yaml
@@ -1,9 +1,8 @@
-template_path: remote/maintenance.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml
 stack_name: prod-default-maintenance-window
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml -O templates/remote/maintenance.yaml"

--- a/sceptre/scipool/config/bmgfki/rotate-credentials.yaml
+++ b/sceptre/scipool/config/bmgfki/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/rotate-credentials.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: "rotate-credentials"
 dependencies:
   - "bmgfki/bootstrap.yaml"
@@ -7,6 +9,3 @@ parameters:
   SendEmail: "true"
   SenderEmail: "it@sagebase.org"
   SendReport: "true"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/scipool/config/bmgfki/s3-gatespoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/bmgfki/s3-gatespoolvpc-gateway-endpoint.yaml
@@ -1,10 +1,9 @@
-template_path: remote/gateway-vpc-endpoint.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml
 stack_name: s3-gatespoolvpc-gateway-endpoint
 dependencies:
   - bmgfki/gatespoolvpc.yaml
 parameters:
   VpcName: gatespoolvpc
   ServiceName: com.amazonaws.us-east-1.s3
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scipool/config/bmgfki/sc-ec2-actions.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-ec2-actions.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-actions.yaml"
+template:
+  path: "sc-ec2-actions.yaml"
 stack_name: "sc-ec2-actions"
 dependencies:
   - "bmgfki/sc-enduser-iam.yaml"

--- a/sceptre/scipool/config/bmgfki/sc-ec2vpc-launchrole.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-ec2vpc-launchrole.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2vpc-launchrole.yaml"
+template:
+  path: "sc-ec2vpc-launchrole.yaml"
 stack_name: "sc-ec2vpc-launchrole"
 dependencies:
   - "bmgfki/essentials.yaml"

--- a/sceptre/scipool/config/bmgfki/sc-enduser-iam.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-enduser-iam.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-enduser-iam.yaml"
+template:
+  path: "sc-enduser-iam.yaml"
 stack_name: "sc-enduser-iam"
 dependencies:
   - "bmgfki/essentials.yaml"

--- a/sceptre/scipool/config/bmgfki/sc-kms-key.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-kms-key.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-kms-key.yaml"
+template:
+  path: "sc-kms-key.yaml"
 stack_name: "sc-kms-key"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/bmgfki/sc-portfolio-ec2-external.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-portfolio-ec2-external.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-ec2-external.yaml"
+template:
+  path: "sc-portfolio-ec2-external.yaml"
 stack_name: "sc-portfolio-ec2-external"
 dependencies:
   - "bmgfki/sc-ec2vpc-launchrole.yaml"

--- a/sceptre/scipool/config/bmgfki/sc-portfolio-ec2.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-portfolio-ec2.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-ec2.yaml"
+template:
+  path: "sc-portfolio-ec2.yaml"
 stack_name: "sc-portfolio-ec2"
 dependencies:
   - "bmgfki/sc-ec2vpc-launchrole.yaml"

--- a/sceptre/scipool/config/bmgfki/sc-portfolio-s3-basic.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-portfolio-s3-basic.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-s3-basic.yaml"
+template:
+  path: "sc-portfolio-s3-basic.yaml"
 stack_name: "sc-portfolio-s3-basic"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/bmgfki/sc-product-assoc-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-assoc-ec2-linux-docker.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-linux-docker"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/bmgfki/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-linux-jumpcloud-notebook"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/bmgfki/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-windows-jumpcloud"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-docker.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-docker.j2"
+template:
+  path: "sc-product-ec2-linux-docker.j2"
 stack_name: "sc-product-ec2-linux-docker"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-jumpcloud-notebook.j2"
+template:
+  path: "sc-product-ec2-linux-jumpcloud-notebook.j2"
 stack_name: "sc-product-ec2-linux-jumpcloud-notebook"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml"
+template:
+  path: "sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml"
 stack_name: "sc-product-ec2-linux-notebook-write-to-ssm-policy"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-windows-jumpcloud.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-windows-jumpcloud.j2"
+template:
+  path: "sc-product-ec2-windows-jumpcloud.j2"
 stack_name: "sc-product-ec2-windows-jumpcloud"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/bmgfki/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-s3-private-enc.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-s3-private-enc.j2"
+template:
+  path: "sc-product-s3-private-enc.j2"
 stack_name: "sc-product-s3-private-enc"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/bmgfki/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-s3-synapse.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-s3-synapse.j2"
+template:
+  path: "sc-product-s3-synapse.j2"
 stack_name: "sc-product-s3-synapse"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/bmgfki/sc-s3-launchrole.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-s3-launchrole.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-s3-launchrole.yaml"
+template:
+  path: "sc-s3-launchrole.yaml"
 stack_name: "sc-s3-launchrole"
 dependencies:
   - "bmgfki/essentials.yaml"

--- a/sceptre/scipool/config/bmgfki/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-tag-options-external.yaml
@@ -1,5 +1,6 @@
 # Tag options for External Sage teams
-template_path: "sc-tag-options.j2"
+template:
+  path: "sc-tag-options.j2"
 stack_name: "sc-tag-options-external"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/bmgfki/sc-tag-options.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-tag-options.yaml
@@ -1,5 +1,6 @@
 # Tag options for internal Sage teams
-template_path: "sc-tag-options.j2"
+template:
+  path: "sc-tag-options.j2"
 stack_name: "sc-tag-options"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/bmgfki/synapse-oidc-idp.yaml
+++ b/sceptre/scipool/config/bmgfki/synapse-oidc-idp.yaml
@@ -1,4 +1,6 @@
-template_path: remote/cfn-cr-oidc-idp.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml
 stack_name: synapse-oidc-idp
 stack_tags:
   Department: "Platform"
@@ -8,6 +10,3 @@ parameters:
   Url: "https://repo-prod.prod.sagebase.org/auth/v1"
   ClientIDList: "100105"
   ThumbprintList: "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml -O templates/remote/cfn-cr-oidc-idp.yaml"

--- a/sceptre/scipool/config/develop/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/develop/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/AccountAlertTopics.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: "AccountAlertTopics"
 dependencies:
   - "develop/bootstrap.yaml"
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm "/infra/SlackWebhookUrl"
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/scipool/config/develop/alb-notebook-access-logsbucket.yaml
+++ b/sceptre/scipool/config/develop/alb-notebook-access-logsbucket.yaml
@@ -1,2 +1,3 @@
-template_path: alb-notebook-access-logsbucket.yaml
+template:
+  path: alb-notebook-access-logsbucket.yaml
 stack_name: alb-notebook-access-logsbucket

--- a/sceptre/scipool/config/develop/alb-notebook-access.yaml
+++ b/sceptre/scipool/config/develop/alb-notebook-access.yaml
@@ -1,4 +1,5 @@
-template_path: alb-notebook-access.yaml
+template:
+  path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
 dependencies:
   - develop/alb-notebook-access-logsbucket.yaml

--- a/sceptre/scipool/config/develop/bootstrap.yaml
+++ b/sceptre/scipool/config/develop/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: "remote/bootstrap.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: "bootstrap"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/scipool/config/develop/cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/cesspoolvpc.yaml
@@ -1,10 +1,9 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: cesspoolvpc
 dependencies:
   - develop/bootstrap.yaml
 parameters:
   VpcSubnetPrefix: "10.31"
   VpcName: "cesspoolvpc"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
@@ -1,4 +1,6 @@
-template_path: remote/cfn-cr-alb-rule.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml
 stack_name: cfn-cr-alb-rule
 stack_tags:
   Department: "Platform"
@@ -11,6 +13,3 @@ parameters:
   OidcTokenEndpoint: 'https://repo-prod.prod.sagebase.org/auth/v1/oauth2/token'
   OidcUserInfoEndpoint: 'https://repo-prod.prod.sagebase.org/auth/v1/oauth2/userinfo'
   OidcClientId: '100055'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml -O templates/remote/cfn-cr-alb-rule.yaml"

--- a/sceptre/scipool/config/develop/cfn-cr-sc-actions-provider.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-sc-actions-provider.yaml
@@ -1,4 +1,6 @@
-template_path: remote/cfn-cr-sc-actions-provider.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml
 stack_name: cfn-cr-sc-actions-provider
 stack_tags:
   Department: "Platform"
@@ -6,6 +8,3 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 dependencies:
   - develop/bootstrap.yaml
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml -O templates/remote/cfn-cr-sc-actions-provider.yaml"

--- a/sceptre/scipool/config/develop/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-sc-bucket-policy.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-sc-bucket-policy-1.0.2.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.2/cfn-cr-sc-bucket-policy.yaml
 stack_name: cfn-cr-sc-bucket-policy
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.2/cfn-cr-sc-bucket-policy.yaml -O templates/remote/cfn-cr-sc-bucket-policy-1.0.2.yaml"

--- a/sceptre/scipool/config/develop/cfn-cr-sc-product-provider.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-sc-product-provider.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-sc-product-provider.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-product-provider/1.0.0/cfn-cr-sc-product-provider.yaml
 stack_name: cfn-cr-sc-product-provider
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-product-provider/1.0.0/cfn-cr-sc-product-provider.yaml -O templates/remote/cfn-cr-sc-product-provider.yaml"

--- a/sceptre/scipool/config/develop/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-synapse-tagger.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-synapse-tagger.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml
 stack_name: cfn-cr-synapse-tagger
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml -O templates/remote/cfn-cr-synapse-tagger.yaml"

--- a/sceptre/scipool/config/develop/cfn-macro-ssm-param.yaml
+++ b/sceptre/scipool/config/develop/cfn-macro-ssm-param.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-macro-ssm-param.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml
 stack_name: "cfn-macro-ssm-param"
 dependencies:
   - "develop/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -O templates/remote/cfn-macro-ssm-param.yaml"

--- a/sceptre/scipool/config/develop/cfn-s3objects-macro.yaml
+++ b/sceptre/scipool/config/develop/cfn-s3objects-macro.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-s3objects-macro.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "develop/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/scipool/config/develop/cfn-ssm-param-policy.yaml
+++ b/sceptre/scipool/config/develop/cfn-ssm-param-policy.yaml
@@ -1,4 +1,5 @@
-template_path: "cfn-ssm-param-policy.yaml"
+template:
+  path: "cfn-ssm-param-policy.yaml"
 stack_name: "cfn-ssm-param-policy"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/develop/cfn-tag-instance-policy.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-tag-instance-policy.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cfn-tag-instance-policy.yaml
 stack_name: "cfn-tag-instance-policy"
 dependencies:
   - "develop/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"

--- a/sceptre/scipool/config/develop/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/develop/docker-runner-efs-vpc.yaml
@@ -1,7 +1,6 @@
-template_path: remote/efs-vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/VPC/efs-vpc.yaml
 stack_name: docker-runner-vpc
 dependencies:
   - develop/bootstrap.yaml
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"

--- a/sceptre/scipool/config/develop/essentials.yaml
+++ b/sceptre/scipool/config/develop/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: "remote/essentials.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "develop/bootstrap.yaml"
 parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/scipool/config/develop/get-role-policy.yaml
+++ b/sceptre/scipool/config/develop/get-role-policy.yaml
@@ -1,2 +1,3 @@
-template_path: "get-role-policy.yaml"
+template:
+  path: "get-role-policy.yaml"
 stack_name: "get-role-policy"

--- a/sceptre/scipool/config/develop/lambda-bucket-cleanup.yaml
+++ b/sceptre/scipool/config/develop/lambda-bucket-cleanup.yaml
@@ -1,4 +1,6 @@
-template_path: remote/lambda-sc-bucket-cleanup.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.2/lambda-sc-bucket-cleanup.yaml
 stack_name: lambda-sc-bucket-cleanup
 parameters:
   ArchivedPeriod: "2"
@@ -8,6 +10,3 @@ stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.2/lambda-sc-bucket-cleanup.yaml -O templates/remote/lambda-sc-bucket-cleanup.yaml"

--- a/sceptre/scipool/config/develop/lambda-budgets.yaml
+++ b/sceptre/scipool/config/develop/lambda-budgets.yaml
@@ -1,4 +1,6 @@
-template_path: remote/lambda-budgets.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml
 stack_name: lambda-budgets
 stack_tags:
   Department: "Platform"
@@ -8,6 +10,3 @@ parameters:
   EndUserRoleName: !stack_output_external sc-enduser-iam::EndUserRoleName
   BudgetRules: !file_contents templates/develop/lambda-budgets/budget-rules.yaml
   Thresholds: !file_contents templates/develop/lambda-budgets/thresholds.yaml
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml -O templates/remote/lambda-budgets.yaml"

--- a/sceptre/scipool/config/develop/lambda-send-budget-alert.yaml
+++ b/sceptre/scipool/config/develop/lambda-send-budget-alert.yaml
@@ -1,4 +1,6 @@
-template_path: remote/lambda-send-budget-alert.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml
 stack_name: lambda-send-budget-alert
 parameters:
   SNSTopicARN: !stack_output_external lambda-budgets::BudgetMakerNotificationTopicArn
@@ -8,6 +10,3 @@ stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml -O templates/remote/lambda-send-budget-alert.yaml"

--- a/sceptre/scipool/config/develop/maintenance.yaml
+++ b/sceptre/scipool/config/develop/maintenance.yaml
@@ -1,9 +1,8 @@
-template_path: remote/maintenance.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml
 stack_name: prod-default-maintenance-window
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml -O templates/remote/maintenance.yaml"

--- a/sceptre/scipool/config/develop/peer-vpn-cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/peer-vpn-cesspoolvpc.yaml
@@ -1,4 +1,6 @@
-template_path: remote/peer-route-config.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml
 stack_name: peer-vpn-cesspoolvpc
 dependencies:
   - develop/cesspoolvpc.yaml
@@ -7,6 +9,3 @@ parameters:
   VpcPrivateRouteTable: "rtb-094f2336c06807361"
   VpcPublicRouteTable: "rtb-036d799b77abcd1fb"
   VpnCidr: "10.1.0.0/16"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scipool/config/develop/rotate-credentials.yaml
+++ b/sceptre/scipool/config/develop/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/rotate-credentials.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: "rotate-credentials"
 dependencies:
   - "develop/bootstrap.yaml"
@@ -7,6 +9,3 @@ parameters:
   SendEmail: "true"
   SenderEmail: "it@sagebase.org"
   SendReport: "true"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/scipool/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
@@ -1,10 +1,9 @@
-template_path: remote/gateway-vpc-endpoint.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml
 stack_name: s3-cesspoolvpc-gateway-endpoint
 dependencies:
   - develop/cesspoolvpc.yaml
 parameters:
   VpcName: cesspoolvpc
   ServiceName: com.amazonaws.us-east-1.s3
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scipool/config/develop/sc-ec2-actions.yaml
+++ b/sceptre/scipool/config/develop/sc-ec2-actions.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-actions.yaml"
+template:
+  path: "sc-ec2-actions.yaml"
 stack_name: "sc-ec2-actions"
 dependencies:
   - "develop/sc-enduser-iam.yaml"

--- a/sceptre/scipool/config/develop/sc-ec2vpc-launchrole.yaml
+++ b/sceptre/scipool/config/develop/sc-ec2vpc-launchrole.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2vpc-launchrole.yaml"
+template:
+  path: "sc-ec2vpc-launchrole.yaml"
 stack_name: "sc-ec2vpc-launchrole"
 dependencies:
   - "develop/essentials.yaml"

--- a/sceptre/scipool/config/develop/sc-enduser-iam.yaml
+++ b/sceptre/scipool/config/develop/sc-enduser-iam.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-enduser-iam.yaml"
+template:
+  path: "sc-enduser-iam.yaml"
 stack_name: "sc-enduser-iam"
 dependencies:
   - "develop/essentials.yaml"

--- a/sceptre/scipool/config/develop/sc-kms-key.yaml
+++ b/sceptre/scipool/config/develop/sc-kms-key.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-kms-key.yaml"
+template:
+  path: "sc-kms-key.yaml"
 stack_name: "sc-kms-key"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-portfolio-ec2-external.yaml
+++ b/sceptre/scipool/config/develop/sc-portfolio-ec2-external.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-ec2-external.yaml"
+template:
+  path: "sc-portfolio-ec2-external.yaml"
 stack_name: "sc-portfolio-ec2-external"
 dependencies:
   - "develop/sc-ec2vpc-launchrole.yaml"

--- a/sceptre/scipool/config/develop/sc-portfolio-ec2.yaml
+++ b/sceptre/scipool/config/develop/sc-portfolio-ec2.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-ec2.yaml"
+template:
+  path: "sc-portfolio-ec2.yaml"
 stack_name: "sc-portfolio-ec2"
 dependencies:
   - "develop/sc-ec2vpc-launchrole.yaml"

--- a/sceptre/scipool/config/develop/sc-portfolio-s3-basic.yaml
+++ b/sceptre/scipool/config/develop/sc-portfolio-s3-basic.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-s3-basic.yaml"
+template:
+  path: "sc-portfolio-s3-basic.yaml"
 stack_name: "sc-portfolio-s3-basic"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-docker.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-linux-docker"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-linux-jumpcloud-notebook"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-jumpcloud-workflows.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-linux-jumpcloud-workflows"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-jumpcloud.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-linux-jumpcloud"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-windows-jumpcloud"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-docker.j2"
+template:
+  path: "sc-product-ec2-linux-docker.j2"
 stack_name: "sc-product-ec2-linux-docker"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-jumpcloud-notebook.j2"
+template:
+  path: "sc-product-ec2-linux-jumpcloud-notebook.j2"
 stack_name: "sc-product-ec2-linux-jumpcloud-notebook"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-jumpcloud-workflows.j2"
+template:
+  path: "sc-product-ec2-linux-jumpcloud-workflows.j2"
 stack_name: "sc-product-ec2-linux-jumpcloud-workflows"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-jumpcloud.j2"
+template:
+  path: "sc-product-ec2-linux-jumpcloud.j2"
 stack_name: "sc-product-ec2-linux-jumpcloud"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml"
+template:
+  path: "sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml"
 stack_name: "sc-product-ec2-linux-notebook-write-to-ssm-policy"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-windows-jumpcloud.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-windows-jumpcloud.j2"
+template:
+  path: "sc-product-ec2-windows-jumpcloud.j2"
 stack_name: "sc-product-ec2-windows-jumpcloud"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/develop/sc-product-s3-private-enc.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-s3-private-enc.j2"
+template:
+  path: "sc-product-s3-private-enc.j2"
 stack_name: "sc-product-s3-private-enc"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/develop/sc-product-s3-synapse.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-s3-synapse.j2"
+template:
+  path: "sc-product-s3-synapse.j2"
 stack_name: "sc-product-s3-synapse"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-s3-launchrole.yaml
+++ b/sceptre/scipool/config/develop/sc-s3-launchrole.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-s3-launchrole.yaml"
+template:
+  path: "sc-s3-launchrole.yaml"
 stack_name: "sc-s3-launchrole"
 dependencies:
   - "develop/essentials.yaml"

--- a/sceptre/scipool/config/develop/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/develop/sc-tag-options-external.yaml
@@ -1,5 +1,6 @@
 # Tag options for External Sage teams
-template_path: "sc-tag-options.j2"
+template:
+  path: "sc-tag-options.j2"
 stack_name: "sc-tag-options-external"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/sc-tag-options.yaml
+++ b/sceptre/scipool/config/develop/sc-tag-options.yaml
@@ -1,5 +1,6 @@
 # Tag options for internal Sage teams
-template_path: "sc-tag-options.j2"
+template:
+  path: "sc-tag-options.j2"
 stack_name: "sc-tag-options"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/synapse-oidc-idp.yaml
+++ b/sceptre/scipool/config/develop/synapse-oidc-idp.yaml
@@ -1,4 +1,6 @@
-template_path: remote/cfn-cr-oidc-idp.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml
 stack_name: synapse-oidc-idp
 stack_tags:
   Department: "Platform"
@@ -8,6 +10,3 @@ parameters:
   Url: "https://repo-prod.prod.sagebase.org/auth/v1"
   ClientIDList: "100055"
   ThumbprintList: "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml -O templates/remote/cfn-cr-oidc-idp.yaml"

--- a/sceptre/scipool/config/develop/tgw-spoke-cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/tgw-spoke-cesspoolvpc.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/transit-gateway-spoke.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml
 stack_name: "tgw-spoke-cesspoolvpc"
 stack_tags:
   Department: "Platform"
@@ -16,6 +18,3 @@ parameters:
     - !stack_output_external cesspoolvpc::PrivateSubnet2
   # shared TGW, https://github.com/Sage-Bionetworks/transit-infra/blob/master/templates/transit-gateway.j2
   TransitGatewayId: "tgw-0004e7e3454cacac5"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/scipool/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/prod/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/AccountAlertTopics.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: "AccountAlertTopics"
 dependencies:
   - "prod/bootstrap.yaml"
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm "/infra/SlackWebhookUrl"
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/scipool/config/prod/alb-notebook-access-logsbucket.yaml
+++ b/sceptre/scipool/config/prod/alb-notebook-access-logsbucket.yaml
@@ -1,2 +1,3 @@
-template_path: alb-notebook-access-logsbucket.yaml
+template:
+  path: alb-notebook-access-logsbucket.yaml
 stack_name: alb-notebook-access-logsbucket

--- a/sceptre/scipool/config/prod/alb-notebook-access.yaml
+++ b/sceptre/scipool/config/prod/alb-notebook-access.yaml
@@ -1,4 +1,5 @@
-template_path: alb-notebook-access.yaml
+template:
+  path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
 dependencies:
   - prod/alb-notebook-access-logsbucket.yaml

--- a/sceptre/scipool/config/prod/bootstrap.yaml
+++ b/sceptre/scipool/config/prod/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: "remote/bootstrap.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: "bootstrap"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/scipool/config/prod/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-alb-rule.yaml
@@ -1,4 +1,6 @@
-template_path: remote/cfn-cr-alb-rule.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml
 stack_name: cfn-cr-alb-rule
 stack_tags:
   Department: "Platform"
@@ -11,6 +13,3 @@ parameters:
   OidcTokenEndpoint: 'https://repo-prod.prod.sagebase.org/auth/v1/oauth2/token'
   OidcUserInfoEndpoint: 'https://repo-prod.prod.sagebase.org/auth/v1/oauth2/userinfo'
   OidcClientId: '100053'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml -O templates/remote/cfn-cr-alb-rule.yaml"

--- a/sceptre/scipool/config/prod/cfn-cr-sc-actions-provider.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-sc-actions-provider.yaml
@@ -1,4 +1,6 @@
-template_path: remote/cfn-cr-sc-actions-provider.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml
 stack_name: cfn-cr-sc-actions-provider
 stack_tags:
   Department: "Platform"
@@ -6,6 +8,3 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 dependencies:
   - prod/bootstrap.yaml
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml -O templates/remote/cfn-cr-sc-actions-provider.yaml"

--- a/sceptre/scipool/config/prod/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-sc-bucket-policy.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-sc-bucket-policy-1.0.2.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.2/cfn-cr-sc-bucket-policy.yaml
 stack_name: cfn-cr-sc-bucket-policy
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.2/cfn-cr-sc-bucket-policy.yaml -O templates/remote/cfn-cr-sc-bucket-policy-1.0.2.yaml"

--- a/sceptre/scipool/config/prod/cfn-cr-sc-product-provider.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-sc-product-provider.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-sc-product-provider.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-product-provider/1.0.0/cfn-cr-sc-product-provider.yaml
 stack_name: cfn-cr-sc-product-provider
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-product-provider/1.0.0/cfn-cr-sc-product-provider.yaml -O templates/remote/cfn-cr-sc-product-provider.yaml"

--- a/sceptre/scipool/config/prod/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-synapse-tagger.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-synapse-tagger.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml
 stack_name: cfn-cr-synapse-tagger
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml -O templates/remote/cfn-cr-synapse-tagger.yaml"

--- a/sceptre/scipool/config/prod/cfn-macro-ssm-param.yaml
+++ b/sceptre/scipool/config/prod/cfn-macro-ssm-param.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-macro-ssm-param.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml
 stack_name: "cfn-macro-ssm-param"
 dependencies:
   - "prod/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -O templates/remote/cfn-macro-ssm-param.yaml"

--- a/sceptre/scipool/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/scipool/config/prod/cfn-s3objects-macro.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-s3objects-macro.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "prod/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/scipool/config/prod/cfn-ssm-param-policy.yaml
+++ b/sceptre/scipool/config/prod/cfn-ssm-param-policy.yaml
@@ -1,4 +1,5 @@
-template_path: "cfn-ssm-param-policy.yaml"
+template:
+  path: "cfn-ssm-param-policy.yaml"
 stack_name: "cfn-ssm-param-policy"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/prod/cfn-tag-instance-policy.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-tag-instance-policy.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cfn-tag-instance-policy.yaml
 stack_name: "cfn-tag-instance-policy"
 dependencies:
   - "prod/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"

--- a/sceptre/scipool/config/prod/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/prod/docker-runner-efs-vpc.yaml
@@ -1,7 +1,6 @@
-template_path: remote/efs-vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/VPC/efs-vpc.yaml
 stack_name: docker-runner-vpc
 dependencies:
   - prod/bootstrap.yaml
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"

--- a/sceptre/scipool/config/prod/essentials.yaml
+++ b/sceptre/scipool/config/prod/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: "remote/essentials.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/scipool/config/prod/get-role-policy.yaml
+++ b/sceptre/scipool/config/prod/get-role-policy.yaml
@@ -1,2 +1,3 @@
-template_path: "get-role-policy.yaml"
+template:
+  path: "get-role-policy.yaml"
 stack_name: "get-role-policy"

--- a/sceptre/scipool/config/prod/internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/internalpoolvpc.yaml
@@ -1,10 +1,9 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: internalpoolvpc
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   VpcSubnetPrefix: "10.41"
   VpcName: internalpoolvpc
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scipool/config/prod/lambda-bucket-cleanup.yaml
+++ b/sceptre/scipool/config/prod/lambda-bucket-cleanup.yaml
@@ -1,4 +1,6 @@
-template_path: remote/lambda-sc-bucket-cleanup.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.2/lambda-sc-bucket-cleanup.yaml
 stack_name: lambda-sc-bucket-cleanup
 parameters:
   EnableSchedule: "true"
@@ -6,6 +8,3 @@ stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.2/lambda-sc-bucket-cleanup.yaml -O templates/remote/lambda-sc-bucket-cleanup.yaml"

--- a/sceptre/scipool/config/prod/lambda-budgets.yaml
+++ b/sceptre/scipool/config/prod/lambda-budgets.yaml
@@ -1,4 +1,6 @@
-template_path: remote/lambda-budgets.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml
 stack_name: lambda-budgets
 stack_tags:
   Department: "Platform"
@@ -8,6 +10,3 @@ parameters:
   EndUserRoleName: !stack_output_external sc-enduser-iam::ExternalEndUserRoleName
   BudgetRules: !file_contents templates/prod/lambda-budgets/budget-rules.yaml
   Thresholds: !file_contents templates/prod/lambda-budgets/thresholds.yaml
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml -O templates/remote/lambda-budgets.yaml"

--- a/sceptre/scipool/config/prod/lambda-send-budget-alert.yaml
+++ b/sceptre/scipool/config/prod/lambda-send-budget-alert.yaml
@@ -1,4 +1,6 @@
-template_path: remote/lambda-send-budget-alert.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml
 stack_name: lambda-send-budget-alert
 parameters:
   SNSTopicARN: !stack_output_external lambda-budgets::BudgetMakerNotificationTopicArn
@@ -8,6 +10,3 @@ stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml -O templates/remote/lambda-send-budget-alert.yaml"

--- a/sceptre/scipool/config/prod/maintenance.yaml
+++ b/sceptre/scipool/config/prod/maintenance.yaml
@@ -1,9 +1,8 @@
-template_path: remote/maintenance.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml
 stack_name: prod-default-maintenance-window
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml -O templates/remote/maintenance.yaml"

--- a/sceptre/scipool/config/prod/peer-vpn-internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/peer-vpn-internalpoolvpc.yaml
@@ -1,10 +1,9 @@
-template_path: remote/peer-route-config.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml
 stack_name: peer-vpn-internalpoolvpc
 parameters:
   PeeringConnectionId: pcx-08fd6360cd56646a3
   VpcPrivateRouteTable: rtb-07a8fba84582c8480
   VpcPublicRouteTable: rtb-057f64d254b0f8712
   VpnCidr: 10.1.0.0/16
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scipool/config/prod/rotate-credentials.yaml
+++ b/sceptre/scipool/config/prod/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/rotate-credentials.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: "rotate-credentials"
 dependencies:
   - "prod/bootstrap.yaml"
@@ -7,6 +9,3 @@ parameters:
   SendEmail: "true"
   SenderEmail: "it@sagebase.org"
   SendReport: "true"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/scipool/config/prod/s3-internalpoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/prod/s3-internalpoolvpc-gateway-endpoint.yaml
@@ -1,10 +1,9 @@
-template_path: remote/gateway-vpc-endpoint.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml
 stack_name: s3-internalpoolvpc-gateway-endpoint
 dependencies:
   - prod/internalpoolvpc.yaml
 parameters:
   VpcName: internalpoolvpc
   ServiceName: com.amazonaws.us-east-1.s3
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scipool/config/prod/sc-ec2-actions.yaml
+++ b/sceptre/scipool/config/prod/sc-ec2-actions.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-actions.yaml"
+template:
+  path: "sc-ec2-actions.yaml"
 stack_name: "sc-ec2-actions"
 dependencies:
   - "prod/sc-enduser-iam.yaml"

--- a/sceptre/scipool/config/prod/sc-ec2vpc-launchrole.yaml
+++ b/sceptre/scipool/config/prod/sc-ec2vpc-launchrole.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2vpc-launchrole.yaml"
+template:
+  path: "sc-ec2vpc-launchrole.yaml"
 stack_name: "sc-ec2vpc-launchrole"
 dependencies:
   - "prod/essentials.yaml"

--- a/sceptre/scipool/config/prod/sc-enduser-iam.yaml
+++ b/sceptre/scipool/config/prod/sc-enduser-iam.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-enduser-iam.yaml"
+template:
+  path: "sc-enduser-iam.yaml"
 stack_name: "sc-enduser-iam"
 dependencies:
   - "prod/essentials.yaml"

--- a/sceptre/scipool/config/prod/sc-kms-key.yaml
+++ b/sceptre/scipool/config/prod/sc-kms-key.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-kms-key.yaml"
+template:
+  path: "sc-kms-key.yaml"
 stack_name: "sc-kms-key"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-portfolio-ec2-external.yaml
+++ b/sceptre/scipool/config/prod/sc-portfolio-ec2-external.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-ec2-external.yaml"
+template:
+  path: "sc-portfolio-ec2-external.yaml"
 stack_name: "sc-portfolio-ec2-external"
 dependencies:
   - "prod/sc-ec2vpc-launchrole.yaml"

--- a/sceptre/scipool/config/prod/sc-portfolio-ec2.yaml
+++ b/sceptre/scipool/config/prod/sc-portfolio-ec2.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-ec2.yaml"
+template:
+  path: "sc-portfolio-ec2.yaml"
 stack_name: "sc-portfolio-ec2"
 dependencies:
   - "prod/sc-ec2vpc-launchrole.yaml"

--- a/sceptre/scipool/config/prod/sc-portfolio-s3-basic.yaml
+++ b/sceptre/scipool/config/prod/sc-portfolio-s3-basic.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-s3-basic.yaml"
+template:
+  path: "sc-portfolio-s3-basic.yaml"
 stack_name: "sc-portfolio-s3-basic"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-product-assoc-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/prod/sc-product-assoc-ec2-linux-docker.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-linux-docker"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/prod/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-linux-jumpcloud-notebook"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-product-assoc-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/prod/sc-product-assoc-ec2-linux-jumpcloud-workflows.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-linux-jumpcloud-workflows"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-product-assoc-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/prod/sc-product-assoc-ec2-linux-jumpcloud.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-linux-jumpcloud"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/prod/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-windows-jumpcloud"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-docker.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-docker.j2"
+template:
+  path: "sc-product-ec2-linux-docker.j2"
 stack_name: "sc-product-ec2-linux-docker"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-jumpcloud-notebook.j2"
+template:
+  path: "sc-product-ec2-linux-jumpcloud-notebook.j2"
 stack_name: "sc-product-ec2-linux-jumpcloud-notebook"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-jumpcloud-workflows.j2"
+template:
+  path: "sc-product-ec2-linux-jumpcloud-workflows.j2"
 stack_name: "sc-product-ec2-linux-jumpcloud-workflows"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-jumpcloud.j2"
+template:
+  path: "sc-product-ec2-linux-jumpcloud.j2"
 stack_name: "sc-product-ec2-linux-jumpcloud"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml"
+template:
+  path: "sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml"
 stack_name: "sc-product-ec2-linux-notebook-write-to-ssm-policy"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-windows-jumpcloud.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-windows-jumpcloud.j2"
+template:
+  path: "sc-product-ec2-windows-jumpcloud.j2"
 stack_name: "sc-product-ec2-windows-jumpcloud"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/prod/sc-product-s3-private-enc.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-s3-private-enc.j2"
+template:
+  path: "sc-product-s3-private-enc.j2"
 stack_name: "sc-product-s3-private-enc"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/prod/sc-product-s3-synapse.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-s3-synapse.j2"
+template:
+  path: "sc-product-s3-synapse.j2"
 stack_name: "sc-product-s3-synapse"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-s3-launchrole.yaml
+++ b/sceptre/scipool/config/prod/sc-s3-launchrole.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-s3-launchrole.yaml"
+template:
+  path: "sc-s3-launchrole.yaml"
 stack_name: "sc-s3-launchrole"
 dependencies:
   - "prod/essentials.yaml"

--- a/sceptre/scipool/config/prod/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/prod/sc-tag-options-external.yaml
@@ -1,5 +1,6 @@
 # Tag options for External Sage teams
-template_path: "sc-tag-options.j2"
+template:
+  path: "sc-tag-options.j2"
 stack_name: "sc-tag-options-external"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/sc-tag-options.yaml
+++ b/sceptre/scipool/config/prod/sc-tag-options.yaml
@@ -1,5 +1,6 @@
 # Tag options for internal Sage teams
-template_path: "sc-tag-options.j2"
+template:
+  path: "sc-tag-options.j2"
 stack_name: "sc-tag-options"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/synapse-oidc-idp.yaml
+++ b/sceptre/scipool/config/prod/synapse-oidc-idp.yaml
@@ -1,4 +1,6 @@
-template_path: remote/cfn-cr-oidc-idp.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml
 stack_name: synapse-oidc-idp
 stack_tags:
   Department: "Platform"
@@ -8,6 +10,3 @@ parameters:
   Url: "https://repo-prod.prod.sagebase.org/auth/v1"
   ClientIDList: "100053"
   ThumbprintList: "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml -O templates/remote/cfn-cr-oidc-idp.yaml"

--- a/sceptre/scipool/config/prod/tgw-spoke-internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/tgw-spoke-internalpoolvpc.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/transit-gateway-spoke.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml
 stack_name: "tgw-spoke-internalpoolvpc"
 stack_tags:
   Department: "Platform"
@@ -16,6 +18,3 @@ parameters:
     - !stack_output_external internalpoolvpc::PrivateSubnet2
   # shared TGW, https://github.com/Sage-Bionetworks/transit-infra/blob/master/templates/transit-gateway.j2
   TransitGatewayId: "tgw-0004e7e3454cacac5"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/scipool/config/strides/AccountAlertTopics.yaml
+++ b/sceptre/scipool/config/strides/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/AccountAlertTopics.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: "AccountAlertTopics"
 dependencies:
   - "strides/bootstrap.yaml"
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm "/infra/SlackWebhookUrl"
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/scipool/config/strides/alb-notebook-access-logsbucket.yaml
+++ b/sceptre/scipool/config/strides/alb-notebook-access-logsbucket.yaml
@@ -1,2 +1,3 @@
-template_path: alb-notebook-access-logsbucket.yaml
+template:
+  path: alb-notebook-access-logsbucket.yaml
 stack_name: alb-notebook-access-logsbucket

--- a/sceptre/scipool/config/strides/alb-notebook-access.yaml
+++ b/sceptre/scipool/config/strides/alb-notebook-access.yaml
@@ -1,4 +1,5 @@
-template_path: alb-notebook-access.yaml
+template:
+  path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
 dependencies:
   - strides/alb-notebook-access-logsbucket.yaml

--- a/sceptre/scipool/config/strides/bootstrap.yaml
+++ b/sceptre/scipool/config/strides/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: "remote/bootstrap.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: "bootstrap"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/scipool/config/strides/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-alb-rule.yaml
@@ -1,4 +1,6 @@
-template_path: remote/cfn-cr-alb-rule.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml
 stack_name: cfn-cr-alb-rule
 stack_tags:
   Department: "Platform"
@@ -11,6 +13,3 @@ parameters:
   OidcTokenEndpoint: 'https://repo-prod.prod.sagebase.org/auth/v1/oauth2/token'
   OidcUserInfoEndpoint: 'https://repo-prod.prod.sagebase.org/auth/v1/oauth2/userinfo'
   OidcClientId: '100063'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml -O templates/remote/cfn-cr-alb-rule.yaml"

--- a/sceptre/scipool/config/strides/cfn-cr-saml-provider.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-saml-provider.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-saml-provider.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml
 stack_name: cfn-cr-saml-provider
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml -O templates/remote/cfn-cr-saml-provider.yaml"

--- a/sceptre/scipool/config/strides/cfn-cr-sc-actions-provider.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-sc-actions-provider.yaml
@@ -1,4 +1,6 @@
-template_path: remote/cfn-cr-sc-actions-provider.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml
 stack_name: cfn-cr-sc-actions-provider
 stack_tags:
   Department: "Platform"
@@ -6,6 +8,3 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 dependencies:
   - strides/bootstrap.yaml
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml -O templates/remote/cfn-cr-sc-actions-provider.yaml"

--- a/sceptre/scipool/config/strides/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-sc-bucket-policy.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-sc-bucket-policy-1.0.2.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.2/cfn-cr-sc-bucket-policy.yaml
 stack_name: cfn-cr-sc-bucket-policy
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.2/cfn-cr-sc-bucket-policy.yaml -O templates/remote/cfn-cr-sc-bucket-policy-1.0.2.yaml"

--- a/sceptre/scipool/config/strides/cfn-cr-sc-product-provider.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-sc-product-provider.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-sc-product-provider.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-product-provider/1.0.0/cfn-cr-sc-product-provider.yaml
 stack_name: cfn-cr-sc-product-provider
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-product-provider/1.0.0/cfn-cr-sc-product-provider.yaml -O templates/remote/cfn-cr-sc-product-provider.yaml"

--- a/sceptre/scipool/config/strides/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-synapse-tagger.yaml
@@ -1,9 +1,8 @@
-template_path: remote/cfn-cr-synapse-tagger.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml
 stack_name: cfn-cr-synapse-tagger
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml -O templates/remote/cfn-cr-synapse-tagger.yaml"

--- a/sceptre/scipool/config/strides/cfn-macro-ssm-param.yaml
+++ b/sceptre/scipool/config/strides/cfn-macro-ssm-param.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-macro-ssm-param.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml
 stack_name: "cfn-macro-ssm-param"
 dependencies:
   - "strides/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-macro-ssm-param/master/cfn-macro-ssm-param.yaml -O templates/remote/cfn-macro-ssm-param.yaml"

--- a/sceptre/scipool/config/strides/cfn-s3objects-macro.yaml
+++ b/sceptre/scipool/config/strides/cfn-s3objects-macro.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-s3objects-macro.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "strides/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/master/cfn-s3objects-macro.yaml -O templates/remote/cfn-s3objects-macro.yaml"

--- a/sceptre/scipool/config/strides/cfn-ssm-param-policy.yaml
+++ b/sceptre/scipool/config/strides/cfn-ssm-param-policy.yaml
@@ -1,4 +1,5 @@
-template_path: "cfn-ssm-param-policy.yaml"
+template:
+  path: "cfn-ssm-param-policy.yaml"
 stack_name: "cfn-ssm-param-policy"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/cfn-tag-instance-policy.yaml
+++ b/sceptre/scipool/config/strides/cfn-tag-instance-policy.yaml
@@ -1,7 +1,6 @@
-template_path: "remote/cfn-tag-instance-policy.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cfn-tag-instance-policy.yaml
 stack_name: "cfn-tag-instance-policy"
 dependencies:
   - "strides/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cfn-tag-instance-policy.yaml -O templates/remote/cfn-tag-instance-policy.yaml"

--- a/sceptre/scipool/config/strides/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/strides/docker-runner-efs-vpc.yaml
@@ -1,7 +1,6 @@
-template_path: remote/efs-vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/VPC/efs-vpc.yaml
 stack_name: docker-runner-vpc
 dependencies:
   - strides/bootstrap.yaml
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/VPC/efs-vpc.yaml -O templates/remote/efs-vpc.yaml"

--- a/sceptre/scipool/config/strides/essentials.yaml
+++ b/sceptre/scipool/config/strides/essentials.yaml
@@ -1,9 +1,8 @@
-template_path: "remote/essentials.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "strides/bootstrap.yaml"
 parameters:
   VpcPeeringRequesterAwsAccountId: "745159704268"  # org-sagebase-admincentral
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/essentials.yaml -O templates/remote/essentials.yaml"

--- a/sceptre/scipool/config/strides/get-role-policy.yaml
+++ b/sceptre/scipool/config/strides/get-role-policy.yaml
@@ -1,2 +1,3 @@
-template_path: "get-role-policy.yaml"
+template:
+  path: "get-role-policy.yaml"
 stack_name: "get-role-policy"

--- a/sceptre/scipool/config/strides/jumpcloud-idp.yaml
+++ b/sceptre/scipool/config/strides/jumpcloud-idp.yaml
@@ -1,4 +1,5 @@
-template_path: "strides/jumpcloud-idp.yaml"
+template:
+  path: "strides/jumpcloud-idp.yaml"
 stack_name: "jumpcloud-idp"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/lambda-bucket-cleanup.yaml
+++ b/sceptre/scipool/config/strides/lambda-bucket-cleanup.yaml
@@ -1,4 +1,6 @@
-template_path: remote/lambda-sc-bucket-cleanup.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.2/lambda-sc-bucket-cleanup.yaml
 stack_name: lambda-sc-bucket-cleanup
 parameters:
   EnableSchedule: "true"
@@ -6,6 +8,3 @@ stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.2/lambda-sc-bucket-cleanup.yaml -O templates/remote/lambda-sc-bucket-cleanup.yaml"

--- a/sceptre/scipool/config/strides/lambda-budgets.yaml
+++ b/sceptre/scipool/config/strides/lambda-budgets.yaml
@@ -1,4 +1,6 @@
-template_path: remote/lambda-budgets.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml
 stack_name: lambda-budgets
 stack_tags:
   Department: "Platform"
@@ -8,6 +10,3 @@ parameters:
   EndUserRoleName: !stack_output_external sc-enduser-iam::ExternalEndUserRoleName
   BudgetRules: !file_contents templates/strides/lambda-budgets/budget-rules.yaml
   Thresholds: !file_contents templates/strides/lambda-budgets/thresholds.yaml
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml -O templates/remote/lambda-budgets.yaml"

--- a/sceptre/scipool/config/strides/lambda-send-budget-alert.yaml
+++ b/sceptre/scipool/config/strides/lambda-send-budget-alert.yaml
@@ -1,4 +1,6 @@
-template_path: remote/lambda-send-budget-alert.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml
 stack_name: lambda-send-budget-alert
 parameters:
   SNSTopicARN: !stack_output_external lambda-budgets::BudgetMakerNotificationTopicArn
@@ -8,6 +10,3 @@ stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-send-budget-alert/master/lambda-send-budget-alert.yaml -O templates/remote/lambda-send-budget-alert.yaml"

--- a/sceptre/scipool/config/strides/maintenance.yaml
+++ b/sceptre/scipool/config/strides/maintenance.yaml
@@ -1,9 +1,8 @@
-template_path: remote/maintenance.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml
 stack_name: prod-default-maintenance-window
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/maintenance.yaml -O templates/remote/maintenance.yaml"

--- a/sceptre/scipool/config/strides/peer-vpn-stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/peer-vpn-stridespoolvpc.yaml
@@ -1,4 +1,6 @@
-template_path: remote/peer-route-config.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml
 stack_name: peer-vpn-stridespoolvpc
 dependencies:
   - strides/stridespoolvpc.yaml
@@ -7,6 +9,3 @@ parameters:
   VpcPrivateRouteTable: !stack_output_external stridespoolvpc::PrivateRouteTable
   VpcPublicRouteTable: !stack_output_external stridespoolvpc::PublicRouteTable
   VpnCidr: !stack_output_external stridespoolvpc::VpnCidr      # org-sagebase-admincentral sophos-utm VPN CIDR
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/scipool/config/strides/rotate-credentials.yaml
+++ b/sceptre/scipool/config/strides/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/rotate-credentials.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: "rotate-credentials"
 dependencies:
   - "strides/bootstrap.yaml"
@@ -7,6 +9,3 @@ parameters:
   SendEmail: "true"
   SenderEmail: "it@sagebase.org"
   SendReport: "true"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/scipool/config/strides/s3-stridespoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/strides/s3-stridespoolvpc-gateway-endpoint.yaml
@@ -1,10 +1,9 @@
-template_path: remote/gateway-vpc-endpoint.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml
 stack_name: s3-stridespoolvpc-gateway-endpoint
 dependencies:
   - strides/stridespoolvpc.yaml
 parameters:
   VpcName: stridespoolvpc
   ServiceName: com.amazonaws.us-east-1.s3
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml -O templates/remote/gateway-vpc-endpoint.yaml"

--- a/sceptre/scipool/config/strides/sc-ec2-actions.yaml
+++ b/sceptre/scipool/config/strides/sc-ec2-actions.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-actions.yaml"
+template:
+  path: "sc-ec2-actions.yaml"
 stack_name: "sc-ec2-actions"
 dependencies:
   - "strides/sc-enduser-iam.yaml"

--- a/sceptre/scipool/config/strides/sc-ec2vpc-launchrole.yaml
+++ b/sceptre/scipool/config/strides/sc-ec2vpc-launchrole.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2vpc-launchrole.yaml"
+template:
+  path: "sc-ec2vpc-launchrole.yaml"
 stack_name: "sc-ec2vpc-launchrole"
 dependencies:
   - "strides/essentials.yaml"

--- a/sceptre/scipool/config/strides/sc-enduser-iam.yaml
+++ b/sceptre/scipool/config/strides/sc-enduser-iam.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-enduser-iam.yaml"
+template:
+  path: "sc-enduser-iam.yaml"
 stack_name: "sc-enduser-iam"
 dependencies:
   - "strides/essentials.yaml"

--- a/sceptre/scipool/config/strides/sc-kms-key.yaml
+++ b/sceptre/scipool/config/strides/sc-kms-key.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-kms-key.yaml"
+template:
+  path: "sc-kms-key.yaml"
 stack_name: "sc-kms-key"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-portfolio-ec2-external.yaml
+++ b/sceptre/scipool/config/strides/sc-portfolio-ec2-external.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-ec2-external.yaml"
+template:
+  path: "sc-portfolio-ec2-external.yaml"
 stack_name: "sc-portfolio-ec2-external"
 dependencies:
   - "strides/sc-ec2vpc-launchrole.yaml"

--- a/sceptre/scipool/config/strides/sc-portfolio-ec2.yaml
+++ b/sceptre/scipool/config/strides/sc-portfolio-ec2.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-ec2.yaml"
+template:
+  path: "sc-portfolio-ec2.yaml"
 stack_name: "sc-portfolio-ec2"
 dependencies:
   - "strides/sc-ec2vpc-launchrole.yaml"

--- a/sceptre/scipool/config/strides/sc-portfolio-s3-basic.yaml
+++ b/sceptre/scipool/config/strides/sc-portfolio-s3-basic.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-s3-basic.yaml"
+template:
+  path: "sc-portfolio-s3-basic.yaml"
 stack_name: "sc-portfolio-s3-basic"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-product-assoc-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/strides/sc-product-assoc-ec2-linux-docker.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-linux-docker"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/strides/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-linux-jumpcloud-notebook"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-product-assoc-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/strides/sc-product-assoc-ec2-linux-jumpcloud-workflows.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-linux-jumpcloud-workflows"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-product-assoc-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/strides/sc-product-assoc-ec2-linux-jumpcloud.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-linux-jumpcloud"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/strides/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-ec2-action-associations.yaml"
+template:
+  path: "sc-ec2-action-associations.yaml"
 stack_name: "sc-product-assoc-ec2-windows-jumpcloud"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-docker.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-docker.j2"
+template:
+  path: "sc-product-ec2-linux-docker.j2"
 stack_name: "sc-product-ec2-linux-docker"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-jumpcloud-notebook.j2"
+template:
+  path: "sc-product-ec2-linux-jumpcloud-notebook.j2"
 stack_name: "sc-product-ec2-linux-jumpcloud-notebook"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-jumpcloud-workflows.j2"
+template:
+  path: "sc-product-ec2-linux-jumpcloud-workflows.j2"
 stack_name: "sc-product-ec2-linux-jumpcloud-workflows"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-jumpcloud.j2"
+template:
+  path: "sc-product-ec2-linux-jumpcloud.j2"
 stack_name: "sc-product-ec2-linux-jumpcloud"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml"
+template:
+  path: "sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml"
 stack_name: "sc-product-ec2-linux-notebook-write-to-ssm-policy"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-windows-jumpcloud.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-ec2-windows-jumpcloud.j2"
+template:
+  path: "sc-product-ec2-windows-jumpcloud.j2"
 stack_name: "sc-product-ec2-windows-jumpcloud"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/strides/sc-product-s3-private-enc.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-s3-private-enc.j2"
+template:
+  path: "sc-product-s3-private-enc.j2"
 stack_name: "sc-product-s3-private-enc"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/strides/sc-product-s3-synapse.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-product-s3-synapse.j2"
+template:
+  path: "sc-product-s3-synapse.j2"
 stack_name: "sc-product-s3-synapse"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-s3-launchrole.yaml
+++ b/sceptre/scipool/config/strides/sc-s3-launchrole.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-s3-launchrole.yaml"
+template:
+  path: "sc-s3-launchrole.yaml"
 stack_name: "sc-s3-launchrole"
 dependencies:
   - "strides/essentials.yaml"

--- a/sceptre/scipool/config/strides/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/strides/sc-tag-options-external.yaml
@@ -1,5 +1,6 @@
 # Tag options for External Sage teams
-template_path: "sc-tag-options.j2"
+template:
+  path: "sc-tag-options.j2"
 stack_name: "sc-tag-options-external"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/sc-tag-options.yaml
+++ b/sceptre/scipool/config/strides/sc-tag-options.yaml
@@ -1,5 +1,6 @@
 # Tag options for internal Sage teams
-template_path: "sc-tag-options.j2"
+template:
+  path: "sc-tag-options.j2"
 stack_name: "sc-tag-options"
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/stridespoolvpc.yaml
@@ -1,10 +1,9 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: stridespoolvpc
 dependencies:
   - strides/bootstrap.yaml
 parameters:
   VpcSubnetPrefix: "10.49"
   VpcName: stridespoolvpc
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/scipool/config/strides/synapse-oidc-idp.yaml
+++ b/sceptre/scipool/config/strides/synapse-oidc-idp.yaml
@@ -1,4 +1,6 @@
-template_path: remote/cfn-cr-oidc-idp.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml
 stack_name: synapse-oidc-idp
 stack_tags:
   Department: "Platform"
@@ -8,6 +10,3 @@ parameters:
   Url: "https://repo-prod.prod.sagebase.org/auth/v1"
   ClientIDList: "100063"
   ThumbprintList: "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml -O templates/remote/cfn-cr-oidc-idp.yaml"

--- a/sceptre/scipool/config/strides/tgw-spoke-stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/tgw-spoke-stridespoolvpc.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/transit-gateway-spoke.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml
 stack_name: "tgw-spoke-stridespoolvpc"
 stack_tags:
   Department: "Platform"
@@ -16,6 +18,3 @@ parameters:
     - !stack_output_external stridespoolvpc::PrivateSubnet2
   # shared TGW, https://github.com/Sage-Bionetworks/transit-infra/blob/master/templates/transit-gateway.j2
   TransitGatewayId: "tgw-0004e7e3454cacac5"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"


### PR DESCRIPTION
Sceptre has template handlers[1] now so we can abandon the use of
hooks in favor of the http template handler to get templates
from our shared template repository. This is only to update
scipool accounts.

[1] https://sceptre.cloudreach.com/dev/docs/template_handlers.html#template-handlers

