### PR TITLE
[SC-306] SC scheduled jobs product

### DIFF
--- a/sceptre/scipool/config/develop/sc-portfolio-scheduled-jobs.yaml
+++ b/sceptre/scipool/config/develop/sc-portfolio-scheduled-jobs.yaml
@@ -1,0 +1,8 @@
+template_path: "sc-portfolio-scheduled-jobs.yaml"
+stack_name: "sc-portfolio-scheduled-jobs"
+dependencies:
+  - "develop/sc-lambda-launchrole.yaml"
+  - "develop/sc-enduser-iam.yaml"
+parameters:
+  PorfolioName: "Sage Scheduled Jobs Porfolio"
+  PorfolioDescription: "Products for Sage Bionetworks staff"

--- a/sceptre/scipool/config/develop/sc-portfolio-scheduled-jobs.yaml
+++ b/sceptre/scipool/config/develop/sc-portfolio-scheduled-jobs.yaml
@@ -1,7 +1,7 @@
 template_path: "sc-portfolio-scheduled-jobs.yaml"
 stack_name: "sc-portfolio-scheduled-jobs"
 dependencies:
-  - "develop/sc-lambda-launchrole.yaml"
+  - "develop/sc-scheduled-jobs-launchrole.yaml"
   - "develop/sc-enduser-iam.yaml"
 parameters:
   PorfolioName: "Sage Scheduled Jobs Porfolio"

--- a/sceptre/scipool/config/develop/sc-product-scheduled-jobs.yaml
+++ b/sceptre/scipool/config/develop/sc-product-scheduled-jobs.yaml
@@ -1,0 +1,10 @@
+template_path: "sc-product-scheduled-jobs.yaml"
+stack_name: "sc-product-scheduled-jobs"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "develop/sc-portfolio-scheduled-jobs.yaml"
+parameters:
+  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}"

--- a/sceptre/scipool/config/develop/sc-scheduled-jobs-launchrole.yaml
+++ b/sceptre/scipool/config/develop/sc-scheduled-jobs-launchrole.yaml
@@ -1,0 +1,4 @@
+template_path: "sc-scheduled-jobs-launchrole.yaml"
+stack_name: "sc-scheduled-jobs-launchrole"
+dependencies:
+  - "develop/essentials.yaml"

--- a/sceptre/scipool/config/develop/sc-tag-options.yaml
+++ b/sceptre/scipool/config/develop/sc-tag-options.yaml
@@ -10,9 +10,11 @@ dependencies:
   - "develop/sc-portfolio-ec2.yaml"
   - "develop/sc-portfolio-ec2-external.yaml"
   - "develop/sc-portfolio-s3-basic.yaml"
+  - "develop/sc-portfolio-scheduled-jobs.yaml"
 sceptre_user_data:
   Departments: !file sc-tag-options/internal/Departments.json
   Projects: !file sc-tag-options/internal/Projects.json
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId
+    - !stack_output_external sc-portfolio-scheduled-jobs::SCScheduledJobsPortfolioId

--- a/sceptre/scipool/templates/sc-portfolio-scheduled-jobs.yaml
+++ b/sceptre/scipool/templates/sc-portfolio-scheduled-jobs.yaml
@@ -8,11 +8,11 @@ Parameters:
   PorfolioName:
     Type: String
     Description: Portfolio Name
-    Default: Lambda Portfolio
+    Default: Scheduled Jobs Portfolio
   PorfolioDescription:
     Type: String
     Description: Portfolio Description
-    Default: Portfolio of Lambda products
+    Default: Portfolio of Scheduled Jobs products
 Resources:
   SCScheduledJobsPortfolio:
     Type: AWS::ServiceCatalog::Portfolio

