### PR TITLE
import cfn template for strides

### DIFF
--- a/sceptre/strides/config/prod/bootstrap-cross-account-role.yaml
+++ b/sceptre/strides/config/prod/bootstrap-cross-account-role.yaml
@@ -1,0 +1,8 @@
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.4/IAM/org-cross-account-role.yaml
+stack_name: "bootstrap-cross-account-role"
+dependencies:
+  - "prod/bootstrap.yaml"
+parameters:
+  MasterAccountId: "531805629419"  # org-sagebase-organizations


### PR DESCRIPTION
There is a CFN template deployed into org-sagebase-strides account
however it's not in CI/CD.  We add the CFN template here to make
it consistent and to allow us to automate those AWS resources.

