### PR TITLE
Pin cfn-cr-alb-rule

### DIFF
--- a/sceptre/scipool/config/bmgfki/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-cr-alb-rule.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/0.1.0/cfn-cr-alb-rule.yaml
 stack_name: cfn-cr-alb-rule
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/0.1.0/cfn-cr-alb-rule.yaml
 stack_name: cfn-cr-alb-rule
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-alb-rule.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/0.1.0/cfn-cr-alb-rule.yaml
 stack_name: cfn-cr-alb-rule
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-alb-rule.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/master/cfn-cr-alb-rule.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/0.1.0/cfn-cr-alb-rule.yaml
 stack_name: cfn-cr-alb-rule
 stack_tags:
   Department: "Platform"


### PR DESCRIPTION
Make the service catalog pin to a specific version of
the cfn-cr-alb-rule[1] custom resource

depends on https://github.com/Sage-Bionetworks-IT/cfn-cr-alb-rule/pull/7

[1] https://github.com/Sage-Bionetworks-IT/cfn-cr-alb-rule

