### PR TITLE
increase SMS alarm from $72 to $96

### DIFF
--- a/sceptre/bridge/templates/bridge.yaml
+++ b/sceptre/bridge/templates/bridge.yaml
@@ -227,7 +227,7 @@ Resources:
       AlarmActions:
         - !Ref AWSSNSSmsTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 72
+      Threshold: 96
       EvaluationPeriods: 1
       MetricName: SMSMonthToDateSpentUSD
       Namespace: AWS/SNS


### PR DESCRIPTION
Our SMS usage has increased from $90 to $120. We need to increase the alarm threshold proportionately. See https://sagebionetworks.jira.com/browse/BRIDGE-3197

PR Checklist:
[X] Describe and explain your intentions for this change
[X] Setup pre-commit and run the validators (info in README.md)
