### PR TITLE
[IT-1331] replace hooks with template handler

### DIFF
--- a/sceptre/bridge/config/develop/essentials.yaml
+++ b/sceptre/bridge/config/develop/essentials.yaml
@@ -1,4 +1,5 @@
-template_path: essentials.yaml
+template:
+  path: essentials.yaml
 stack_name: essentials
 dependencies:
   - develop/bootstrap.yaml

--- a/sceptre/bridge/config/develop/iam-policies.yaml
+++ b/sceptre/bridge/config/develop/iam-policies.yaml
@@ -1,4 +1,5 @@
-template_path: iam-policies.yaml
+template:
+  path: iam-policies.yaml
 stack_name: iam-policies
 dependencies:
   - develop/essentials.yaml

--- a/sceptre/bridge/config/prod/AccountAlertTopics.yaml
+++ b/sceptre/bridge/config/prod/AccountAlertTopics.yaml
@@ -1,4 +1,6 @@
-template_path: remote/AccountAlertTopics.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml
 stack_name: AccountAlertTopics
 dependencies:
   - prod/bootstrap.yaml
@@ -9,6 +11,3 @@ parameters:
   DeployLambda: "true"
   SlackWebhookURL: !ssm /infra/SlackWebhookUrl
   SlackChannel: "#infra-notices"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/AccountAlertTopics.yaml -O templates/remote/AccountAlertTopics.yaml"

--- a/sceptre/bridge/config/prod/BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/BridgeServer2-vpc.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: remote/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml
 stack_name: BridgeServer2-vpc
 dependencies:
   - prod/bootstrap.yaml

--- a/sceptre/bridge/config/prod/BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/BridgeServer2-vpc.yaml
@@ -1,10 +1,9 @@
-template_path: remote/vpc.yaml
+template:
+  type: http
+  url: remote/vpc.yaml
 stack_name: BridgeServer2-vpc
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   VpcName: BridgeServer2-vpc
   VpcSubnetPrefix: "172.32"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/vpc.yaml -O templates/remote/vpc.yaml"

--- a/sceptre/bridge/config/prod/bootstrap.yaml
+++ b/sceptre/bridge/config/prod/bootstrap.yaml
@@ -1,5 +1,4 @@
-template_path: remote/bootstrap.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: bootstrap
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml -O templates/remote/bootstrap.yaml"

--- a/sceptre/bridge/config/prod/bridge.yaml
+++ b/sceptre/bridge/config/prod/bridge.yaml
@@ -1,4 +1,5 @@
-template_path: bridge.yaml
+template:
+  path: bridge.yaml
 stack_name: bridge
 dependencies:
   - prod/essentials.yaml

--- a/sceptre/bridge/config/prod/essentials.yaml
+++ b/sceptre/bridge/config/prod/essentials.yaml
@@ -1,4 +1,5 @@
-template_path: essentials.yaml
+template:
+  path: essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml

--- a/sceptre/bridge/config/prod/iam-policies.yaml
+++ b/sceptre/bridge/config/prod/iam-policies.yaml
@@ -1,4 +1,5 @@
-template_path: iam-policies.yaml
+template:
+  path: iam-policies.yaml
 stack_name: iam-policies
 dependencies:
   - prod/essentials.yaml

--- a/sceptre/bridge/config/prod/peer-vpn-BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/peer-vpn-BridgeServer2-vpc.yaml
@@ -1,4 +1,5 @@
-template_path: remote/peer-route-config.yaml
+template:
+  path: remote/peer-route-config.yaml
 stack_name: peer-vpn-BridgeServer2-vpc
 dependencies:
   - prod/BridgeServer2-vpc.yaml

--- a/sceptre/bridge/config/prod/peer-vpn-BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/peer-vpn-BridgeServer2-vpc.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml 
+  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml
 stack_name: peer-vpn-BridgeServer2-vpc
 dependencies:
   - prod/BridgeServer2-vpc.yaml

