### PR TITLE
PLFM-7169: Remove  IAM users from Synapse Prod account

### DIFF
--- a/sceptre/synapseprod/templates/accounts.yaml
+++ b/sceptre/synapseprod/templates/accounts.yaml
@@ -10,60 +10,6 @@ Resources:
   # 1. Detach or remove the following user resources: login profile, attached
   #    MFA device, access-keys, ssh-keys, and policies.
   # 2. Detach the user from all groups.
-  AWSIAMXavierSchildwachterUser:
-    Type: 'AWS::IAM::User'
-    Properties:
-      UserName: x.schildwachter@sagebase.org
-      Groups:
-        - !Ref AWSIAMAllUsersGroup
-        - !Ref AWSIAMDeveloperUsersGroup
-        - !Ref AWSIAMBillingManagersGroup
-      LoginProfile:
-        Password: !Ref InitNewUserPassword
-        PasswordResetRequired: true
-  AWSIAMKhaiDoUser:
-    Type: 'AWS::IAM::User'
-    Properties:
-      UserName: khai.do@sagebase.org
-      Groups:
-        - !Ref AWSIAMAllUsersGroup
-        - !Ref AWSIAMDeveloperUsersGroup
-        - !Ref AWSIAMBillingManagersGroup
-      LoginProfile:
-        Password: !Ref InitNewUserPassword
-        PasswordResetRequired: true
-  AWSIAMBruceHoffUser:
-    Type: 'AWS::IAM::User'
-    Properties:
-      UserName: bruce.hoff@sagebase.org
-      Groups:
-        - !Ref AWSIAMAllUsersGroup
-        - !Ref AWSIAMDeveloperUsersGroup
-        - !Ref AWSIAMBillingManagersGroup
-        - !Ref AWSIAMAnalyticsUsersGroup
-      LoginProfile:
-        Password: !Ref InitNewUserPassword
-        PasswordResetRequired: true
-  AWSIAMJayHodgsonUser:
-    Type: 'AWS::IAM::User'
-    Properties:
-      UserName: jay.hodgson@sagebase.org
-      Groups:
-        - !Ref AWSIAMAllUsersGroup
-        - !Ref AWSIAMDeveloperUsersGroup
-      LoginProfile:
-        Password: !Ref InitNewUserPassword
-        PasswordResetRequired: true
-  AWSIAMJohnHillUser:
-    Type: 'AWS::IAM::User'
-    Properties:
-      UserName: john.hill@sagebase.org
-      Groups:
-        - !Ref AWSIAMAllUsersGroup
-        - !Ref AWSIAMDeveloperUsersGroup
-      LoginProfile:
-        Password: !Ref InitNewUserPassword
-        PasswordResetRequired: true
   AWSIAMSynapseEmergencyUser:
     Type: 'AWS::IAM::User'
     Properties:
@@ -71,28 +17,6 @@ Resources:
       Groups:
         - !Ref AWSIAMAllUsersGroup
         - !Ref AWSIAMDeveloperUsersGroup
-      LoginProfile:
-        Password: !Ref InitNewUserPassword
-        PasswordResetRequired: true
-  AWSIAMNickGrosenbacherUser:
-    Type: 'AWS::IAM::User'
-    Properties:
-      UserName: nick.grosenbacher@sagebase.org
-      Groups:
-        - !Ref AWSIAMAllUsersGroup
-        - !Ref AWSIAMDeveloperUsersGroup
-        - !Ref AWSIAMWebEngineerUsersGroup
-      LoginProfile:
-        Password: !Ref InitNewUserPassword
-        PasswordResetRequired: true
-  AWSIAMMarcoMarascaUser:
-    Type: 'AWS::IAM::User'
-    Properties:
-      UserName: marco.marasca@sagebase.org
-      Groups:
-        - !Ref AWSIAMAllUsersGroup
-        - !Ref AWSIAMDeveloperUsersGroup
-        - !Ref AWSIAMAnalyticsUsersGroup
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true

--- a/sceptre/synapseprod/templates/accounts.yaml
+++ b/sceptre/synapseprod/templates/accounts.yaml
@@ -47,8 +47,6 @@ Resources:
             Effect: "Allow"
             Principal:
               AWS:
-                - !GetAtt AWSIAMXavierSchildwachterUser.Arn
-                - !GetAtt AWSIAMKhaiDoUser.Arn
                 - !GetAtt AWSIAMSynapseEmergencyUser.Arn
             Action:
               - "sts:AssumeRole"


### PR DESCRIPTION
Developers should have required access through AWS SSO / JC. Per comment in template, **do not merge** until we have cleaned up the users (MFA etc.). Leaving groups etc in place in case we need to revert.