### PR TITLE
[IT-1671] Deny assume role

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -236,7 +236,7 @@ SsoDeveloper:
           "Statement": [
               {
                   "Effect": "Deny",
-                  "Action": "iam:PassRole",
+                  "Action": "sts:AssumeRole",
                   "Resource": "*"
               }
           ]
@@ -514,7 +514,7 @@ SsoWorkflowNextflowDevDeveloper:
               },
               {
                   "Effect": "Deny",
-                  "Action": "iam:PassRole",
+                  "Action": "sts:AssumeRole",
                   "Resource": "*"
               }
           ]
@@ -801,7 +801,7 @@ SsoBridgeProdDeveloper:
           },
           {
               "Effect": "Deny",
-              "Action": "iam:PassRole",
+              "Action": "sts:AssumeRole",
               "Resource": "*"
           }
         ]


### PR DESCRIPTION
We initially denied `iam:PassRole` but that's wrong, as pointed
out by @ahayden we should be denying on `sts:AssumeRole`

