### PR TITLE
increase SMS alarm from $96 to $192

### DIFF
--- a/sceptre/bridge/templates/bridge.yaml
+++ b/sceptre/bridge/templates/bridge.yaml
@@ -227,7 +227,7 @@ Resources:
       AlarmActions:
         - !Ref AWSSNSSmsTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 96
+      Threshold: 192
       EvaluationPeriods: 1
       MetricName: SMSMonthToDateSpentUSD
       Namespace: AWS/SNS


### PR DESCRIPTION
To support MindKind launch, we have increased our SMS spending threshold from $120 to $240. We need to increase the alarm threshold proportionately, from $96 to $192.

PR Checklist:
[X] Describe and explain your intentions for this change
[ ] Setup pre-commit and run the validators (info in README.md)