### PR TITLE
Update security auditor access

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -250,6 +250,7 @@ SsoAuditor:
     permissionSetName: 'Auditor'
     managedPolicies: [ 'arn:aws:iam::aws:policy/SecurityAudit' ]
     sessionDuration: 'PT1H'
+    masterAccountId: !Ref MasterAccount
 
 SsoViewer:
   Type: update-stacks


### PR DESCRIPTION
Give our security auditor access to the Sage Organizations
account with the auditor access role.

