### PR TITLE
Pin cfn-cr-sc-actions-provider

### DIFF
--- a/sceptre/scipool/config/bmgfki/cfn-cr-sc-actions-provider.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-cr-sc-actions-provider.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/0.1.0/cfn-cr-sc-actions-provider.yaml
 stack_name: cfn-cr-sc-actions-provider
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/cfn-cr-sc-actions-provider.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-sc-actions-provider.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/0.1.0/cfn-cr-sc-actions-provider.yaml
 stack_name: cfn-cr-sc-actions-provider
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/cfn-cr-sc-actions-provider.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-sc-actions-provider.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/0.1.0/cfn-cr-sc-actions-provider.yaml
 stack_name: cfn-cr-sc-actions-provider
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/cfn-cr-sc-actions-provider.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-sc-actions-provider.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-actions-provider/0.1.0/cfn-cr-sc-actions-provider.yaml
 stack_name: cfn-cr-sc-actions-provider
 stack_tags:
   Department: "Platform"


### PR DESCRIPTION
Make the service catalog pin to a specific version of
the cfn-cr-sc-actions-provider[1] lambda

depends on https://github.com/Sage-Bionetworks-IT/cfn-cr-sc-actions-provider/pull/16

[1] https://github.com/Sage-Bionetworks-IT/cfn-cr-sc-actions-provider

