### PR TITLE
[IT-1234] Decouple VPN from configuring VPN auth and routes

### DIFF
--- a/org-formation/720-client-vpn/_tasks.yaml
+++ b/org-formation/720-client-vpn/_tasks.yaml
@@ -35,7 +35,7 @@ VpnIdp:
 Vpn:
   DependsOn: [ VpnIdp ]
   Type: update-stacks
-  Template: vpn.njk
+  Template: vpn.yaml
   StackName: !Sub '${resourcePrefix}-${appName}'
   StackDescription: The AWS client VPN
   DefaultOrganizationBindingRegion: !Ref primaryRegion
@@ -46,6 +46,35 @@ Vpn:
       Account:
         - !Ref accountId
       IncludeMasterAccount: false
+  Parameters:
+    ClientCidrBlock: "10.100.0.0/16"
+    VpnSamlProviderArn: !CopyValue [!Sub '${resourcePrefix}-${appName}-idp-TransitVpnSamlProviderArn']
+    VpnSspSamlProviderArn: !CopyValue [!Sub '${resourcePrefix}-${appName}-idp-TransitVpnSspSamlProviderArn']
+    VpcId: !CopyValue [!Sub '${resourcePrefix}-tgw-${vpnVpc}-VpcId']
+    ConnectionLogGroup: !Sub '/aws/vpn/${resourcePrefix}-${appName}'
+    SessionTimeoutHours: "12"
+    LogRetentionInDays: "3653"
+    # manually generated and imported server cert, saved to lastpass "Sage VPN Certificate"
+    # https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-getting-started.html#cvpn-getting-started-certs
+    ServerCertificateArn: !Sub 'arn:aws:acm:${primaryRegion}:${accountId}:certificate/8bdbf421-c38a-4d87-8a03-821a1b7acab6'
+    SplitTunnel: "false"
+
+VpnAuthRoutes:
+  DependsOn: [ Vpn ]
+  Type: update-stacks
+  Template: vpn-auth-routes.njk
+  StackName: !Sub '${resourcePrefix}-${appName}-auth-routes'
+  StackDescription: Setup AWS client VPN authorizations and routes
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref accountId
+  OrganizationBindings:
+    AllBinding:
+      Account:
+        - !Ref accountId
+      IncludeMasterAccount: false
+  Parameters:
+    ClientVpnEndpointId: !CopyValue [!Sub '${resourcePrefix}-${appName}-EndpointId']
   TemplatingContext:
     # work around for issue https://github.com/org-formation/org-formation-cli/issues/259
     SubnetIds:
@@ -116,19 +145,6 @@ Vpn:
           - "aws-admins"
           - "aws-agoraprod-admins"
           - "aws-agoraprod-developers"
-
-  Parameters:
-    ClientCidrBlock: "10.100.0.0/16"
-    VpnSamlProviderArn: !CopyValue [!Sub '${resourcePrefix}-${appName}-idp-TransitVpnSamlProviderArn']
-    VpnSspSamlProviderArn: !CopyValue [!Sub '${resourcePrefix}-${appName}-idp-TransitVpnSspSamlProviderArn']
-    VpcId: !CopyValue [!Sub '${resourcePrefix}-tgw-${vpnVpc}-VpcId']
-    ConnectionLogGroup: !Sub '/aws/vpn/${resourcePrefix}-${appName}'
-    SessionTimeoutHours: "12"
-    LogRetentionInDays: "3653"
-    # manually generated and imported server cert, saved to lastpass "Sage VPN Certificate"
-    # https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-getting-started.html#cvpn-getting-started-certs
-    ServerCertificateArn: !Sub 'arn:aws:acm:${primaryRegion}:${accountId}:certificate/8bdbf421-c38a-4d87-8a03-821a1b7acab6'
-    SplitTunnel: "false"
 
 VpnEndpointRedirect:
   DependsOn: [ Vpn ]

