### PR TITLE
Remove budget alerts in favor of granular alerts

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -356,8 +356,6 @@ Organization:
         <<: !Include ./_default_org_tags.yaml
         Department: IBC
         Project: Infrastructure
-        budget-alarm-threshold: 3000
-        budget-alarm-threshold-email-recipient: aws-workflows-nextflow-prod@sagebase.org
 
   WorkflowsNextflowDevAccount:
     Type: OC::ORG::Account
@@ -369,5 +367,3 @@ Organization:
         <<: !Include ./_default_org_tags.yaml
         Department: IBC
         Project: Infrastructure
-        budget-alarm-threshold: 3000
-        budget-alarm-threshold-email-recipient: aws-workflows-nextflow-dev@sagebase.org

--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -356,6 +356,8 @@ Organization:
         <<: !Include ./_default_org_tags.yaml
         Department: IBC
         Project: Infrastructure
+        # More granular budget alerts (compute, storage, and other) deployed here:
+        # https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/tree/main/config/common
 
   WorkflowsNextflowDevAccount:
     Type: OC::ORG::Account
@@ -367,3 +369,5 @@ Organization:
         <<: !Include ./_default_org_tags.yaml
         Department: IBC
         Project: Infrastructure
+        # More granular budget alerts (compute, storage, and other) deployed here:
+        # https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/tree/main/config/common


### PR DESCRIPTION
We have deployed more granular budget alerts on the AWS account here:
https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/tree/main/config/common

As a result, it's no longer useful to have a budget alert set in organizations-infra. It's better for us to adjust alerts in one place as our expectations for monthly costs change. 