### PR TITLE
Pin lambda-budgets

### DIFF
--- a/sceptre/scipool/config/bmgfki/lambda-budgets.yaml
+++ b/sceptre/scipool/config/bmgfki/lambda-budgets.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/0.1.0/lambda-budgets.yaml
 stack_name: lambda-budgets
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/lambda-budgets.yaml
+++ b/sceptre/scipool/config/develop/lambda-budgets.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/0.1.0/lambda-budgets.yaml
 stack_name: lambda-budgets
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/lambda-budgets.yaml
+++ b/sceptre/scipool/config/prod/lambda-budgets.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/0.1.0/lambda-budgets.yaml
 stack_name: lambda-budgets
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/lambda-budgets.yaml
+++ b/sceptre/scipool/config/strides/lambda-budgets.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/0.1.0/lambda-budgets.yaml
 stack_name: lambda-budgets
 stack_tags:
   Department: "Platform"


### PR DESCRIPTION
Make the service catalog pin to a specific version of
the lambda-budgets[1] lambda

depends on https://github.com/Sage-Bionetworks-IT/lambda-budgets/pull/12

[1] https://github.com/Sage-Bionetworks-IT/lambda-budgets

