### PR TITLE
[IT-1234] Fix VPN resource names

### DIFF
--- a/org-formation/720-client-vpn/vpn.njk
+++ b/org-formation/720-client-vpn/vpn.njk
@@ -122,10 +122,8 @@ Resources:
 
 {# Authorization and routes between VPN and spokes #}
 {% for spoke, spoke_data in TgwSpokes %}
-{%   set spoke_loop = loop %}
 {%   for access_group in spoke_data.AccessGroups %}
-{%     set access_group_loop = loop %}
-  EndpointAuthorization{{ spoke_loop.index }}{{ access_group_loop.index }}:
+  EndpointAuthorization{{ spoke_data.CIDR | replace('.','') | replace('/','') }}{{ access_group | replace('-','') }}:
     Type: AWS::EC2::ClientVpnAuthorizationRule
     DependsOn:
 {%     for subnet_id in SubnetIds %}
@@ -140,10 +138,8 @@ Resources:
 {% endfor %}
 
 {% for spoke, spoke_data in TgwSpokes %}
-{%   set spoke_loop = loop %}
 {%   for subnet_id in SubnetIds %}
-{%     set subnet_id_loop = loop %}
-  EndpointRoute{{ spoke_loop.index }}{{ subnet_id_loop.index }}:
+  EndpointRoute{{ spoke_data.CIDR | replace('.','') | replace('/','') }}{{ subnet_id | last }}:
     Type: AWS::EC2::ClientVpnRoute
     DependsOn:
 {%     for depend in SubnetIds %}


### PR DESCRIPTION
Using an index for resource names is not good because it's not
gauranteed to be in the same order on the next deployment.  This
can cause AWS to do many replacements which may force users to
reconnect to the VPN.  We change to more static naming convention
to make it consistent across deployments.

