### PR TITLE
Setup VP for full tunnel

### DIFF
--- a/org-formation/710-tgw/vpc.yaml
+++ b/org-formation/710-tgw/vpc.yaml
@@ -15,8 +15,12 @@ Mappings:
       CIDR: "2.0/24"
     SubnetC:  # private
       CIDR: "3.0/24"
-#    SubnetD:  # public
-#      CIDR: "100.0/24"
+    SubnetD:  # public
+      CIDR: "100.0/24"
+    SubnetE:  # public
+      CIDR: "101.0/24"
+    SubnetF:  # public
+      CIDR: "102.0/24"
 Resources:
   VPC:
     Type: 'AWS::EC2::VPC'
@@ -28,24 +32,24 @@ Resources:
       EnableDnsSupport: true
       EnableDnsHostnames: true
       InstanceTenancy: default
-#  InternetGateway:
-#    Type: "AWS::EC2::InternetGateway"
-#  GatewayToInternet:
-#    Type: "AWS::EC2::VPCGatewayAttachment"
-#    Properties:
-#      VpcId: !Ref VPC
-#      InternetGatewayId: !Ref InternetGateway
-#  PublicRouteTable:
-#    Type: "AWS::EC2::RouteTable"
-#    Properties:
-#      VpcId: !Ref VPC
-#  PublicRoute:
-#    Type: "AWS::EC2::Route"
-#    DependsOn: "GatewayToInternet"
-#    Properties:
-#      RouteTableId: !Ref PublicRouteTable
-#      DestinationCidrBlock: "0.0.0.0/0"
-#      GatewayId: !Ref InternetGateway
+  InternetGateway:
+    Type: "AWS::EC2::InternetGateway"
+  GatewayToInternet:
+    Type: "AWS::EC2::VPCGatewayAttachment"
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+  PublicRouteTable:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId: !Ref VPC
+  PublicRoute:
+    Type: "AWS::EC2::Route"
+    DependsOn: "GatewayToInternet"
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: "0.0.0.0/0"
+      GatewayId: !Ref InternetGateway
   SubnetA:
     Type: 'AWS::EC2::Subnet'
     Properties:
@@ -73,16 +77,36 @@ Resources:
         - - !Ref VpcSubnetPrefix
           - !FindInMap [SubnetConfig, SubnetC, CIDR]
       VpcId: !Ref VPC
-#  SubnetD:
-#    Type: "AWS::EC2::Subnet"
-#    Properties:
-#      AvailabilityZone: !Select [3, !GetAZs '']
-#      CidrBlock: !Join
-#        - '.'
-#        - - !Ref VpcSubnetPrefix
-#          - !FindInMap [SubnetConfig, SubnetD, CIDR]
-#      VpcId: !Ref VPC
-#      MapPublicIpOnLaunch: true
+  SubnetD:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      AvailabilityZone: !Select [0, !GetAZs '']
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, SubnetD, CIDR]
+      VpcId: !Ref VPC
+      MapPublicIpOnLaunch: true
+  SubnetE:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      AvailabilityZone: !Select [1, !GetAZs '']
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, SubnetE, CIDR]
+      VpcId: !Ref VPC
+      MapPublicIpOnLaunch: true
+  SubnetF:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      AvailabilityZone: !Select [2, !GetAZs '']
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, SubnetF, CIDR]
+      VpcId: !Ref VPC
+      MapPublicIpOnLaunch: true
   PrivateRouteTable:
     Type: "AWS::EC2::RouteTable"
     Properties:
@@ -102,85 +126,120 @@ Resources:
     Properties:
       SubnetId: !Ref "SubnetC"
       RouteTableId: !Ref PrivateRouteTable