--- a/sceptre/scipool/templates/sc-portfolio-scheduled-jobs.yaml
+++ b/sceptre/scipool/templates/sc-portfolio-scheduled-jobs.yaml
@@ -1,0 +1,34 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Scheduled Jobs Portfolio for Service Catalog
+Parameters:
+  PortfolioProvider:
+    Type: String
+    Description: Provider Name
+    Default: Sage Bionetworks
+  PorfolioName:
+    Type: String
+    Description: Portfolio Name
+    Default: Lambda Portfolio
+  PorfolioDescription:
+    Type: String
+    Description: Portfolio Description
+    Default: Portfolio of Lambda products
+Resources:
+  SCScheduledJobsPortfolio:
+    Type: AWS::ServiceCatalog::Portfolio
+    Properties:
+      ProviderName: !Ref 'PortfolioProvider'
+      Description: !Ref 'PorfolioDescription'
+      DisplayName: !Ref 'PorfolioName'
+  LinkEndusersRole:
+    Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
+    Properties:
+      PrincipalARN: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-enduser-iam-ServiceCatalogEndusers-RoleArn'
+      PortfolioId: !Ref 'SCScheduledJobsPortfolio'
+      PrincipalType: IAM
+Outputs:
+  SCScheduledJobsPortfolioId:
+    Value: !Ref SCScheduledJobsPortfolio
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SCScheduledJobsPortfolioId'

--- a/sceptre/scipool/templates/sc-product-scheduled-jobs.yaml
+++ b/sceptre/scipool/templates/sc-product-scheduled-jobs.yaml
@@ -23,7 +23,7 @@ Resources:
       ProvisioningArtifactParameters:
         - Description: Baseline version. Last updated
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.27/lambda/docker-runner.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.27/batch/sc-batch-fargate.yaml'
           Name: 'v1.1.27'
       'Fn::Transform':
         Name: 'AWS::Include'
@@ -34,17 +34,17 @@ Resources:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:
       PortfolioId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-sc-portfolio-lambda-SCLambdaPortfolioId'
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-scheduled-jobs-SCScheduledJobsPortfolioId'
       ProductId: !Ref 'ScheduledJobsProduct'
   ConstrainAccess:
     Type: AWS::ServiceCatalog::LaunchRoleConstraint
     DependsOn: AssociatePortfolio
     Properties:
       PortfolioId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-sc-portfolio-lambda-SCLambdaPortfolioId'
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-scheduled-jobs-SCScheduledJobsPortfolioId'
       ProductId: !Ref 'ScheduledJobsProduct'
       RoleArn: !ImportValue
-        'Fn::Sub': '${AWS::Region}-sc-lambda-launchrole-LaunchRoleArn'
+        'Fn::Sub': '${AWS::Region}-sc-scheduled-jobs-launchrole-LaunchRoleArn'
 Outputs:
   ProductId:
     Value: !Ref 'ScheduledJobsProduct'

--- a/sceptre/scipool/templates/sc-product-scheduled-jobs.yaml
+++ b/sceptre/scipool/templates/sc-product-scheduled-jobs.yaml
@@ -1,0 +1,52 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Scheduled Jobs ServiceCatalog product
+Parameters:
+  RepoRootURL:
+    Type: String
+    Description: Root url for the repo containing the product templates.
+  ProductName:
+    Type: String
+    Description: Name of the product that will be visible to the end user
+    Default: 'Scheduled Jobs'
+Resources:
+  ScheduledJobsProduct:
+    Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002  # missing `owner` property error -> it's inside of included products.yaml
+            - E3003  # invalid property `Fn::Transform` error -> cfn-lint bug
+    Properties:
+      Name: !Ref ProductName
+      Description: "This product provisions AWS batch to execute scheduled jobs"
+      ProvisioningArtifactParameters:
+        - Description: Baseline version. Last updated
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.27/lambda/docker-runner.yaml'
+          Name: 'v1.1.27'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          # source: https://github.com/Sage-Bionetworks/admincentral-infra/blob/master/templates/cfn-snippets-bucket.yaml
+          Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipool/products.yaml"
+  AssociatePortfolio:
+    Type: AWS::ServiceCatalog::PortfolioProductAssociation
+    Properties:
+      PortfolioId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-lambda-SCLambdaPortfolioId'
+      ProductId: !Ref 'ScheduledJobsProduct'
+  ConstrainAccess:
+    Type: AWS::ServiceCatalog::LaunchRoleConstraint
+    DependsOn: AssociatePortfolio
+    Properties:
+      PortfolioId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-lambda-SCLambdaPortfolioId'
+      ProductId: !Ref 'ScheduledJobsProduct'
+      RoleArn: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-lambda-launchrole-LaunchRoleArn'
+Outputs:
+  ProductId:
+    Value: !Ref 'ScheduledJobsProduct'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ProductId'

