### PR TITLE
Remove S3 gateway endpoint

### DIFF
--- a/sceptre/sandbox/config/prod/s3-gateway-vpc-endpoint.yaml
+++ b/sceptre/sandbox/config/prod/s3-gateway-vpc-endpoint.yaml
@@ -1,9 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml
-stack_name: s3-gateway-vpc-endpoint
-dependencies:
-  - prod/sandcastlevpc.yaml
-parameters:
-  VpcName: sandcastlevpc
-  ServiceName: com.amazonaws.us-east-1.s3

--- a/sceptre/scicomp/config/prod/s3-computevpc-gateway-endpoint.yaml
+++ b/sceptre/scicomp/config/prod/s3-computevpc-gateway-endpoint.yaml
@@ -1,9 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml
-stack_name: s3-computevpc-gateway-vpc-endpoint
-dependencies:
-  - prod/computevpc.yaml
-parameters:
-  VpcName: computevpc
-  ServiceName: com.amazonaws.us-east-1.s3

--- a/sceptre/scicomp/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
+++ b/sceptre/scicomp/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
@@ -1,9 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml
-stack_name: s3-snowflakevpc-gateway-vpc-endpoint
-dependencies:
-  - prod/snowflakevpc.yaml
-parameters:
-  VpcName: snowflakevpc
-  ServiceName: com.amazonaws.us-east-1.s3

--- a/sceptre/scipool/config/bmgfki/s3-gatespoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/bmgfki/s3-gatespoolvpc-gateway-endpoint.yaml
@@ -1,9 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml
-stack_name: s3-gatespoolvpc-gateway-endpoint
-dependencies:
-  - bmgfki/gatespoolvpc.yaml
-parameters:
-  VpcName: gatespoolvpc
-  ServiceName: com.amazonaws.us-east-1.s3

--- a/sceptre/scipool/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
@@ -1,9 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml
-stack_name: s3-cesspoolvpc-gateway-endpoint
-dependencies:
-  - develop/cesspoolvpc.yaml
-parameters:
-  VpcName: cesspoolvpc
-  ServiceName: com.amazonaws.us-east-1.s3

--- a/sceptre/scipool/config/prod/s3-internalpoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/prod/s3-internalpoolvpc-gateway-endpoint.yaml
@@ -1,9 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml
-stack_name: s3-internalpoolvpc-gateway-endpoint
-dependencies:
-  - prod/internalpoolvpc.yaml
-parameters:
-  VpcName: internalpoolvpc
-  ServiceName: com.amazonaws.us-east-1.s3

--- a/sceptre/scipool/config/strides/s3-stridespoolvpc-gateway-endpoint.yaml
+++ b/sceptre/scipool/config/strides/s3-stridespoolvpc-gateway-endpoint.yaml
@@ -1,9 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/gateway-vpc-endpoint.yaml
-stack_name: s3-stridespoolvpc-gateway-endpoint
-dependencies:
-  - strides/stridespoolvpc.yaml
-parameters:
-  VpcName: stridespoolvpc
-  ServiceName: com.amazonaws.us-east-1.s3


### PR DESCRIPTION
We have added the s3 gateway endpoint to the VPC templates in
PR https://github.com/Sage-Bionetworks/aws-infra/pull/324 therefore
we we don't need to deploy the gateway in a spearate template