-#  SubnetRouteTableAssociationD:
-#    Type: "AWS::EC2::SubnetRouteTableAssociation"
-#    Properties:
-#      SubnetId: !Ref SubnetD
-#      RouteTableId: !Ref PublicRouteTable
-#  ElasticIP:
-#    Type: "AWS::EC2::EIP"
-#    Properties:
-#      Domain: "vpc"
-#  NATGateway:
-#    Type: "AWS::EC2::NatGateway"
-#    Properties:
-#      AllocationId: !GetAtt ElasticIP.AllocationId
-#      SubnetId: !Ref SubnetD
-#  PrivateRouteToInternet:
-#    Type: "AWS::EC2::Route"
-#    Properties:
-#      RouteTableId: !Ref PrivateRouteTable
-#      DestinationCidrBlock: "0.0.0.0/0"
-#      NatGatewayId: !Ref NATGateway
-#  PublicNetworkAcl:
-#    Type: "AWS::EC2::NetworkAcl"
-#    Properties:
-#      VpcId: !Ref VPC
-#  PublicSubnetNetworkAclAssociation:
-#    Type: "AWS::EC2::SubnetNetworkAclAssociation"
-#    Properties:
-#      SubnetId: !Ref SubnetD
-#      NetworkAclId: !Ref PublicNetworkAcl
-#  InboundPublicNetworkAclEntry:
-#    Type: "AWS::EC2::NetworkAclEntry"
-#    Properties:
-#      NetworkAclId: !Ref PublicNetworkAcl
-#      RuleNumber: 100
-#      Protocol: -1
-#      RuleAction: "allow"
-#      Egress: false
-#      CidrBlock: "0.0.0.0/0"
-#      PortRange:
-#        From: 0
-#        To: 65535
-#  OutboundPublicNetworkAclEntry:
-#    Type: "AWS::EC2::NetworkAclEntry"
-#    Properties:
-#      NetworkAclId: !Ref PublicNetworkAcl
-#      RuleNumber: 100
-#      Protocol: -1
-#      RuleAction: "allow"
-#      Egress: true
-#      CidrBlock: "0.0.0.0/0"
-#      PortRange:
-#        From: 0
-#        To: 65535
+  SubnetRouteTableAssociationD:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref SubnetD
+      RouteTableId: !Ref PublicRouteTable
+  SubnetRouteTableAssociationE:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref SubnetE
+      RouteTableId: !Ref PublicRouteTable
+  SubnetRouteTableAssociationF:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref SubnetF
+      RouteTableId: !Ref PublicRouteTable
+  ElasticIP:
+    Type: "AWS::EC2::EIP"
+    Properties:
+      Domain: "vpc"
+  NATGateway:
+    Type: "AWS::EC2::NatGateway"
+    Properties:
+      AllocationId: !GetAtt ElasticIP.AllocationId
+      SubnetId: !Ref SubnetD
+  PrivateRouteToInternet:
+    Type: "AWS::EC2::Route"
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: "0.0.0.0/0"
+      NatGatewayId: !Ref NATGateway
+  PublicNetworkAcl:
+    Type: "AWS::EC2::NetworkAcl"
+    Properties:
+      VpcId: !Ref VPC
+  NetworkAclAssociationPublicSubnetD:
+    Type: "AWS::EC2::SubnetNetworkAclAssociation"
+    Properties:
+      SubnetId: !Ref SubnetD
+      NetworkAclId: !Ref PublicNetworkAcl
+  NetworkAclAssociationPublicSubnetE:
+    Type: "AWS::EC2::SubnetNetworkAclAssociation"
+    Properties:
+      SubnetId: !Ref SubnetE
+      NetworkAclId: !Ref PublicNetworkAcl
+  NetworkAclAssociationPublicSubnetF:
+    Type: "AWS::EC2::SubnetNetworkAclAssociation"
+    Properties:
+      SubnetId: !Ref SubnetF
+      NetworkAclId: !Ref PublicNetworkAcl
+  InboundPublicNetworkAclEntry:
+    Type: "AWS::EC2::NetworkAclEntry"
+    Properties:
+      NetworkAclId: !Ref PublicNetworkAcl
+      RuleNumber: 100
+      Protocol: -1
+      RuleAction: "allow"
+      Egress: false
+      CidrBlock: "0.0.0.0/0"
+      PortRange:
+        From: 0
+        To: 65535
+  OutboundPublicNetworkAclEntry:
+    Type: "AWS::EC2::NetworkAclEntry"
+    Properties:
+      NetworkAclId: !Ref PublicNetworkAcl
+      RuleNumber: 100
+      Protocol: -1
+      RuleAction: "allow"
+      Egress: true
+      CidrBlock: "0.0.0.0/0"
+      PortRange:
+        From: 0
+        To: 65535
 Outputs:
-  SubnetIDs:
-    Description: "VPC Subnet IDs"
+  PrivateSubnetIDs:
+    Description: "Private VPC Subnet IDs"
     Value: !Sub '${SubnetA}, ${SubnetB}, ${SubnetC}'
     Export:
