### PR TITLE
Reduce iAtlas collaborator access

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -23,7 +23,7 @@ iAtlasCollaboratorAccess:
     PrincipalArns:
       - arn:aws:iam::556856096938:user/ebs_automation    # Jon Ryser from GenUI
     ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/AdministratorAccess
+      - arn:aws:iam::aws:policy/ReadOnlyAccess
   DefaultOrganizationBinding:
     IncludeMasterAccount: false
     Account: !Ref iAtlasProdAccount


### PR DESCRIPTION
Our collaborators needed admin access to get the iAtlas app going.
They have successfully done that with PR
https://github.com/Sage-Bionetworks/iAtlas-infra/pull/19

Now we can restrict their access so that only our CI can make updates
to the account again.

