### PR TITLE
[IT-1736] Role for AWS sceptre account

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -130,6 +130,20 @@ CnbCIServiceAccount:
       - !Ref CnbAccount
     Region: !Ref primaryRegion
 
+# A service account for https://github.com/Sceptre/sceptre-aws
+SceptreCIServiceAccount:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/IAM/service-account.yaml
+  StackName: ci-service-access
+  Parameters:
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AdministratorAccess
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+    Account:
+      - !Ref SceptreDevAccount
+    Region: us-east-1
+
 # =====================================================================================================
 # Some of our accounts, like org-sagebase-strides, are not part of the Sage organization therefore we need
 # to manage them as external entities. To allow strides account to send cloudtrail and config artifacts to


### PR DESCRIPTION
Setup a service account for the AWS account used for testing
Sceptre.  This credential is used in the sceptre-aws repo[1]

[1] https://github.com/Sceptre/sceptre-aws

