### PR TITLE
[IT-1549] Fix AWS config logging to logcentral account

### DIFF
--- a/sceptre/strides/templates/aws-config.yaml
+++ b/sceptre/strides/templates/aws-config.yaml
@@ -73,10 +73,14 @@ Resources:
           Statement:
           - Effect: Allow
             Action: s3:GetBucketAcl
-            Resource: !Sub 'arn:aws:s3:::${S3ConfigBucket}'
+            Resource:
+              - !Sub 'arn:aws:s3:::${S3ConfigBucket}'
+              - !Sub 'arn:aws:s3:::${LogCentralBucket}'
           - Effect: Allow
             Action: s3:PutObject
-            Resource: !Sub 'arn:aws:s3:::${S3ConfigBucket}/AWSLogs/${AWS::AccountId}/*'
+            Resource:
+              - !Sub 'arn:aws:s3:::${S3ConfigBucket}/AWSLogs/${AWS::AccountId}/*'
+              - !Sub 'arn:aws:s3:::${LogCentralBucket}/AWSLogs/${AWS::AccountId}/*'
             Condition:
               StringEquals:
                 s3:x-amz-acl: bucket-owner-full-control


### PR DESCRIPTION
AWS Config from strides account wasn't logging to logcentral
account due to missing permissions.  We also need to give
strides account permissions to write to the central s3 config
bucket in logcentral account.

We are following the pattern established by org-formation which
does work as expected. org-formation patter is defined in
[ConfigurationRecorderRole](https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/Config/config.yaml)

