### PR TITLE
IT-426 add SumoLogic role to Bridge

### DIFF
--- a/sceptre/bridge/config/develop/sumologic-role.yaml
+++ b/sceptre/bridge/config/develop/sumologic-role.yaml
@@ -1,0 +1,10 @@
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/sumologic-role.yaml
+stack_name: sumologic-role
+dependencies:
+  - develop/essentials.yaml
+parameters:
+  ExternalID: !ssm /infra/SumologicExternalID
+  Actions: 's3:GetObject,s3:GetObjectVersion,s3:ListBucketVersions,s3:ListBucket'
+  Resource: 'arn:aws:s3:::elasticbeanstalk-us-east-1-420786776710'

--- a/sceptre/bridge/config/prod/sumologic-role.yaml
+++ b/sceptre/bridge/config/prod/sumologic-role.yaml
@@ -1,0 +1,10 @@
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/sumologic-role.yaml
+stack_name: sumologic-role
+dependencies:
+  - prod/essentials.yaml
+parameters:
+  ExternalID: !ssm /infra/SumologicExternalID
+  Actions: 's3:GetObject,s3:GetObjectVersion,s3:ListBucketVersions,s3:ListBucket'
+  Resource: 'arn:aws:s3:::elasticbeanstalk-us-east-1-649232250620'


### PR DESCRIPTION
Add SumoLogic roles to the Bridge account so we can migrate from key-based authentication to role-based authentication.

PR Checklist:
[X] Describe and explain your intentions for this change
[ ] Setup pre-commit and run the validators (info in README.md)
