### PR TITLE
CFN Deploy stacks in parallel

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Validate ofn templates
         run: npm run validate-tasks
       - name: Deploy with ofn
-        run: npm run ci-perform-tasks
+        run: npm run ci-perform-tasks-parallel
   sceptre-organizations:
     if: github.event_name == 'push'
     needs: org-formation

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "print-tasks": "npx org-formation print-tasks ./org-formation/_tasks.yaml --verbose --print-stack --output yaml --max-concurrent-stacks 100 --max-concurrent-tasks 100",
     "perform-tasks": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 1 --max-concurrent-tasks 1",
     "ci-perform-tasks": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 1 --max-concurrent-tasks 1 --perform-cleanup",
-    "ci-perform-tasks-parallel": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 100 --max-concurrent-tasks 100 --perform-cleanup",
+    "ci-perform-tasks-parallel": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 10 --max-concurrent-tasks 10 --perform-cleanup",
     "validate-tasks": "npx org-formation validate-tasks ./org-formation/_tasks.yaml --verbose --print-stack --failed-tasks-tolerance 0  --max-concurrent-stacks 100 --max-concurrent-tasks 100",
     "cfn-lint": "cfn-lint ./.printed-stacks/**/*.yaml -i W2001,E3001,E1019,W1020,W2509,E3021"
   },


### PR DESCRIPTION
Make org-formation deploy stacks in parallel.  Some things, like
guardduty, needs to be deployed in parallel becuase it requires
syncronysation (invite/accept) between accounts.

Note: We have seen issues when parallelism is enabled when creating new
accounts[1] so we set to only 10 to see if new account creation still
fails.

[1] related to issue https://github.com/org-formation/org-formation-cli/issues/192
