### PR TITLE
[SC-306] Update SC launch role for Scheduled Jobs product

### DIFF
--- a/sceptre/scipool/templates/sc-scheduled-jobs-launchrole.yaml
+++ b/sceptre/scipool/templates/sc-scheduled-jobs-launchrole.yaml
@@ -8,6 +8,14 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AWSLambdaExecute
         - arn:aws:iam::aws:policy/AWSBatchFullAccess
+        - arn:aws:iam::aws:policy/AmazonEC2FullAccess
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
+        - arn:aws:iam::aws:policy/AmazonAPIGatewayAdministrator
+        - arn:aws:iam::aws:policy/AWSBatchFullAccess
+        - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
+        - arn:aws:iam::aws:policy/AWSLambda_FullAccess
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -31,6 +39,7 @@ Resources:
                   - "iam:AddRoleToInstanceProfile"
                   - "iam:ListRolePolicies"
                   - "iam:ListPolicies"
+                  - "iam:ListPolicyVersions"
                   - "iam:DeleteRole"
                   - "iam:GetRole"
                   - "iam:CreateInstanceProfile"
@@ -39,25 +48,15 @@ Resources:
                   - "iam:ListRoles"
                   - "iam:RemoveRoleFromInstanceProfile"
                   - "iam:CreateRole"
+                  - "iam:CreatePolicy"
                   - "iam:DetachRolePolicy"
                   - "iam:AttachRolePolicy"
+                  - "iam:DeletePolicy"
                   - "iam:TagRole"
-                  - "cloudformation:DescribeStackResource"
-                  - "cloudformation:DescribeStackResources"
-                  - "cloudformation:GetTemplate"
-                  - "cloudformation:List*"
-                  - "cloudformation:DescribeStackEvents"
-                  - "cloudformation:DescribeStacks"
-                  - "cloudformation:CreateStack"
-                  - "cloudformation:DeleteStack"
-                  - "cloudformation:DescribeStackEvents"
-                  - "cloudformation:DescribeStacks"
-                  - "cloudformation:GetTemplateSummary"
-                  - "cloudformation:SetStackPolicy"
-                  - "cloudformation:ValidateTemplate"
-                  - "cloudformation:UpdateStack"
-                  - "cloudformation:*ChangeSet*"
-                  - "s3:GetObject"
+                  - "secretsmanager:CreateSecret"
+                  - "secretsmanager:TagResource"
+                  - "secretsmanager:DeleteSecret"
+                  - "events:*"
                 Resource: '*'
 Outputs:
   LaunchRoleArn:

--- a/sceptre/scipool/templates/sc-scheduled-jobs-launchrole.yaml
+++ b/sceptre/scipool/templates/sc-scheduled-jobs-launchrole.yaml
@@ -13,7 +13,6 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonS3FullAccess
         - arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
         - arn:aws:iam::aws:policy/AmazonAPIGatewayAdministrator
-        - arn:aws:iam::aws:policy/AWSBatchFullAccess
         - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
         - arn:aws:iam::aws:policy/AWSLambda_FullAccess
       AssumeRolePolicyDocument:


### PR DESCRIPTION
The role used to deploy the scheduled jobs products requires more access
because it deploys a batch trigger lambda nested inside of the product.
AWS recommends providing more extensive permissions[1] when deploying
lambdas.

[1] https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-permissions.html
