### PR TITLE
SC-318 using new AMI in R-Studio notebook product

### DIFF
--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -73,7 +73,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.21'
-    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
+    - Description: 'Add instance types x2gd, g4dn, and i3en.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.22'
+    - Description: 'Allow more simultaneously open files. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.26/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.1.26'


### PR DESCRIPTION
This PR updates the R-Studio notebook product to use a new packer-generated AMI which incorporates an increase in the limit of concurrently open files allowed by the Linux o/s.
