### PR TITLE
[IT-1234] Fix VPN configuration

### DIFF
--- a/org-formation/720-client-vpn/_tasks.yaml
+++ b/org-formation/720-client-vpn/_tasks.yaml
@@ -66,6 +66,7 @@ Vpn:
     # https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-getting-started.html#cvpn-getting-started-certs
     ServerCertificateArn: !Sub 'arn:aws:acm:${primaryRegion}:${accountId}:certificate/8bdbf421-c38a-4d87-8a03-821a1b7acab6'
     SplitTunnel: !Ref splitTunnel
+    VpnDnsServers: ["10.50.0.2", "8.8.8.8"]
 
 VpnAuthRoutes:
   DependsOn: [ Vpn ]

--- a/org-formation/720-client-vpn/vpn.yaml
+++ b/org-formation/720-client-vpn/vpn.yaml
@@ -38,12 +38,11 @@ Parameters:
     Type: Number
     Description: "The maximum VPN session duration time in hours."
     Default: 24
-    AllowedValues:
-      - 8
-      - 10
-      - 12
-      - 24
+    AllowedValues: [8, 10, 12, 24]
     ConstraintDescription: 'Must be one of 8, 10, 12, or 24 hours'
+  VpnDnsServers:
+    Type: List<String>
+    Description: "A list IP Addresses for DNS"
 Resources:
   SecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
@@ -76,6 +75,7 @@ Resources:
             SAMLProviderArn: !Ref VpnSamlProviderArn
             SelfServiceSAMLProviderArn: !Ref VpnSspSamlProviderArn
       ClientCidrBlock: !Ref ClientCidrBlock
+      DnsServers: !Ref VpnDnsServers
       ConnectionLogOptions:
         Enabled: true
         CloudwatchLogGroup: !Ref CloudwatchLogGroup


### PR DESCRIPTION
The existing configuration did not allow windows clients to access
to the internet after connecting to the VPN.  AWS support says that
we need to configure the DNS servers in order for windows to connect
to the internet.  This sets the DNS configurations as specified in
the VPC docs[1]

[1] https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html

