### PR TITLE
Remove sceptre identity resolver

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -519,7 +519,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install git+https://github.com/Sceptre/sceptre.git@5c0ab39 sceptre-ssm-resolver
-          pip install git+git://github.com/zaro0508/sceptre-identity-resolver.git
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
Remove the sceptre identity resolver.  This was probably used once
upon a time however there currently is no evidence that we still
need it anynore.