--- a/sceptre/bridge/config/prod/peer-vpn-BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/peer-vpn-BridgeServer2-vpc.yaml
@@ -1,5 +1,6 @@
 template:
-  path: remote/peer-route-config.yaml
+  type: http
+  path: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml 
 stack_name: peer-vpn-BridgeServer2-vpc
 dependencies:
   - prod/BridgeServer2-vpc.yaml
@@ -8,6 +9,3 @@ parameters:
   VpcPublicRouteTable: rtb-03ea8549c4444bf3a
   VpcPrivateRouteTable: rtb-0e8854efafd1cb53f
   VpnCidr: 10.1.0.0/16
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/peer-route-config.yaml -O templates/remote/peer-route-config.yaml"

--- a/sceptre/bridge/config/prod/peer-vpn-bridge-prod.yaml
+++ b/sceptre/bridge/config/prod/peer-vpn-bridge-prod.yaml
@@ -1,4 +1,5 @@
-template_path: peer-route-config-defaultvpc.yaml
+template:
+  path: peer-route-config-defaultvpc.yaml
 stack_name: peer-vpn-bridge-prod
 dependencies:
   - prod/bridge.yaml

--- a/sceptre/bridge/config/prod/rotate-credentials.yaml
+++ b/sceptre/bridge/config/prod/rotate-credentials.yaml
@@ -1,4 +1,6 @@
-template_path: remote/rotate-credentials.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml
 stack_name: rotate-credentials
 dependencies:
   - prod/bootstrap.yaml
@@ -7,6 +9,3 @@ parameters:
   SendEmail: 'true'
   SenderEmail: 'it@sagebase.org'
   SendReport: 'true'
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/rotate-credentials/master/rotate-credentials.yaml -O templates/remote/rotate-credentials.yaml"

--- a/sceptre/bridge/config/prod/tgw-spoke-BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/tgw-spoke-BridgeServer2-vpc.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml 
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml
 stack_name: "tgw-spoke-BridgeServer2-vpc"
 stack_tags:
   Department: "Platform"

--- a/sceptre/bridge/config/prod/tgw-spoke-BridgeServer2-vpc.yaml
+++ b/sceptre/bridge/config/prod/tgw-spoke-BridgeServer2-vpc.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/transit-gateway-spoke.yaml"
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml 
 stack_name: "tgw-spoke-BridgeServer2-vpc"
 stack_tags:
   Department: "Platform"
@@ -16,6 +18,3 @@ parameters:
     - !stack_output_external BridgeServer2-vpc::PrivateSubnet2
   # shared TGW, https://github.com/Sage-Bionetworks/transit-infra/blob/master/templates/transit-gateway.j2
   TransitGatewayId: "tgw-0004e7e3454cacac5"
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/transit-gateway-spoke.yaml -O templates/remote/transit-gateway-spoke.yaml"

--- a/sceptre/sageit/config/staging/staging-csbc-pson-s3web.yaml
+++ b/sceptre/sageit/config/staging/staging-csbc-pson-s3web.yaml
@@ -1,4 +1,6 @@
-template_path: remote/managed-s3WebCloudfront.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/managed-s3WebCloudfront.yaml
 stack_name: staging-csbc-pson-s3webcf
 parameters:
   DomainName: csbc-pson.synapse.org
@@ -7,6 +9,3 @@ parameters:
   Department: Oncology
   Project: CSBC-PSON
   OwnerEmail: michael.lee@sagebionetworks.org
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/managed-s3WebCloudfront.yaml -O templates/remote/managed-s3WebCloudfront.yaml"


### PR DESCRIPTION
Sceptre has template handlers[1] now so we can abandon the use of
hooks in favor of the http template handler to get templates
from our shared template repository. This updates some of the one
we missed from previous updates

[1] https://sceptre.cloudreach.com/dev/docs/template_handlers.html#template-handlers

