### PR TITLE
[IT-1621] Enable aws guard duty on all accounts

### DIFF
--- a/org-formation/070-guard-duty/_tasks.yaml
+++ b/org-formation/070-guard-duty/_tasks.yaml
@@ -22,30 +22,24 @@ GuardDuty:
     LogArchiveBinding:
       Account: !Ref LogCentralAccount
     MemberBinding:
-      Account:
-        - !Ref TransitAccount
-        - !Ref AdminCentralAccount
-        - !Ref ImageCentralAccount
       OrganizationalUnit:
         - !Ref BridgeOU
         - !Ref ServiceCatalogOU
         - !Ref ScienceDevOU
         - !Ref ScienceProdOU
         - !Ref SynapseOU
-      IncludeMasterAccount: false
+        - !Ref ItProdOU
+      IncludeMasterAccount: true
     AllBinding:
       Account:
-        - !Ref accountId
-        - !Ref TransitAccount
-        - !Ref AdminCentralAccount
-        - !Ref ImageCentralAccount
       OrganizationalUnit:
         - !Ref BridgeOU
         - !Ref ServiceCatalogOU
         - !Ref ScienceDevOU
         - !Ref ScienceProdOU
         - !Ref SynapseOU
-      IncludeMasterAccount: false
+        - !Ref ItProdOU
+      IncludeMasterAccount: true
   Parameters:
     resourcePrefix: !Ref resourcePrefix
     accountId: !Ref accountId


### PR DESCRIPTION
Run the AWS guardduty service on all accounts and have them
report back to the guardduty hub (logcentral).

