### PR TITLE
[SC-373] Add a cost center tag option

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-tag-options-external.yaml
@@ -13,5 +13,6 @@ dependencies:
 sceptre_user_data:
   Departments: !file sc-tag-options/external/Departments.json
   Projects: !file sc-tag-options/external/Projects.json
+  CostCenters: [ "Not Applicable / 000000" ]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/sceptre/scipool/config/bmgfki/sc-tag-options.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-tag-options.yaml
@@ -13,7 +13,7 @@ dependencies:
 sceptre_user_data:
   Departments: !file sc-tag-options/internal/Departments.json
   Projects: !file sc-tag-options/internal/Projects.json
-  CostCenters: !file https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.6/tags/SageFinancialProgramCodes.json
+  CostCenters: [ "Not Applicable / 000000" ]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/sceptre/scipool/config/bmgfki/sc-tag-options.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-tag-options.yaml
@@ -13,6 +13,7 @@ dependencies:
 sceptre_user_data:
   Departments: !file sc-tag-options/internal/Departments.json
   Projects: !file sc-tag-options/internal/Projects.json
+  CostCenters: !file https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.6/tags/SageFinancialProgramCodes.json
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/sceptre/scipool/config/develop/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/develop/sc-tag-options-external.yaml
@@ -13,5 +13,6 @@ dependencies:
 sceptre_user_data:
   Departments: !file sc-tag-options/external/Departments.json
   Projects: !file sc-tag-options/external/Projects.json
+  CostCenters: [ "Not Applicable / 000000" ]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/sceptre/scipool/config/develop/sc-tag-options.yaml
+++ b/sceptre/scipool/config/develop/sc-tag-options.yaml
@@ -14,6 +14,7 @@ dependencies:
 sceptre_user_data:
   Departments: !file sc-tag-options/internal/Departments.json
   Projects: !file sc-tag-options/internal/Projects.json
+  CostCenters: !file https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.6/tags/SageFinancialProgramCodes.json
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/sceptre/scipool/config/prod/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/prod/sc-tag-options-external.yaml
@@ -13,5 +13,6 @@ dependencies:
 sceptre_user_data:
   Departments: !file sc-tag-options/external/Departments.json
   Projects: !file sc-tag-options/external/Projects.json
+  CostCenters: [ "Not Applicable / 000000" ]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/sceptre/scipool/config/prod/sc-tag-options.yaml
+++ b/sceptre/scipool/config/prod/sc-tag-options.yaml
@@ -13,6 +13,7 @@ dependencies:
 sceptre_user_data:
   Departments: !file sc-tag-options/internal/Departments.json
   Projects: !file sc-tag-options/internal/Projects.json
+  CostCenters: !file https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.6/tags/SageFinancialProgramCodes.json
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/sceptre/scipool/config/strides/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/strides/sc-tag-options-external.yaml
@@ -13,5 +13,6 @@ dependencies:
 sceptre_user_data:
   Departments: !file sc-tag-options/external/Departments.json
   Projects: !file sc-tag-options/external/Projects.json
+  CostCenters: [ "Not Applicable / 000000" ]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/sceptre/scipool/config/strides/sc-tag-options.yaml
+++ b/sceptre/scipool/config/strides/sc-tag-options.yaml
@@ -13,7 +13,7 @@ dependencies:
 sceptre_user_data:
   Departments: !file sc-tag-options/internal/Departments.json
   Projects: !file sc-tag-options/internal/Projects.json
-  CostCenters: !file https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.6/tags/SageFinancialProgramCodes.json
+  CostCenters: [ "Not Applicable / 000000" ]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/sceptre/scipool/config/strides/sc-tag-options.yaml
+++ b/sceptre/scipool/config/strides/sc-tag-options.yaml
@@ -13,6 +13,7 @@ dependencies:
 sceptre_user_data:
   Departments: !file sc-tag-options/internal/Departments.json
   Projects: !file sc-tag-options/internal/Projects.json
+  CostCenters: !file https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.6/tags/SageFinancialProgramCodes.json
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/sceptre/scipool/templates/sc-tag-options.j2
+++ b/sceptre/scipool/templates/sc-tag-options.j2
@@ -2,7 +2,7 @@ Description: Tag options for for service catalog products
 AWSTemplateFormatVersion: 2010-09-09
 Resources:
 {% for department in sceptre_user_data.Departments %}
-  {{ department.replace('.','').replace('-','').replace('_','').replace('/','') }}DepartmentTag:
+  {{ department.replace(' ','').replace('.','').replace('-','').replace('_','').replace('/','') }}DepartmentTag:
     Type: AWS::ServiceCatalog::TagOption
     Properties:
       Active: true
@@ -10,7 +10,7 @@ Resources:
       Value: {{ department }}
 {% endfor %}
 {% for project in sceptre_user_data.Projects %}
