### PR TITLE
[IT-1683] Remove collaborator access

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -14,21 +14,6 @@ iAtlasCIServiceAccount:
     Account: !Ref iAtlasProdAccount
     Region: us-east-1
 
-# Setup iAtlas collaborator access
-iAtlasCollaboratorAccess:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.10/templates/IAM/cross-account-access.yaml
-  StackName: iatlas-collaborator-access
-  Parameters:
-    PrincipalArns:
-      - arn:aws:iam::556856096938:user/ebs_automation    # Jon Ryser from GenUI
-    ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/ReadOnlyAccess
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: false
-    Account: !Ref iAtlasProdAccount
-    Region: us-east-1
-
 # A service account for https://github.com/nlpsandbox/aws-cloudformation
 NlpSandboxServiceAccount:
   Type: update-stacks


### PR DESCRIPTION
We believe our GenUI consultant, Jon Ryser, no longer works
on the iAtlas project so removing his access to the iAtlas
AWS account.
