### PR TITLE
[IT-1671] Prevent users from escalating privileges

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -231,6 +231,17 @@ SsoDeveloper:
     permissionSetName: 'Developer'
     managedPolicies: [ 'arn:aws:iam::aws:policy/PowerUserAccess' ]
     sessionDuration: 'PT12H'
+    inlinePolicy: >-
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Effect": "Deny",
+                  "Action": "iam:PassRole",
+                  "Resource": "*"
+              }
+          ]
+      }
 
 SsoAuditor:
   Type: update-stacks
@@ -467,6 +478,11 @@ SsoWorkflowNextflowDevDeveloper:
                       "arn:aws:iam::035458030717:instance-profile/dev-*",
                       "arn:aws:iam::035458030717:policy/dev-*"
                   ]
+              },
+              {
+                  "Effect": "Deny",
+                  "Action": "iam:PassRole",
+                  "Resource": "*"
               }
           ]
       }
@@ -749,6 +765,11 @@ SsoBridgeProdDeveloper:
               "dynamodb:DeleteTable"
             ],
             "Resource": "*"
+          },
+          {
+              "Effect": "Deny",
+              "Action": "iam:PassRole",
+              "Resource": "*"
           }
         ]
       }

--- a/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
+++ b/sceptre/scicomp/config/prod/cloudwatch-cross-account-sharing.yaml
@@ -1,7 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/cloudwatch-cross-account-sharing.yaml
-stack_name: "cloudwatch-cross-account-sharing"
-parameters:
-  MonitoringAccountIds:
-    - "563295687221"  # org-sagebase-sandbox


### PR DESCRIPTION
The PowerUserAccess job function policy gives our SSO roles the
ability to assume other roles in an AWS account.  Since our JC
users are mapped to SSO roles this would allow our JC users to
potentially escalate their privileges by assuming a more
privileged role.

We want our IDP to be the source of truth for access to AWS.  This
setup is a security hole because it allows the role to circumvent
how we manage AWS access in JC.  To prevent this from happening we add
an explict deny to not allow our JC users to assume other roles.