-  {{ project.replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag:
+  {{ project.replace(' ','').replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag:
     Type: AWS::ServiceCatalog::TagOption
     Properties:
       Active: true
@@ -18,33 +18,55 @@ Resources:
       Value: {{ project }}
 {% endfor %}
 
+{% for CostCenter in sceptre_user_data.CostCenters %}
+  {{ CostCenter.replace(' ','').replace('+','').replace('.','').replace('-','').replace('_','').replace('/','') }}CostCenterTag:
+    Type: AWS::ServiceCatalog::TagOption
+    Properties:
+      Active: true
+      Key: "CostCenter"
+      Value: {{ CostCenter }}
+{% endfor %}
+
 {% for id in sceptre_user_data.ProductIDs %}
   {% for department in sceptre_user_data.Departments %}
-  {{ department.replace('.','').replace('-','').replace('_','').replace('/','') }}TagAssociationProd{{ id.split('-')[1] }}:
+  {{ department.replace(' ','').replace('.','').replace('-','').replace('_','').replace('/','') }}TagAssociationProd{{ id.split('-')[1] }}:
     Type: AWS::ServiceCatalog::TagOptionAssociation
     Properties:
       ResourceId: "{{ id }}"
-      TagOptionId: !Ref "{{ department.replace('.','').replace('-','').replace('_','').replace('/','') }}DepartmentTag"
+      TagOptionId: !Ref "{{ department.replace(' ','').replace('.','').replace('-','').replace('_','').replace('/','') }}DepartmentTag"
   {% endfor %}
   {% for project in sceptre_user_data.Projects %}
-  {{ project.replace('.','').replace('-','').replace('_','').replace('/','') }}TagAssociationProd{{ id.split('-')[1] }}:
+  {{ project.replace(' ','').replace('.','').replace('-','').replace('_','').replace('/','') }}TagAssociationProd{{ id.split('-')[1] }}:
     Type: AWS::ServiceCatalog::TagOptionAssociation
     Properties:
       ResourceId: "{{ id }}"
-      TagOptionId: !Ref "{{ project.replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag"
+      TagOptionId: !Ref "{{ project.replace(' ','').replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag"
+  {% endfor %}
+  {% for CostCenter in sceptre_user_data.CostCenters %}
+  {{ CostCenter.replace(' ','').replace('+','').replace('.','').replace('-','').replace('_','').replace('/','') }}TagAssociationProd{{ id.split('-')[1] }}:
+    Type: AWS::ServiceCatalog::TagOptionAssociation
+    Properties:
+      ResourceId: "{{ id }}"
+      TagOptionId: !Ref "{{ CostCenter.replace(' ','').replace('+','').replace('.','').replace('-','').replace('_','').replace('/','') }}CostCenterTag"
   {% endfor %}
 {% endfor %}
 
 Outputs:
 {% for department in sceptre_user_data.Departments %}
-  {{ department.replace('.','').replace('-','').replace('_','').replace('/','') }}DepartmentTag:
-    Value: !Ref "{{ department.replace('.','').replace('-','').replace('_','').replace('/','') }}DepartmentTag"
+  {{ department.replace(' ','').replace('.','').replace('-','').replace('_','').replace('/','') }}DepartmentTag:
+    Value: !Ref "{{ department.replace(' ','').replace('.','').replace('-','').replace('_','').replace('/','') }}DepartmentTag"
     Export:
-      Name: !Sub "${AWS::Region}-${AWS::StackName}-{{ department.replace('.','').replace('-','').replace('_','').replace('/','') }}DepartmentTag"
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-{{ department.replace(' ','').replace('.','').replace('-','').replace('_','').replace('/','') }}DepartmentTag"
 {% endfor %}
 {% for project in sceptre_user_data.Projects %}
-  {{ project.replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag:
-    Value: !Ref "{{ project.replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag"
+  {{ project.replace(' ','').replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag:
+    Value: !Ref "{{ project.replace(' ','').replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag"
     Export:
-      Name: !Sub "${AWS::Region}-${AWS::StackName}-{{ project.replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag"
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-{{ project.replace(' ','').replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag"
+{% endfor %}
+{% for CostCenter in sceptre_user_data.CostCenters %}
+  {{ CostCenter.replace(' ','').replace('+','').replace('.','').replace('-','').replace('_','').replace('/','') }}CostCenterTag:
+    Value: !Ref "{{ CostCenter.replace(' ','').replace('+','').replace('.','').replace('-','').replace('_','').replace('/','') }}CostCenterTag"
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-{{ CostCenter.replace(' ','').replace('+','').replace('.','').replace('-','').replace('_','').replace('/','') }}CostCenterTag"
 {% endfor %}


### PR DESCRIPTION
Add a service catalog CostCenter tag.  It is a required tag so users
will need to pick one cost center from the list when provisioning SC
products.  The source of the cost center tags are in the
aws-infra repo[1].

[1] https://github.com/Sage-Bionetworks/aws-infra/blob/master/templates/tags/SageFinancialProgramCodes.json
