### PR TITLE
[IT-1598] Setup AWS inspector

### DIFF
--- a/org-formation/075-inspector/README.md
+++ b/org-formation/075-inspector/README.md
@@ -1,0 +1,4 @@
+### Purpose of these templates
+The templates in this folder enable [AWS Inspector](https://docs.aws.amazon.com/managedservices/latest/userguide/inspector.html) in each account. Amazon Inspector is an automated security assessment service that helps improve the security and compliance of applications deployed on AWS. Amazon Inspector automatically assesses applications for exposure, vulnerabilities, and deviations from best practices.
+
+AWS Inspector is setup at the AWS organizations level and management of the service has been [delegated to the org-sagebase-securitycentral account](https://docs.aws.amazon.com/organizations/latest/userguide/services-that-can-integrate-inspector2.html).  

--- a/org-formation/075-inspector/_tasks.yaml
+++ b/org-formation/075-inspector/_tasks.yaml
@@ -1,0 +1,25 @@
+Parameters:
+  <<: !Include '../_parameters.yaml'
+
+  appName:
+    Type: String
+    Default: 'inspector'
+
+  accountId:
+    Type: String
+    Description: The identifier from the account used to manage inspector
+    Default: !Ref SecurityCentralAccount
+
+Inspector:
+  Type: update-stacks
+  Template: inspector.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}'
+  StackDescription: AWS Inspector service
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref accountId
+  OrganizationBindings:
+    InspectorBinding:
+      Account: '*'
+      IncludeMasterAccount: true
+

--- a/org-formation/075-inspector/inspector.yaml
+++ b/org-formation/075-inspector/inspector.yaml
@@ -1,0 +1,76 @@
+AWSTemplateFormatVersion: '2010-09-09-OC'
+OrganizationBindings:
+  InspectorBinding:
+Mappings:
+  RulesPackagesAmazonInspectorArns: # ARNs derived from https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html
+    us-east-1:
+      CommonVulnerabilitiesExposures: arn:aws:inspector:us-east-1:316112463485:rulespackage/0-gEjTy7T7
+      CISOperatingSystemBenchmarks: arn:aws:inspector:us-east-1:316112463485:rulespackage/0-rExsr2X8
+      NetworkReachability: arn:aws:inspector:us-east-1:316112463485:rulespackage/0-PmNV0Tcd
+      SecurityBestPractices: arn:aws:inspector:us-east-1:316112463485:rulespackage/0-R01qwB5Q
+    us-east-2:
+      CommonVulnerabilitiesExposures: arn:aws:inspector:us-east-2:646659390643:rulespackage/0-JnA8Zp85
+      CISOperatingSystemBenchmarks: arn:aws:inspector:us-east-2:646659390643:rulespackage/0-m8r61nnh
+      NetworkReachability: arn:aws:inspector:us-east-2:646659390643:rulespackage/0-cE4kTR30
+      SecurityBestPractices: arn:aws:inspector:us-east-2:646659390643:rulespackage/0-AxKmMHPX
+    us-west-1:
+      CommonVulnerabilitiesExposures: arn:aws:inspector:us-west-1:166987590008:rulespackage/0-TKgzoVOa
+      CISOperatingSystemBenchmarks: arn:aws:inspector:us-west-1:166987590008:rulespackage/0-xUY8iRqX
+      NetworkReachability: arn:aws:inspector:us-west-1:166987590008:rulespackage/0-TxmXimXF
+      SecurityBestPractices: arn:aws:inspector:us-west-1:166987590008:rulespackage/0-byoQRFYm
+    us-west-2:
+      CommonVulnerabilitiesExposures: arn:aws:inspector:us-west-2:758058086616:rulespackage/0-9hgA516p
+      CISOperatingSystemBenchmarks: arn:aws:inspector:us-west-2:758058086616:rulespackage/0-H5hpSawc
+      NetworkReachability: arn:aws:inspector:us-west-2:758058086616:rulespackage/0-rD1z6dpl
+      SecurityBestPractices: arn:aws:inspector:us-west-2:758058086616:rulespackage/0-JJOtZiqQ
+Resources:
+  InspectorServiceLinkedRole:
+    Type: AWS::IAM::ServiceLinkedRole
+    OrganizationBinding: !Ref InspectorBinding
+    Properties:
+      AWSServiceName: inspector.amazonaws.com
+      Description: Service-Linked-Role for Amazon Inspector
+  AssessmentTarget:
+    Type: AWS::Inspector::AssessmentTarget
+    OrganizationBinding: !Ref InspectorBinding
+  AssessmentTemplate:
+    Type: AWS::Inspector::AssessmentTemplate
+    OrganizationBinding: !Ref InspectorBinding
+    Properties:
+      AssessmentTargetArn: !GetAtt AssessmentTarget.Arn
+      DurationInSeconds: 3600
+      RulesPackageArns:
+        - !FindInMap [ RulesPackagesAmazonInspectorArns, !Ref AWS::Region, CommonVulnerabilitiesExposures ]
+        - !FindInMap [ RulesPackagesAmazonInspectorArns, !Ref AWS::Region, CISOperatingSystemBenchmarks ]
+        - !FindInMap [ RulesPackagesAmazonInspectorArns, !Ref AWS::Region, NetworkReachability ]
+        - !FindInMap [ RulesPackagesAmazonInspectorArns, !Ref AWS::Region, SecurityBestPractices ]
+  EventsRole:
+    Type: AWS::IAM::Role
+    OrganizationBinding: !Ref InspectorBinding
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: events.amazonaws.com
+      Policies:
+        - PolicyName: AssessmentTemplatePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: inspector:StartAssessmentRun
+                Resource: '*'
+  Schedule:
+    Type: AWS::Events::Rule
+    OrganizationBinding: !Ref InspectorBinding
+    Properties:
+      Description: !Sub Scheduled Inspector Assessment for ${AssessmentTemplate.Arn} running every 7 day(s)
+      ScheduleExpression: rate(7 days)
+      State: ENABLED
+      Targets:
+        - Id: InspectorAssessmentTemplateSchedule
+          Arn: !Sub ${AssessmentTemplate.Arn}
+          RoleArn: !GetAtt EventsRole.Arn


### PR DESCRIPTION
Enable AWS inspector service in all accounts and delegate
management of the service to org-sagebase-securitycentral
account.

