### PR TITLE
[IT-1234] Move and update VPN redirect

### DIFF
--- a/org-formation/720-client-vpn/_tasks.yaml
+++ b/org-formation/720-client-vpn/_tasks.yaml
@@ -80,3 +80,22 @@ Vpn:
     # https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-getting-started.html#cvpn-getting-started-certs
     ServerCertificateArn: !Sub 'arn:aws:acm:${primaryRegion}:${accountId}:certificate/8bdbf421-c38a-4d87-8a03-821a1b7acab6'
     SplitTunnel: "false"
+
+VpnEndpointRedirect:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/s3-redirector.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-redirect'
+  StackDescription: Setup a redirect to the VPN URL endpoint
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref SageITAccount
+  Parameters:
+    # the endpoint we are redirecting from
+    SourceHostName: "vpn.sageit.org"
+    SourceAcmCertificateArn: !CopyValue [!Sub '${primaryRegion}-sageit-org-acm-cert-CertificateArn']
+    # ID of the sageit.org zone (in sageit account)
+    SourceHostedZoneId: "Z0478495257GEB73WFM63"
+    # the endpoint we are redirecting to (AWS VPN client self service)
+    TargetHostName: "self-service.clientvpn.amazonaws.com"
+    # and a path to our specific config
+    TargetKey: "endpoints/cvpn-endpoint-047b40d546b387b36"


### PR DESCRIPTION
* Changes were made to the VPN so we need to update the VPN endpoint
* Move setup of the DNS redirect to the VPN from sceptre deploy to
org-formation deploy. This also keeps it inline with the entire VPN
setup which provides better context for this setup.

