### PR TITLE
Deploy CI service account for STRIDES AMP-AD acct

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -75,7 +75,7 @@ HtanDevCIServiceAccount:
 
 WorkflowsNextflowCIServiceAccounts:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.2/templates/IAM/service-account.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.4/templates/IAM/service-account.yaml
   StackName: workflows-nextflow-ci-service-account
   Parameters:
     ManagedPolicyArns:
@@ -85,6 +85,8 @@ WorkflowsNextflowCIServiceAccounts:
     Account:
       - !Ref WorkflowsNextflowProdAccount
       - !Ref WorkflowsNextflowDevAccount
+      # Also deployed by Sceptre for the following non-member accounts:
+      # sceptre/strides-ampad-workflows/config/prod/workflows-nextflow-ci-service-account.yaml
     Region: us-east-1
 
 # Service accounts for https://github.com/Sage-Bionetworks-Workflows/aws-workflows-nextflow-infra

--- a/sceptre/strides-ampad-workflows/config/prod/workflows-nextflow-ci-service-account.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/workflows-nextflow-ci-service-account.yaml
@@ -1,0 +1,8 @@
+# Configured like WorkflowsNextflowCIServiceAccounts in org-formation/600-access/_tasks.yaml
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.4/templates/IAM/service-account.yaml
+stack_name: "workflows-nextflow-ci-service-account"
+parameters:
+  ManagedPolicyArns:
+    - arn:aws:iam::aws:policy/AdministratorAccess


### PR DESCRIPTION
I'll be deploying to the `strides-ampad-workflows` AWS account from our [nextflow-infra](https://github.com/Sage-Bionetworks-Workflows/nextflow-infra) repository. This CI service account will be used by the [GitHub Actions workflow](https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/blob/bgrande/WORKFLOWS-85/test-sandbox-tower-project/.github/workflows/aws-deploy.yaml) to deploy infrastructure for running Nextflow workflows in `strides-ampad-workflows`. 