### PR TITLE
Remove explode macro

### DIFF
--- a/sceptre/sandbox/config/prod/cfn-explode-macro.yaml
+++ b/sceptre/sandbox/config/prod/cfn-explode-macro.yaml
@@ -1,6 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-explode-macro/master/cfn-explode-macro.yaml
-stack_name: "cfn-explode-macro"
-dependencies:
-  - "prod/bootstrap.yaml"


### PR DESCRIPTION
This macro was installed for testing.  We've determined that
it is not useful and it's not used anywhere so we are removing it.

