### PR TITLE
[IT-1536] Setup org-sagebase-strides-ampad-workflows AWS Account

### DIFF
--- a/org-formation/070-guard-duty/_tasks.yaml
+++ b/org-formation/070-guard-duty/_tasks.yaml
@@ -50,8 +50,10 @@ GuardDuty:
     resourcePrefix: !Ref resourcePrefix
     accountId: !Ref accountId
 
-# one off association for Guardduty in org-sagebase-strides account because it's not in the Sage ORG
-# the other half of this Guardduty association is in ../sceptre/strides
+# ==================================================================================================
+# one off associations for Guardduty in AWS accounts that are not in the Sage ORG
+
+# For org-sagebase-strides, the other half of this Guardduty association is in ../sceptre/strides
 GuardDutyConnectStrides:
   Type: update-stacks
   Template: ./GuardDutyExternalConnect.yaml
@@ -66,6 +68,23 @@ GuardDutyConnectStrides:
     MemberAccountId: "423819316185"           # org-sagebase-strides
     MemberRootEmail: "aws.strides@sagebase.org"
     MasterDectector: !CopyValue [ !Sub '${resourcePrefix}-${appName}-detector-id' ]
+
+# For org-sagebase-strides-ampad-workflows, the other half of this Guardduty association is in ../sceptre/strides-ampad-workflows
+GuardDutyConnectStridesAmpadWorkflows:
+  Type: update-stacks
+  Template: ./GuardDutyExternalConnect.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-connect-stridesampadworkflows'
+  StackDescription: Associate an external Guardduty member account
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+    Account:
+      - !Ref accountId
+  Parameters:
+    MemberAccountId: "751556145034"           # strides-ampad-workflows
+    MemberRootEmail: "aws.strides-ampad-workflows@sagebase.org"
+    MasterDectector: !CopyValue [ !Sub '${resourcePrefix}-${appName}-detector-id' ]
+# ==================================================================================================
 
 # bucket that contains the trusted IP addresses that are excluded from GuardDuty findings
 GuardDutyTrustedIpsBucket:

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -129,8 +129,8 @@ CnbCIServiceAccount:
     Region: !Ref primaryRegion
 
 # =====================================================================================================
-# Some of our accounts, like org-sagebase-strides, are not part of the Sage organziation therefore we need
-# to manage them as external entities. To allow strides account to send cloudtrail and config artifcats to
+# Some of our accounts, like org-sagebase-strides, are not part of the Sage organization therefore we need
+# to manage them as external entities. To allow strides account to send cloudtrail and config artifacts to
 # logcentral account we need to setup external access to the master buckets.
 AwsCloudtrailExternalAccountAccess:
   Type: update-stacks
@@ -140,6 +140,7 @@ AwsCloudtrailExternalAccountAccess:
     cloudtrail_bucket: sagebase-cloudtrail-231505186444
     accounts:
       - "423819316185"    # org-sagebase-strides
+      - "751556145034"    # org-sagebase-strides-ampad-workflows
   DefaultOrganizationBinding:
     IncludeMasterAccount: false
     Account:
@@ -154,6 +155,7 @@ AwsConfigExternalAccountAccess:
     config_bucket: sagebase-config-231505186444
     accounts:
       - "423819316185"    # org-sagebase-strides
+      - "751556145034"    # org-sagebase-strides-ampad-workflows
   DefaultOrganizationBinding:
     IncludeMasterAccount: false
     Account:


### PR DESCRIPTION
We need to setup some snowflake infra for the
org-sagebase-strides-ampad-workflows account because it's not
under our org account.  This sets up master member configuration
for guard duty, AWS config, and cloudtrail.