### PR TITLE
[IT-1234] Fix VPN full tunnel option

### DIFF
--- a/org-formation/720-client-vpn/_tasks.yaml
+++ b/org-formation/720-client-vpn/_tasks.yaml
@@ -52,6 +52,7 @@ Vpn:
       - !Sub '!ImportValue ${resourcePrefix}-tgw-${vpnVpc}-SubnetA'
       - !Sub '!ImportValue ${resourcePrefix}-tgw-${vpnVpc}-SubnetB'
       - !Sub '!ImportValue ${resourcePrefix}-tgw-${vpnVpc}-SubnetC'
+      - !Sub '!ImportValue ${resourcePrefix}-tgw-${vpnVpc}-SubnetD'
     TgwSpokes:
       # "10.50.0.0/16" (unionstationvpc) route automatically setup by the VPN endpoint association
       # AccessGroups values must match Jumpcloud User Group names


### PR DESCRIPTION
We've noticed that when we disable VPN split tunnel there is no outbound
route to the internet when connected with the AWS VPN client.  When the split
tunnel option is enabled then the internet works fine.

I believe the problem is that when we enable full tunnel (disable split
tunnel) all outbound traffic goes thru the VPN and since the VPN is currently
only associated to private subnets there is no outbound routes to the internet.

To fix this issue we need to add a public subnet with a NAT to the VPN to allow
an outbound route to the internet.
