### PR TITLE
Deploy CI service account to sandbox

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -70,6 +70,7 @@ WorkflowsNextflowCIServiceAccounts:
     Account:
       - !Ref WorkflowsNextflowProdAccount
       - !Ref WorkflowsNextflowDevAccount
+      - !Ref SandboxAccount
     Region: us-east-1
 
 # Service accounts for https://github.com/Sage-Bionetworks-Workflows/aws-workflows-nextflow-infra


### PR DESCRIPTION
I would like to create a CI service account in sandbox to test the deployment of workflows into an AWS account that isn't one of our two Nextflow accounts. These credentials will be added to our [nextflow-infra repository](https://github.com/Sage-Bionetworks-Workflows/nextflow-infra) as secrets and used for Sceptre deployment. 

Alternatively, if the AMP-AD STRIDES account can be bootstrapped ([IT-1536](https://sagebionetworks.jira.com/browse/IT-1536)), I can test the deployment there instead. 