### PR TITLE
Move SageIT to prod OU after IT-447 resolved

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -63,6 +63,7 @@ Organization:
         - !Ref LogCentralAccount
         - !Ref ImageCentralAccount
         - !Ref SecurityCentralAccount
+        - !Ref SageITAccount
 
   PolicyStagingOU:
     Type: OC::ORG::OrganizationalUnit


### PR DESCRIPTION
The follow up to IT-447 is to move the SageIT account into ITProd