### PR TITLE
Disable SCP region restriction for testing

### DIFF
--- a/org-formation/010-scps/_tasks.yaml
+++ b/org-formation/010-scps/_tasks.yaml
@@ -55,27 +55,27 @@ PreventDisableCloudwatchConfigs:
       - !Ref BridgeOU
       - !Ref ServiceCatalogOU
 
-DenyAllRegionsOutsideUsEast1:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.4/templates/SCP/deny-all-regions-outside-us-east-1.yaml
-  StackName: !Sub '${resourcePrefix}-deny-all-regions-outside-us-east-1'
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: true
-  Parameters:
-    targetIds:
-      - !Ref ItDevOU
-      - !Ref ItProdOU
-      - !Ref ScienceProdOU
+#DenyAllRegionsOutsideUsEast1:
+#  Type: update-stacks
+#  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.4/templates/SCP/deny-all-regions-outside-us-east-1.yaml
+#  StackName: !Sub '${resourcePrefix}-deny-all-regions-outside-us-east-1'
+#  DefaultOrganizationBindingRegion: !Ref primaryRegion
+#  DefaultOrganizationBinding:
+#    IncludeMasterAccount: true
+#  Parameters:
+#    targetIds:
+#      - !Ref ItDevOU
+#      - !Ref ItProdOU
+#      - !Ref ScienceProdOU
 
-DenyAllRegionsOutsideUs:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.4/templates/SCP/deny-all-regions-outside-us.yaml
-  StackName: !Sub '${resourcePrefix}-deny-all-regions-outside-us'
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: true
-  Parameters:
-    targetIds:
-      - !Ref ScienceDevOU
-      - !Ref ServiceCatalogOU
+#DenyAllRegionsOutsideUs:
+#  Type: update-stacks
+#  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.4/templates/SCP/deny-all-regions-outside-us.yaml
+#  StackName: !Sub '${resourcePrefix}-deny-all-regions-outside-us'
+#  DefaultOrganizationBindingRegion: !Ref primaryRegion
+#  DefaultOrganizationBinding:
+#    IncludeMasterAccount: true
+#  Parameters:
+#    targetIds: "*"
+#      - !Ref ScienceDevOU
+#      - !Ref ServiceCatalogOU


### PR DESCRIPTION
We are getting a message that says that admins are denied access to route53
resources.  We suspect that our SCP region restriction is causing this
problem.  We disable to test whether this is indeed the issue.

2022-03-28 20:02:59] - develop/agora R53RecordSet AWS::Route53::RecordSet CREATE_FAILED API:
route53:GetHostedZone User: arn:aws:sts::XXXXXX5864:assumed-role/AWSReservedSSO_Administrator_f5dc1fd84ac184d1/YYYY@sagebase.org
is not authorized to access this resource

