### PR TITLE
[SC-306] Allow SC users to view jobs

### DIFF
--- a/sceptre/scipool/templates/sc-enduser-iam.yaml
+++ b/sceptre/scipool/templates/sc-enduser-iam.yaml
@@ -14,6 +14,7 @@ Resources:
         - !Ref SCEnduserExpandedPolicy
         - !Ref ScCloudformationPolicy
         - !Ref SCEnduserRemoteAccessPolicy
+        - !Ref BatchReadOnlyPolicy
       Path: /
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -56,6 +57,19 @@ Resources:
               - organizations:DescribeOrganization
               - servicecatalog:DescribeProvisionedProduct
               - cloudwatch:GetMetricData  # access to EC2 monitoring info
+            Resource: "*"
+  BatchReadOnlyPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Read only access to AWS batch
+      Path: "/"
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - "batch:Describe*"
+              - "batch:List*"
             Resource: "*"
   SCEnduserRemoteAccessPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
With the addition of a batch product users should be able
to view their batch jobs ocnce it's been provisioned.  This
gives all SC end users permission to view batch jobs using
the AWS console.
