### PR TITLE
Fix TGW SubnetD

### DIFF
--- a/org-formation/710-tgw/vpc.yaml
+++ b/org-formation/710-tgw/vpc.yaml
@@ -76,7 +76,7 @@ Resources:
   SubnetD:
     Type: "AWS::EC2::Subnet"
     Properties:
-      AvailabilityZone: !Select [0, !GetAZs '']
+      AvailabilityZone: !Select [3, !GetAZs '']
       CidrBlock: !Join
         - '.'
         - - !Ref VpcSubnetPrefix


### PR DESCRIPTION
When attempting to associate SubnetD with client VPN we got
the following error..

```
Duplicate subnet detected in az us-east-1a (Service: AmazonEC2;
Status Code: 400; Error Code: InvalidClientVpnSubnetId.DuplicateAz;
Request ID: cfcc7fdd-6589-4b46-9a64-216e4e855659; Proxy: null)
```

The problem is that SubnetD was placed in the same AZ as SubnetA.
To fix we put SubnetD into a different subnet.
