### PR TITLE
[SC-306] Install CFN PyPlate macro

### DIFF
--- a/sceptre/scipool/config/bmgfki/PyPlate.yaml
+++ b/sceptre/scipool/config/bmgfki/PyPlate.yaml
@@ -1,0 +1,4 @@
+template:
+  type: http
+  url: https://raw.githubusercontent.com/awslabs/aws-cloudformation-templates/master/aws/services/CloudFormation/MacrosExamples/PyPlate/python.yaml
+stack_name: PyPlate

--- a/sceptre/scipool/config/develop/PyPlate.yaml
+++ b/sceptre/scipool/config/develop/PyPlate.yaml
@@ -1,0 +1,4 @@
+template:
+  type: http
+  url: https://raw.githubusercontent.com/awslabs/aws-cloudformation-templates/master/aws/services/CloudFormation/MacrosExamples/PyPlate/python.yaml
+stack_name: PyPlate

--- a/sceptre/scipool/config/prod/PyPlate.yaml
+++ b/sceptre/scipool/config/prod/PyPlate.yaml
@@ -1,0 +1,4 @@
+template:
+  type: http
+  url: https://raw.githubusercontent.com/awslabs/aws-cloudformation-templates/master/aws/services/CloudFormation/MacrosExamples/PyPlate/python.yaml
+stack_name: PyPlate

--- a/sceptre/scipool/config/strides/PyPlate.yaml
+++ b/sceptre/scipool/config/strides/PyPlate.yaml
@@ -1,0 +1,4 @@
+template:
+  type: http
+  url: https://raw.githubusercontent.com/awslabs/aws-cloudformation-templates/master/aws/services/CloudFormation/MacrosExamples/PyPlate/python.yaml
+stack_name: PyPlate


### PR DESCRIPTION
Install the cloudformation PyPlate macro[1] which will allow more
flexibility in our cloudformation templates.  Essentially it
will allow us to manipulate input parameters.

[1] https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services/CloudFormation/MacrosExamples/PyPlate/README.md