### PR TITLE
Limit ALB logging bucket cross account to single region

### DIFF
--- a/sceptre/scipool/templates/alb-notebook-access-logsbucket.yaml
+++ b/sceptre/scipool/templates/alb-notebook-access-logsbucket.yaml
@@ -1,14 +1,12 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Create ALB that can be modified by Service Catalog provisioning requests
 
+# Include only one region in the map today
+# See: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
 Mappings:
   ELBAccountsMap:
     us-east-1:
       "ELBAccountRoot": "arn:aws:iam::127311923021:root"
-    us-west-2:
-      "ELBAccountRoot": "arn:aws:iam::797873946194:root"
-    us-west-1:
-      "ELBAccountRoot": "arn:aws:iam::027434742980:root"
 
 Resources:
 


### PR DESCRIPTION
[ x ] The org should need only a cross account S3 logger access for the AWS ALB main account from a single region
[ x ] Passes pre-commit