--- a/org-formation/720-client-vpn/_tasks.yaml
+++ b/org-formation/720-client-vpn/_tasks.yaml
@@ -15,6 +15,14 @@ Parameters:
     Description: The VPC name to associate with the VPN
     Default: 'unionstationvpc'
 
+  splitTunnel:
+    Type: String
+    Description: "Indicates whether split-tunnel is enabled on the AWS Client VPN endpoint (false for full tunnel)"
+    Default: false
+    AllowedValues:
+      - true
+      - false
+
 VpnIdp:
   Type: update-stacks
   Template: vpn-idp.yaml
@@ -57,7 +65,7 @@ Vpn:
     # manually generated and imported server cert, saved to lastpass "Sage VPN Certificate"
     # https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-getting-started.html#cvpn-getting-started-certs
     ServerCertificateArn: !Sub 'arn:aws:acm:${primaryRegion}:${accountId}:certificate/8bdbf421-c38a-4d87-8a03-821a1b7acab6'
-    SplitTunnel: "false"
+    SplitTunnel: !Ref splitTunnel
 
 VpnAuthRoutes:
   DependsOn: [ Vpn ]
@@ -75,6 +83,7 @@ VpnAuthRoutes:
       IncludeMasterAccount: false
   Parameters:
     ClientVpnEndpointId: !CopyValue [!Sub '${resourcePrefix}-${appName}-EndpointId']
+    SplitTunnel: !Ref splitTunnel
   TemplatingContext:
     # work around for issue https://github.com/org-formation/org-formation-cli/issues/259
     SubnetIds:

--- a/org-formation/720-client-vpn/vpn-auth-routes.njk
+++ b/org-formation/720-client-vpn/vpn-auth-routes.njk
@@ -4,6 +4,15 @@ Parameters:
   ClientVpnEndpointId:
     Type: String
     Description: The ID of the VPN Endpoint
+  SplitTunnel:
+    Type: String
+    Description: "Indicates whether split-tunnel is enabled on the AWS Client VPN endpoint (false for full tunnel)"
+    AllowedValues:
+      - true
+      - false
+    ConstraintDescription: 'Must be true or false'
+Conditions:
+  FullTunnel: !Equals [!Ref SplitTunnel, false]
 Resources:
 {% for subnet_id in SubnetIds %}
   EndpointAssociation{{ subnet_id | last }}:
