### PR TITLE
[IT-1663] Setup service role for Agora dev account

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -1,7 +1,7 @@
 Parameters:
   <<: !Include '../_parameters.yaml'
 
-#---------- A service account for https://github.com/Sage-Bionetworks/agora-infra  -----------
+# ------ A service account for https://github.com/Sage-Bionetworks/agora-infra  -------
 AgoraDevCIServiceAccount:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/IAM/service-account.yaml
@@ -25,7 +25,7 @@ AgoraProdCIServiceAccount:
     IncludeMasterAccount: false
     Account: !Ref AgoraProdAccount
     Region: us-east-1
-----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 # A service account for https://github.com/Sage-Bionetworks/iatlas-infra
 iAtlasCIServiceAccount:

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -1,8 +1,20 @@
 Parameters:
   <<: !Include '../_parameters.yaml'
 
-# A service account for https://github.com/Sage-Bionetworks/agora-infra
-AgoraCIServiceAccount:
+#---------- A service account for https://github.com/Sage-Bionetworks/agora-infra  -----------
+AgoraDevCIServiceAccount:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/IAM/service-account.yaml
+  StackName: ci-service-access
+  Parameters:
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AdministratorAccess
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+    Account: !Ref AgoraDevAccount
+    Region: us-east-1
+
+AgoraProdCIServiceAccount:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/IAM/service-account.yaml
   StackName: ci-service-access
@@ -13,6 +25,7 @@ AgoraCIServiceAccount:
     IncludeMasterAccount: false
     Account: !Ref AgoraProdAccount
     Region: us-east-1
+----------------------------------------------------------------------
 
 # A service account for https://github.com/Sage-Bionetworks/iatlas-infra
 iAtlasCIServiceAccount:


### PR DESCRIPTION
Setup a service user/role pair to allow CI to deploy resources
to the Agora Dev account.

depends on #443