-      Name: !Sub '${AWS::StackName}-SubnetIDs'
+      Name: !Sub '${AWS::StackName}-PrivateSubnetIDs'
+  PublicSubnetIDs:
+    Description: "Public VPC Subnet IDs"
+    Value: !Sub '${SubnetD}, ${SubnetE}, ${SubnetF}'
+    Export:
+      Name: !Sub '${AWS::StackName}-PublicSubnetIDs'
   SubnetA:
-    Description: "VPC Subnet A"
+    Description: "Private Subnet"
     Value: !Ref SubnetA
     Export:
       Name: !Sub '${AWS::StackName}-SubnetA'
   SubnetB:
-    Description: "VPC Subnet B"
+    Description: "Private Subnet"
     Value: !Ref SubnetB
     Export:
       Name: !Sub '${AWS::StackName}-SubnetB'
   SubnetC:
-    Description: "VPC Subnet C"
+    Description: "Private Subnet"
     Value: !Ref SubnetC
     Export:
       Name: !Sub '${AWS::StackName}-SubnetC'
-#  SubnetD:
-#    Description: "VPC Subnet D"
-#    Value: !Ref SubnetD
-#    Export:
-#      Name: !Sub '${AWS::StackName}-SubnetD'
+  SubnetD:
+    Description: "Public Subnet"
+    Value: !Ref SubnetD
+    Export:
+      Name: !Sub '${AWS::StackName}-SubnetD'
+  SubnetE:
+    Description: "Public Subnet"
+    Value: !Ref SubnetE
+    Export:
+      Name: !Sub '${AWS::StackName}-SubnetE'
+  SubnetF:
+    Description: "Public Subnet"
+    Value: !Ref SubnetF
+    Export:
+      Name: !Sub '${AWS::StackName}-SubnetF'
   VpcId:
     Description: "The VPC ID"
     Value: !Ref VPC
@@ -191,13 +250,13 @@ Outputs:
     Value: !Ref PrivateRouteTable
     Export:
       Name: !Sub '${AWS::StackName}-PrivateRouteTableId'
-#  PublicRouteTableId:
-#    Description: "The VPC public route table ID"
-#    Value: !Ref PublicRouteTable
-#    Export:
-#      Name: !Sub '${AWS::StackName}-PublicRouteTableId'
-#  NATGatewayId:
-#    Description: "The NAT Gateway ID"
-#    Value: !Ref NATGateway
-#    Export:
-#      Name: !Sub '${AWS::StackName}-NATGatewayId'
+  PublicRouteTableId:
+    Description: "The VPC public route table ID"
+    Value: !Ref PublicRouteTable
+    Export:
+      Name: !Sub '${AWS::StackName}-PublicRouteTableId'
+  NATGatewayId:
+    Description: "The NAT Gateway ID"
+    Value: !Ref NATGateway
+    Export:
+      Name: !Sub '${AWS::StackName}-NATGatewayId'

--- a/org-formation/720-client-vpn/_tasks.yaml
+++ b/org-formation/720-client-vpn/_tasks.yaml
@@ -49,10 +49,9 @@ Vpn:
   TemplatingContext:
     # work around for issue https://github.com/org-formation/org-formation-cli/issues/259
     SubnetIds:
-      - !Sub '!ImportValue ${resourcePrefix}-tgw-${vpnVpc}-SubnetA'
-      - !Sub '!ImportValue ${resourcePrefix}-tgw-${vpnVpc}-SubnetB'
-      - !Sub '!ImportValue ${resourcePrefix}-tgw-${vpnVpc}-SubnetC'
-#      - !Sub '!ImportValue ${resourcePrefix}-tgw-${vpnVpc}-SubnetD'
+      - !Sub '!ImportValue ${resourcePrefix}-tgw-${vpnVpc}-SubnetD'
+      - !Sub '!ImportValue ${resourcePrefix}-tgw-${vpnVpc}-SubnetE'
+      - !Sub '!ImportValue ${resourcePrefix}-tgw-${vpnVpc}-SubnetF'
     TgwSpokes:
       # "10.50.0.0/16" (unionstationvpc) route automatically setup by the VPN endpoint association
       # AccessGroups values must match Jumpcloud User Group names


### PR DESCRIPTION
The aws documentation[1] suggests that we need to associate the AWS
VPN to public subnets instead of private subnets to allow
internet traffic.  This re-enables the TGW and VPN setup and update
the VPN to use public subnets.

[1] https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/scenario-internet.html

