### PR TITLE
[IT-1234] Enable VPN full tunnel

### DIFF
--- a/org-formation/720-client-vpn/_tasks.yaml
+++ b/org-formation/720-client-vpn/_tasks.yaml
@@ -79,4 +79,4 @@ Vpn:
     # manually generated and imported server cert, saved to lastpass "Sage VPN Certificate"
     # https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-getting-started.html#cvpn-getting-started-certs
     ServerCertificateArn: !Sub 'arn:aws:acm:${primaryRegion}:${accountId}:certificate/8bdbf421-c38a-4d87-8a03-821a1b7acab6'
-    SplitTunnel: "true"
+    SplitTunnel: "false"

--- a/org-formation/720-client-vpn/vpn.njk
+++ b/org-formation/720-client-vpn/vpn.njk
@@ -101,20 +101,20 @@ Resources:
   EndpointAuthorizationPublic:
     Type: AWS::EC2::ClientVpnAuthorizationRule
     Properties:
-      Description: "authorization between VPN and public internet"
-      AccessGroupId: {{ access_group }}
+      Description: "public"
+      AuthorizeAllGroups: true
       ClientVpnEndpointId: !Ref Endpoint
       TargetNetworkCidr: "0.0.0.0/0"
 
-  EndpointRoutePublic:
+{% for subnet_id in SubnetIds %}
+  EndpointRoutePublicSubnet{{ subnet_id | last }}:
     Type: AWS::EC2::ClientVpnRoute
-    DependsOn:
-      - EndpointAuthorizationPublic
     Properties:
-      Description: "route between VPN and public internet"
+      Description: public-subnet{{ subnet_id | last }}
       ClientVpnEndpointId: !Ref Endpoint
       DestinationCidrBlock: "0.0.0.0/0"
-      TargetVpcSubnetId: !ImportValue sagebase-tgw-unionstationvpc-SubnetD
+      TargetVpcSubnetId: {{ subnet_id }}
+{% endfor %}
 
 {# Authorization and routes between VPN and spokes #}
 {% for spoke, spoke_data in TgwSpokes %}

--- a/org-formation/720-client-vpn/vpn.njk
+++ b/org-formation/720-client-vpn/vpn.njk
@@ -97,6 +97,30 @@ Resources:
       SubnetId: {{ subnet_id }}
 {% endfor %}
 
+{# Authorization and route between VPN and public internet #}
+  EndpointAuthorizationPublic:
+    Type: AWS::EC2::ClientVpnAuthorizationRule
+    DependsOn:
+{%     for subnet_id in SubnetIds %}
+      - EndpointAssociation{{ subnet_id | last }}
+{%     endfor %}
+    Properties:
+      Description: {{ spoke }}-{{ access_group }}
+      AccessGroupId: {{ access_group }}
+      ClientVpnEndpointId: "0.0.0.0/0"
+      TargetNetworkCidr: {{ spoke_data.CIDR }}
+
+  EndpointRoutePublic:
+    Type: AWS::EC2::ClientVpnRoute
+    DependsOn:
+      - EndpointAuthorizationPublic
+    Properties:
+      Description: "route between VPN and public internet"
+      ClientVpnEndpointId: !Ref Endpoint
+      DestinationCidrBlock: "0.0.0.0/0"
+      TargetVpcSubnetId: !ImportValue sagebase-tgw-unionstationvpc-SubnetC
+
+{# Authorization and routes between VPN and spokes #}
 {% for spoke, spoke_data in TgwSpokes %}
 {%   set spoke_loop = loop %}
 {%   for access_group in spoke_data.AccessGroups %}

--- a/org-formation/720-client-vpn/vpn.njk
+++ b/org-formation/720-client-vpn/vpn.njk
@@ -101,7 +101,7 @@ Resources:
   EndpointAuthorizationPublic:
     Type: AWS::EC2::ClientVpnAuthorizationRule
     Properties:
-      Description: {{ spoke }}-{{ access_group }}
+      Description: "authorization between VPN and public internet"
       AccessGroupId: {{ access_group }}
       ClientVpnEndpointId: !Ref Endpoint
       TargetNetworkCidr: "0.0.0.0/0"

--- a/org-formation/720-client-vpn/vpn.njk
+++ b/org-formation/720-client-vpn/vpn.njk
@@ -107,8 +107,8 @@ Resources:
     Properties:
       Description: {{ spoke }}-{{ access_group }}
       AccessGroupId: {{ access_group }}
-      ClientVpnEndpointId: "0.0.0.0/0"
-      TargetNetworkCidr: {{ spoke_data.CIDR }}
+      ClientVpnEndpointId: !Ref Endpoint
+      TargetNetworkCidr: "0.0.0.0/0"
 
   EndpointRoutePublic:
     Type: AWS::EC2::ClientVpnRoute

--- a/org-formation/720-client-vpn/vpn.njk
+++ b/org-formation/720-client-vpn/vpn.njk
@@ -118,7 +118,7 @@ Resources:
       Description: "route between VPN and public internet"
       ClientVpnEndpointId: !Ref Endpoint
       DestinationCidrBlock: "0.0.0.0/0"
-      TargetVpcSubnetId: !ImportValue sagebase-tgw-unionstationvpc-SubnetC
+      TargetVpcSubnetId: !ImportValue sagebase-tgw-unionstationvpc-SubnetD
 
 {# Authorization and routes between VPN and spokes #}
 {% for spoke, spoke_data in TgwSpokes %}

--- a/org-formation/720-client-vpn/vpn.njk
+++ b/org-formation/720-client-vpn/vpn.njk
@@ -100,10 +100,6 @@ Resources:
 {# Authorization and route between VPN and public internet #}
   EndpointAuthorizationPublic:
     Type: AWS::EC2::ClientVpnAuthorizationRule
-    DependsOn:
-{%     for subnet_id in SubnetIds %}
-      - EndpointAssociation{{ subnet_id | last }}
-{%     endfor %}
     Properties:
       Description: {{ spoke }}-{{ access_group }}
       AccessGroupId: {{ access_group }}


### PR DESCRIPTION
To setup VPN to access internet traffic we need to provide a
route between the VPN and the internet as described in the
AWS documentation[1].  This will allow a full VPN tunnel to
access the internet.

[1] https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/scenario-internet.html

