### PR TITLE
[SC-379] Update batch tagger lambda

### DIFF
--- a/sceptre/scipool/config/bmgfki/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-cr-synapse-tagger.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.1/cfn-cr-synapse-tagger.yaml
 stack_name: cfn-cr-synapse-tagger
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-synapse-tagger.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.1/cfn-cr-synapse-tagger.yaml
 stack_name: cfn-cr-synapse-tagger
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-synapse-tagger.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.1/cfn-cr-synapse-tagger.yaml
 stack_name: cfn-cr-synapse-tagger
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-synapse-tagger.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.0/cfn-cr-synapse-tagger.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.1/cfn-cr-synapse-tagger.yaml
 stack_name: cfn-cr-synapse-tagger
 stack_tags:
   Department: "Platform"


### PR DESCRIPTION
Update the batch tagger lambda with new release. The new
release contains a workaround for the issue where SC tags
are not propogated to batch resources.

depends on https://github.com/Sage-Bionetworks-IT/cfn-cr-synapse-tagger/pull/30

