### PR TITLE
increase SMS alarm from $24 to $72

### DIFF
--- a/sceptre/bridge/templates/bridge.yaml
+++ b/sceptre/bridge/templates/bridge.yaml
@@ -227,7 +227,7 @@ Resources:
       AlarmActions:
         - !Ref AWSSNSSmsTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 24
+      Threshold: 72
       EvaluationPeriods: 1
       MetricName: SMSMonthToDateSpentUSD
       Namespace: AWS/SNS


### PR DESCRIPTION
PR Checklist:
[X] Describe and explain your intentions for this change - We recently increased our SMS spending threshold from $30 to $90. This corresponding change increases our alarm from $24 to $72.
[X] Setup pre-commit and run the validators (info in README.md)