### PR TITLE
Remove unused role

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -189,27 +189,6 @@ SsoAdministratorSupporter:
     principalId: !Ref scienceSupporterGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
 
-SsoWriter:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-writer'
-  StackDescription: 'Read and Write role used by Supporter group within Production organizational units'
-  TerminationProtection: false
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: true
-  OrganizationBindings:
-    TargetBinding:
-      OrganizationalUnit:
-        - !Ref ScienceDevOU
-        - !Ref ScienceProdOU
-  Parameters:
-    instanceArn: !Ref instanceArn
-    principalId: !Ref scienceSupporterGroup
-    permissionSetName: 'Writer'
-    managedPolicies: [ 'arn:aws:iam::aws:policy/PowerUserAccess' ]
-    sessionDuration: 'PT1H'
-
 SsoDeveloper:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/SSO/aws-sso.yaml

--- a/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
+++ b/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
@@ -1,7 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cloudwatch-cross-account-sharing.yaml
-stack_name: "cloudwatch-cross-account-sharing"
-parameters:
-  MonitoringAccountIds:
-    - "563295687221"  # org-sagebase-sandbox

--- a/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
+++ b/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
@@ -1,0 +1,7 @@
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cloudwatch-cross-account-sharing.yaml
+stack_name: "cloudwatch-cross-account-sharing"
+parameters:
+  MonitoringAccountIds:
+    - "563295687221"  # org-sagebase-sandbox


### PR DESCRIPTION
We do not use the support writer role therefore we should
not keep it around.

