### PR TITLE
[IT-306] Give SC users access to cloudwatch logs

### DIFF
--- a/sceptre/scipool/templates/sc-enduser-iam.yaml
+++ b/sceptre/scipool/templates/sc-enduser-iam.yaml
@@ -10,6 +10,7 @@ Resources:
       RoleName: ServiceCatalogEndusers
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AWSServiceCatalogEndUserFullAccess
+        - arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess
         - !Ref SCEnduserExpandedPolicy
         - !Ref ScCloudformationPolicy
         - !Ref SCEnduserRemoteAccessPolicy


### PR DESCRIPTION
We setup batch to send cron job logs to cloudwatch logs therefore we
need to give SC users read only access to cloudwatch logs so they view
logs from their jobs.