### PR TITLE
Remove VPC for EFS

### DIFF
--- a/sceptre/scipool/config/bmgfki/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/bmgfki/docker-runner-efs-vpc.yaml
@@ -1,6 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/VPC/efs-vpc.yaml
-stack_name: docker-runner-vpc
-dependencies:
-  - bmgfki/bootstrap.yaml

--- a/sceptre/scipool/config/develop/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/develop/docker-runner-efs-vpc.yaml
@@ -1,6 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/VPC/efs-vpc.yaml
-stack_name: docker-runner-vpc
-dependencies:
-  - develop/bootstrap.yaml

--- a/sceptre/scipool/config/prod/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/prod/docker-runner-efs-vpc.yaml
@@ -1,6 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/VPC/efs-vpc.yaml
-stack_name: docker-runner-vpc
-dependencies:
-  - prod/bootstrap.yaml

--- a/sceptre/scipool/config/strides/docker-runner-efs-vpc.yaml
+++ b/sceptre/scipool/config/strides/docker-runner-efs-vpc.yaml
@@ -1,6 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/VPC/efs-vpc.yaml
-stack_name: docker-runner-vpc
-dependencies:
-  - strides/bootstrap.yaml


### PR DESCRIPTION
This reverts PR #102.  We are no longer using lambda therefore
we no longer need EFS.

