### PR TITLE
[IT-1708] Create new AWS account

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -64,6 +64,7 @@ Organization:
         - !Ref LogCentralAccount
         - !Ref ImageCentralAccount
         - !Ref SecurityCentralAccount
+        - !Ref IpamAccount
 
   PolicyStagingOU:
     Type: OC::ORG::OrganizationalUnit
@@ -394,3 +395,12 @@ Organization:
         Project: amp-ad
         budget-alarm-threshold: 2000
         budget-alarm-threshold-email-recipient: agora-prod@sagebase.org
+
+  IpamAccount:
+    Type: OC::ORG::Account
+    Properties:
+      AccountName: org-sagebase-ipam
+      RootEmail: aws.ipam@sagebase.org
+      Alias: org-sagebase-ipam
+      Tags:
+        <<: !Include ./_default_org_tags.yaml


### PR DESCRIPTION
The best practice to setting up IPAM[1] is to set it up in a separate
aws account so we can delgate specific groups to admin and monitoring
it.  This PR is to create a new AWS account for the IPAM service.

[1] https://docs.aws.amazon.com/vpc/latest/ipam/enable-integ-ipam.html
