### PR TITLE
[IT-1234] AWS Security group for TGW

### DIFF
--- a/sceptre/bridge/templates/aws-default-vpc.yaml
+++ b/sceptre/bridge/templates/aws-default-vpc.yaml
@@ -291,6 +291,11 @@ Resources:
           ToPort: -1
           IpProtocol: "-1"
           Description: "Allow all VPN traffic"
+        - CidrIp: "10.50.0.0/16"    # AWS TGW Hub
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
+          Description: "Allow AWS TGW Hub traffic"
       # CF does not support removing all rules, workaround is to add a pointless rule
       SecurityGroupEgress:
         - CidrIp: "0.0.0.0/0"

--- a/sceptre/bridge/templates/bridge.yaml
+++ b/sceptre/bridge/templates/bridge.yaml
@@ -344,6 +344,11 @@ Resources:
           ToPort: -1
           IpProtocol: "-1"
           Description: "Allow all VPN traffic"
+        - CidrIp: "10.50.0.0/16"    # AWS TGW Hub
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
+          Description: "Allow AWS TGW Hub traffic"
       SecurityGroupEgress:
         - CidrIp: "0.0.0.0/0"
           FromPort: -1


### PR DESCRIPTION
We use the transit gateway to route traffic between the hub
and spoke VPCs. To allow access to resources in a spoke VPC we need
to give the hub VPC access to the resources. This adds an SG ingress
to resources provisioned in our spoke VPCs which will allow VPN users
access to the resources in the spoke VPCs.

