### PR TITLE
Give SC community manager access to AWS support

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -842,6 +842,7 @@ SsoScipoolDevCommunityManager:
     instanceArn: !Ref instanceArn
     principalId: !Ref scipoolDevCommunityManagerGroup
     permissionSetName: 'Community-Manager'
+    managedPolicies: [ 'arn:aws:iam::aws:policy/AWSSupportAccess' ]
     sessionDuration: 'PT12H'
     inlinePolicy: >-
       {

--- a/sceptre/strides/templates/jumpcloud-idp.yaml
+++ b/sceptre/strides/templates/jumpcloud-idp.yaml
@@ -56,6 +56,7 @@ Resources:
       RoleName: !GetAtt StridesCommunityMgrSamlProvider.Name
       ManagedPolicyArns:
         - !Ref AWSIAMCommunityMgrAccessPolicy
+        - "arn:aws:iam::aws:policy/AWSSupportAccess"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
Sometimes the Service Catalog community manager wants to submit support tickets
to AWS because they have questions regarding the SC account that they
manage.  This will give all SC community managers access to submit AWS
support tickets.