@@ -36,10 +45,8 @@ Resources:
 
 {# Authorization and routes between VPN and spokes #}
 {% for spoke, spoke_data in TgwSpokes %}
-{%   set spoke_loop = loop %}
 {%   for access_group in spoke_data.AccessGroups %}
-{%     set access_group_loop = loop %}
-  EndpointAuthorization{{ spoke_loop.index }}{{ access_group_loop.index }}:
+  EndpointAuthorization{{ spoke_data.CIDR | replace('.','') | replace('/','') }}{{ access_group | replace('-','') }}:
     Type: AWS::EC2::ClientVpnAuthorizationRule
     DependsOn:
 {%     for subnet_id in SubnetIds %}
@@ -54,10 +61,8 @@ Resources:
 {% endfor %}
 
 {% for spoke, spoke_data in TgwSpokes %}
-{%   set spoke_loop = loop %}
 {%   for subnet_id in SubnetIds %}
-{%     set subnet_id_loop = loop %}
-  EndpointRoute{{ spoke_loop.index }}{{ subnet_id_loop.index }}:
+  EndpointRoute{{ spoke_data.CIDR | replace('.','') | replace('/','') }}{{ subnet_id | last }}:
     Type: AWS::EC2::ClientVpnRoute
     DependsOn:
 {%     for depend in SubnetIds %}

--- a/org-formation/720-client-vpn/vpn-auth-routes.njk
+++ b/org-formation/720-client-vpn/vpn-auth-routes.njk
@@ -1,0 +1,72 @@
+Description: Setup client VPN authorization and routes
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  ClientVpnEndpointId:
+    Type: String
+    Description: The ID of the VPN Endpoint
+Resources:
+{% for subnet_id in SubnetIds %}
+  EndpointAssociation{{ subnet_id | last }}:
+    Type: AWS::EC2::ClientVpnTargetNetworkAssociation
+    Properties:
+      ClientVpnEndpointId: !Ref ClientVpnEndpointId
+      SubnetId: {{ subnet_id }}
+{% endfor %}
+
+{# Authorization and route between VPN and public internet #}
+  EndpointAuthorizationPublic:
+    Condition: FullTunnel
+    Type: AWS::EC2::ClientVpnAuthorizationRule
+    Properties:
+      Description: "public"
+      AuthorizeAllGroups: true
+      ClientVpnEndpointId: !Ref ClientVpnEndpointId
+      TargetNetworkCidr: "0.0.0.0/0"
+
+{% for subnet_id in SubnetIds %}
+  EndpointRoutePublicSubnet{{ subnet_id | last }}:
+    Condition: FullTunnel
+    Type: AWS::EC2::ClientVpnRoute
+    Properties:
+      Description: public-subnet{{ subnet_id | last }}
+      ClientVpnEndpointId: !Ref ClientVpnEndpointId
+      DestinationCidrBlock: "0.0.0.0/0"
+      TargetVpcSubnetId: {{ subnet_id }}
+{% endfor %}
+
+{# Authorization and routes between VPN and spokes #}
+{% for spoke, spoke_data in TgwSpokes %}
+{%   set spoke_loop = loop %}
+{%   for access_group in spoke_data.AccessGroups %}
+{%     set access_group_loop = loop %}
+  EndpointAuthorization{{ spoke_loop.index }}{{ access_group_loop.index }}:
+    Type: AWS::EC2::ClientVpnAuthorizationRule
+    DependsOn:
+{%     for subnet_id in SubnetIds %}
+      - EndpointAssociation{{ subnet_id | last }}
+{%     endfor %}
+    Properties:
+      Description: {{ spoke }}-{{ access_group }}
+      AccessGroupId: {{ access_group }}
+      ClientVpnEndpointId: !Ref ClientVpnEndpointId
+      TargetNetworkCidr: {{ spoke_data.CIDR }}
+{%   endfor %}
+{% endfor %}
+
+{% for spoke, spoke_data in TgwSpokes %}
+{%   set spoke_loop = loop %}
+{%   for subnet_id in SubnetIds %}
+{%     set subnet_id_loop = loop %}
+  EndpointRoute{{ spoke_loop.index }}{{ subnet_id_loop.index }}:
+    Type: AWS::EC2::ClientVpnRoute
+    DependsOn:
+{%     for depend in SubnetIds %}
+      - EndpointAssociation{{ subnet_id | last }}
+{%     endfor %}
+    Properties:
+      Description: {{ spoke }}-Subnet{{ subnet_id | last }}
+      ClientVpnEndpointId: !Ref ClientVpnEndpointId
+      DestinationCidrBlock: {{ spoke_data.CIDR }}
+      TargetVpcSubnetId: {{ subnet_id }}
+{%   endfor %}
+{% endfor %}

--- a/org-formation/720-client-vpn/vpn-auth-routes.njk
+++ b/org-formation/720-client-vpn/vpn-auth-routes.njk
@@ -36,6 +36,8 @@ Resources:
   EndpointRoutePublicSubnet{{ subnet_id | last }}:
     Condition: FullTunnel
     Type: AWS::EC2::ClientVpnRoute
+    DependsOn:
+      - EndpointAssociation{{ subnet_id | last }}
     Properties:
       Description: public-subnet{{ subnet_id | last }}
       ClientVpnEndpointId: !Ref ClientVpnEndpointId

--- a/org-formation/720-client-vpn/vpn.yaml
+++ b/org-formation/720-client-vpn/vpn.yaml
@@ -30,7 +30,6 @@ Parameters:
   SplitTunnel:
     Type: String
     Description: "Indicates whether split-tunnel is enabled on the AWS Client VPN endpoint (false for full tunnel)"
-    Default: false
     AllowedValues:
       - true
       - false

--- a/org-formation/720-client-vpn/vpn.yaml
+++ b/org-formation/720-client-vpn/vpn.yaml
@@ -45,8 +45,6 @@ Parameters:
       - 12
       - 24
     ConstraintDescription: 'Must be one of 8, 10, 12, or 24 hours'
-Conditions:
-  FullTunnel: !Equals [!Ref SplitTunnel, false]
 Resources:
   SecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
@@ -91,70 +89,8 @@ Resources:
       SecurityGroupIds:
         - !GetAtt SecurityGroup.GroupId
 
-{% for subnet_id in SubnetIds %}
-  EndpointAssociation{{ subnet_id | last }}:
-    Type: AWS::EC2::ClientVpnTargetNetworkAssociation
-    Properties:
-      ClientVpnEndpointId: !Ref Endpoint
-      SubnetId: {{ subnet_id }}
-{% endfor %}
-
-{# Authorization and route between VPN and public internet #}
-  EndpointAuthorizationPublic:
-    Condition: FullTunnel
-    Type: AWS::EC2::ClientVpnAuthorizationRule
-    Properties:
-      Description: "public"
-      AuthorizeAllGroups: true
-      ClientVpnEndpointId: !Ref Endpoint
-      TargetNetworkCidr: "0.0.0.0/0"
-
-{% for subnet_id in SubnetIds %}
-  EndpointRoutePublicSubnet{{ subnet_id | last }}:
-    Condition: FullTunnel
-    Type: AWS::EC2::ClientVpnRoute
-    Properties:
-      Description: public-subnet{{ subnet_id | last }}
-      ClientVpnEndpointId: !Ref Endpoint
-      DestinationCidrBlock: "0.0.0.0/0"
-      TargetVpcSubnetId: {{ subnet_id }}
-{% endfor %}
-
-{# Authorization and routes between VPN and spokes #}
-{% for spoke, spoke_data in TgwSpokes %}
-{%   for access_group in spoke_data.AccessGroups %}
-  EndpointAuthorization{{ spoke_data.CIDR | replace('.','') | replace('/','') }}{{ access_group | replace('-','') }}:
-    Type: AWS::EC2::ClientVpnAuthorizationRule
-    DependsOn:
-{%     for subnet_id in SubnetIds %}
-      - EndpointAssociation{{ subnet_id | last }}
-{%     endfor %}
-    Properties:
-      Description: {{ spoke }}-{{ access_group }}
-      AccessGroupId: {{ access_group }}
-      ClientVpnEndpointId: !Ref Endpoint
-      TargetNetworkCidr: {{ spoke_data.CIDR }}
-{%   endfor %}
-{% endfor %}
-
-{% for spoke, spoke_data in TgwSpokes %}
-{%   for subnet_id in SubnetIds %}
-  EndpointRoute{{ spoke_data.CIDR | replace('.','') | replace('/','') }}{{ subnet_id | last }}:
-    Type: AWS::EC2::ClientVpnRoute
-    DependsOn:
-{%     for depend in SubnetIds %}
-      - EndpointAssociation{{ subnet_id | last }}
-{%     endfor %}
-    Properties:
-      Description: {{ spoke }}-Subnet{{ subnet_id | last }}
-      ClientVpnEndpointId: !Ref Endpoint
-      DestinationCidrBlock: {{ spoke_data.CIDR }}
-      TargetVpcSubnetId: {{ subnet_id }}
-{%   endfor %}
-{% endfor %}
-
 Outputs:
-  Endpoint:
+  EndpointId:
     Description: The VPN endpoint Id
     Value: !Ref Endpoint
     Export:


### PR DESCRIPTION
Authorization and route configurations will change often however
the VPN should not.  We de-couple the two so it will make it
easier to fix auth and route configurations if they ever get
messed up.

