### PR TITLE
[IT-1234] Use updated templates for VPN access

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -79,7 +79,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.22'
-    - Description: 'Allow more simultaneously open files. {{ range(1, 10000) | random }}'
+    - Description: 'Allow more simultaneously open files.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.26/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.26'
+    - Description: 'AWS VPN Access. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.34/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.1.34'

--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-windows-jumpcloud.yaml
@@ -42,7 +42,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.13/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.13'
-    - Description:  'Restore set_env_var. {{ range(1, 10000) | random }}'
+    - Description:  'Restore set_env_var.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.14/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.14'
+    - Description:  'AWS VPN access. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.34/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.34'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -78,7 +78,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.22'
-    - Description: 'Allow more simultaneously open files. {{ range(1, 10000) | random }}'
+    - Description: 'Allow more simultaneously open files.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.26/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.26'
+    - Description: 'AWS VPN Access. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.34/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.1.34'

--- a/sceptre/scipool/config/develop/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-windows-jumpcloud.yaml
@@ -45,3 +45,7 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.14/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.14'
+    - Description:  'AWS VPN access. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.34/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.34'

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -79,7 +79,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.22'
-    - Description: 'Allow more simultaneously open files. {{ range(1, 10000) | random }}'
+    - Description: 'Allow more simultaneously open files.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.26/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.26'
+    - Description: 'AWS VPN Access. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.34/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.1.34'

--- a/sceptre/scipool/config/prod/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-windows-jumpcloud.yaml
@@ -42,7 +42,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.13/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.13'
-    - Description: 'Restore set_env_var. {{ range(1, 10000) | random }}'
+    - Description: 'Restore set_env_var.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.14/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.14'
+    - Description:  'AWS VPN access. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.34/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.34'

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -79,7 +79,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.22'
-    - Description: 'Allow more simultaneously open files. {{ range(1, 10000) | random }}'
+    - Description: 'Allow more simultaneously open files.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.26/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.26'
+    - Description: 'AWS VPN Access. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.34/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.1.34'

--- a/sceptre/scipool/config/strides/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-windows-jumpcloud.yaml
@@ -46,3 +46,7 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.14/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.14'
+    - Description:  'AWS VPN access. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.34/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.34'


### PR DESCRIPTION
Use new version of SC templates that provide transit gateway
access to instances which allows access from the VPN

depends on https://github.com/Sage-Bionetworks/service-catalog-library/pull/275

