### PR TITLE
[IT-607] Move security hub service

### DIFF
--- a/org-formation/075-security-hub/_tasks.yaml
+++ b/org-formation/075-security-hub/_tasks.yaml
@@ -7,7 +7,7 @@ Parameters:
 
   accountId:
     Type: String
-    Description: The identifier from the account used to manage GuardDuty
+    Description: The identifier from the account used to manage this service
     Default: !Ref MasterAccount
 
 SecurityHub:

--- a/org-formation/075-security-hub/_tasks.yaml
+++ b/org-formation/075-security-hub/_tasks.yaml
@@ -8,13 +8,13 @@ Parameters:
   accountId:
     Type: String
     Description: The identifier from the account used to manage GuardDuty
-    Default: !Ref SecurityCentralAccount
+    Default: !Ref MasterAccount
 
 SecurityHub:
   Type: update-stacks
   Template: security-hub.yaml
   StackName: !Sub '${resourcePrefix}-${appName}'
-  StackDescription: SecurityHub notifications
+  StackDescription: Setup SecurityHub service
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     Account: !Ref accountId


### PR DESCRIPTION
We are moving the security hub service to the organizations account
and delegating administrating to securitycentral account.

Note: delegation happens after setting this up and it can only be
done manually thru the AWS console or CLI

