### PR TITLE
[IT-1478] deploy cost anomaly detector services

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -1,0 +1,18 @@
+Parameters:
+  <<: !Include '../_parameters.yaml'
+
+AnomalyDetectorServices:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.3/templates/Cost/anomaly-detector-services.yaml
+  StackName: !Sub '${resourcePrefix}-anomaly-detector-services'
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+    Account: '*'
+    Region: !Ref primaryRegion
+  Parameters:
+    Subscribers: [
+      {
+        "Type": "EMAIL",
+        "Address": !GetAtt CurrentAccount.RootEmail
+      }
+    ]

--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -1,18 +1,13 @@
 Parameters:
   <<: !Include '../_parameters.yaml'
 
-AnomalyDetectorServices:
+AnomalyDetectorService:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.3/templates/Cost/anomaly-detector-services.yaml
-  StackName: !Sub '${resourcePrefix}-anomaly-detector-services'
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.3/templates/Cost/anomaly-detector-service.yaml
+  StackName: !Sub '${resourcePrefix}-anomaly-detector-service'
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'
     Region: !Ref primaryRegion
   Parameters:
-    Subscribers: [
-      {
-        "Type": "EMAIL",
-        "Address": !GetAtt CurrentAccount.RootEmail
-      }
-    ]
+    Subscriber: !GetAtt CurrentAccount.RootEmail

--- a/org-formation/_tasks.yaml
+++ b/org-formation/_tasks.yaml
@@ -21,6 +21,11 @@ Budgets:
   DependsOn: [ Types ]
   Path: ./040-budgets/_tasks.yaml
 
+Costs:
+  Type: include
+  DependsOn: [ Types ]
+  Path: ./050-costs/_tasks.yaml
+
 Cloudtrail:
   Type: include
   DependsOn: [ Types ]

--- a/sceptre/strides/config/prod/anomaly-detector-service.yaml
+++ b/sceptre/strides/config/prod/anomaly-detector-service.yaml
@@ -1,0 +1,6 @@
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.3/Cost/anomaly-detector-service.yaml
+stack_name: anomaly-detector-service
+parameters:
+  Subscriber: aws.strides@sagebase.org


### PR DESCRIPTION
Setup AWS cost anomaly detection on every account to get notifications
of unforeseen cost changes.  Notifications are sent to account owner email
lists.  This will hopefully help prevent situations where accounts are racking
up big costs without anybody knowing.

depends on https://github.com/Sage-Bionetworks/aws-infra/pull/325