### PR TITLE
[IT-1663] Setup agora service user

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -1,7 +1,7 @@
 Parameters:
   <<: !Include '../_parameters.yaml'
 
-# A service account for https://github.com/Sage-Bionetworks/agora2-infra
+# A service account for https://github.com/Sage-Bionetworks/agora-infra
 AgoraCIServiceAccount:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/IAM/service-account.yaml

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -1,6 +1,19 @@
 Parameters:
   <<: !Include '../_parameters.yaml'
 
+# A service account for https://github.com/Sage-Bionetworks/agora2-infra
+AgoraCIServiceAccount:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/IAM/service-account.yaml
+  StackName: agora-prod-ci-access
+  Parameters:
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AdministratorAccess
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+    Account: !Ref AgoraProdAccount
+    Region: us-east-1
+
 # A service account for https://github.com/Sage-Bionetworks/iatlas-infra
 iAtlasCIServiceAccount:
   Type: update-stacks


### PR DESCRIPTION
This creates a service account/role pair for CI to deploy
agora resources into org-sagebase-agora-prod AWS account

