### PR TITLE
Add AWS account for TB Cough Collaboratory

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -150,6 +150,10 @@ Parameters:
     Type: String
     Default: '906769aa66-911ad81b-8331-4670-a8eb-d53c63d6a0e1'
 
+  tbCoughCollabGroup:
+    Type: String
+    Default: TBD # supplied by IT after they add to JC
+
 SsoAdministrator:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
@@ -997,4 +1001,21 @@ SsoCnbAdmin:
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref cnbAdminGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
+
+SsoTbCoughCollabAdmin:
+  Type: update-stacks
+  DependsOn: SsoAdministrator
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.19/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-tb-cough-collab-admin'
+  StackDescription: 'SSO: Administrator role used by TB Cough Collaboratory admin group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref TbCoughCollaboratoryAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref tbCoughCollabGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]

--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -38,6 +38,7 @@ Organization:
         - !Ref WorkflowsNextflowProdAccount
         - !Ref MobileHealthDataEngineeringProdAccount
         - !Ref CnbAccount
+        - !Ref TbCoughCollaboratoryAccount
 
   PlatformOU:
     Type: OC::ORG::OrganizationalUnit
@@ -371,3 +372,16 @@ Organization:
         Project: Infrastructure
         budget-alarm-threshold: 3000
         budget-alarm-threshold-email-recipient: aws-workflows-nextflow-dev@sagebase.org
+
+  TbCoughCollaboratoryAccount:
+    Type: OC::ORG::Account
+    Properties:
+      AccountName: org-sagebase-tb-cough-collab
+      RootEmail: vijay.yadav@sagebase.org
+      Alias: org-sagebase-tb-cough-collab
+      Tags:
+        <<: !Include ./_default_org_tags.yaml
+        Department: IBC
+        Project: tb-cough-collab
+        budget-alarm-threshold: 1000
+        budget-alarm-threshold-email-recipient: vijay.yadav@sagebase.org


### PR DESCRIPTION
This adds an AWS account for the TB Cough Collaboratory project -- primarily for Vijay Yadav.
The intention is to provide a PHI-safe account where Vijay can create Sagemaker instances for model development.
Please see the description in [IBCDPE-21](https://sagebionetworks.jira.com/browse/IBCDPE-21).