### PR TITLE
[SC-306] update SC scheduled jobs product

### DIFF
--- a/sceptre/scipool/config/develop/sc-product-scheduled-jobs.yaml
+++ b/sceptre/scipool/config/develop/sc-product-scheduled-jobs.yaml
@@ -10,7 +10,11 @@ dependencies:
 sceptre_user_data:
   # force cloudformation to update stack by setting a random number to the latest product's description
   ProvisioningArtifactParameters: |
-    - Description: 'Baseline version. {{ range(1, 10000) | random }}'
+    - Description: 'Baseline version.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.28/batch/sc-batch-fargate.yaml'
       Name: 'v1.1.28'
+    - Description: 'Make parameters required. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.29/batch/sc-batch-fargate.yaml'
+      Name: 'v1.1.29'


### PR DESCRIPTION
This includes changes in
PR https://github.com/Sage-Bionetworks/service-catalog-library/pull/267
which will make the parameters in the service catalog
Scheduled jobs product a required field.