--- a/sceptre/scipool/templates/sc-scheduled-jobs-launchrole.yaml
+++ b/sceptre/scipool/templates/sc-scheduled-jobs-launchrole.yaml
@@ -7,6 +7,7 @@ Resources:
       RoleName: SCScheduledJobsLaunchRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonLambdaFullAccess
+        - arn:aws:iam::aws:policy/AWSBatchFullAccess
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/sceptre/scipool/templates/sc-scheduled-jobs-launchrole.yaml
+++ b/sceptre/scipool/templates/sc-scheduled-jobs-launchrole.yaml
@@ -1,0 +1,69 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: "ServiceCatalog Scheduled Jobs launch role"
+Resources:
+  SCScheduledJobsLaunchRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: SCScheduledJobsLaunchRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonLambdaFullAccess
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - servicecatalog.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: SCLaunchPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: SCLaunchPolicySID
+                Effect: Allow
+                Action:
+                  - "servicecatalog:ListServiceActionsForProvisioningArtifact"
+                  - "servicecatalog:ExecuteprovisionedProductServiceAction"
+                  - "iam:AddRoleToInstanceProfile"
+                  - "iam:ListRolePolicies"
+                  - "iam:ListPolicies"
+                  - "iam:DeleteRole"
+                  - "iam:GetRole"
+                  - "iam:CreateInstanceProfile"
+                  - "iam:PassRole"
+                  - "iam:DeleteInstanceProfile"
+                  - "iam:ListRoles"
+                  - "iam:RemoveRoleFromInstanceProfile"
+                  - "iam:CreateRole"
+                  - "iam:DetachRolePolicy"
+                  - "iam:AttachRolePolicy"
+                  - "iam:TagRole"
+                  - "cloudformation:DescribeStackResource"
+                  - "cloudformation:DescribeStackResources"
+                  - "cloudformation:GetTemplate"
+                  - "cloudformation:List*"
+                  - "cloudformation:DescribeStackEvents"
+                  - "cloudformation:DescribeStacks"
+                  - "cloudformation:CreateStack"
+                  - "cloudformation:DeleteStack"
+                  - "cloudformation:DescribeStackEvents"
+                  - "cloudformation:DescribeStacks"
+                  - "cloudformation:GetTemplateSummary"
+                  - "cloudformation:SetStackPolicy"
+                  - "cloudformation:ValidateTemplate"
+                  - "cloudformation:UpdateStack"
+                  - "cloudformation:*ChangeSet*"
+                  - "s3:GetObject"
+                Resource: '*'
+Outputs:
+  LaunchRoleArn:
+    Value: !GetAtt SCScheduledJobsLaunchRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-LaunchRoleArn'
+  LaunchRoleName:
+    Value: !Ref SCScheduledJobsLaunchRole
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-LaunchRoleName'


### PR DESCRIPTION
Add a scheduled jobs product to the service catalog.  Setup the product
in a new portfolio with a separate role so we can conditionally give
different users access to this product.

depends on PR https://github.com/Sage-Bionetworks/service-catalog-library/pull/264 https://github.com/Sage-Bionetworks/service-catalog-library/pull/266

