### PR TITLE
[IT-1235] Setup redirect for new AWS Sage VPN

### DIFF
--- a/sceptre/sageit/config/prod/vpn-sageit-org-redirector.yaml
+++ b/sceptre/sageit/config/prod/vpn-sageit-org-redirector.yaml
@@ -17,4 +17,4 @@ parameters:
   # the endpoint we are redirecting to (AWS VPN client self service)
   TargetHostName: "self-service.clientvpn.amazonaws.com"
   # and a path to our specific config
-  TargetKey: "endpoints/cvpn-endpoint-055bd9db65af09d63"
+  TargetKey: "endpoints/cvpn-endpoint-0343fb9e37fbbd1f0"


### PR DESCRIPTION
The Sage VPN was recreated.  We update the redirect to point to the new
location.  The new location is at https://self-service.clientvpn.amazonaws.com/endpoints/cvpn-endpoint-0343fb9e37fbbd1f0

depends on PR https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/375

