### PR TITLE
Fix update

### DIFF
--- a/org-formation/710-tgw/vpc.yaml
+++ b/org-formation/710-tgw/vpc.yaml
@@ -16,7 +16,7 @@ Mappings:
     SubnetC:  # private
       CIDR: "3.0/24"
     SubnetD:  # public
-      CIDR: "4.0/24"
+      CIDR: "100.0/24"
 Resources:
   VPC:
     Type: 'AWS::EC2::VPC'


### PR DESCRIPTION
The PR #390 to update AZ for SubnetD returned the following error.
```
ERROR: Resource SubnetD failed because CIDR Block must change if
Availability Zone is changed and VPC ID is not changed
```

Attempt to fix by bumping the SubnetD CIDR range. New setup
is..

* 10.100.1-99.x would be non public vpcs
* 10.100.100.x would be a public vpc internal range

