### PR TITLE
Remove `templates/` from S3 URL

### DIFF
--- a/sceptre/strides-ampad-workflows/config/prod/workflows-nextflow-ci-service-account.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/workflows-nextflow-ci-service-account.yaml
@@ -1,7 +1,7 @@
 # Configured like WorkflowsNextflowCIServiceAccounts in org-formation/600-access/_tasks.yaml
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.4/templates/IAM/service-account.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.4/IAM/service-account.yaml
 stack_name: "workflows-nextflow-ci-service-account"
 parameters:
   ManagedPolicyArns:


### PR DESCRIPTION
I copy-pasted the GitHub URL and changed it to the S3 bucket, but `templates/` isn't part of the key in S3. 