### PR TITLE
[IT-1234] Update scipool products

### DIFF
--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
@@ -27,7 +27,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.21'
-    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
+    - Description: 'Add instance types x2gd, g4dn, and i3en.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.22'
+    - Description: 'Update for AWS VPN. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.36/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.36'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -82,7 +82,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.26/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.26'
-    - Description: 'Update R and R-Studio versions. {{ range(1, 10000) | random }}'
+    - Description: 'Update R and R-Studio versions.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.34/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.34'
+    - Description: 'Update for AWS VPN. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.36/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.1.36'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -75,7 +75,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.19/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
       Name: 'v1.1.19'
-    - Description: 'Reduce instance types. {{ range(1, 10000) | random }}'
+    - Description: 'Reduce instance types.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
       Name: 'v1.1.21'
+    - Description: 'Update for AWS VPN. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.36/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
+      Name: 'v1.1.36'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud.yaml
@@ -64,7 +64,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-jumpcloud.yaml'
       Name: 'v1.1.21'
-    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
+    - Description: 'Add instance types x2gd, g4dn, and i3en.'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-jumpcloud.yaml'
       Name: 'v1.1.22'
+    - Description: 'Update for AWS VPN. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.36/ec2/sc-ec2-linux-jumpcloud.yaml'
+      Name: 'v1.1.36'

--- a/sceptre/scipool/config/develop/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-windows-jumpcloud.yaml
@@ -41,7 +41,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.13/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.13'
-    - Description:  'Restore set_env_var. {{ range(1, 10000) | random }}'
+    - Description:  'Restore set_env_var.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.14/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.14'
+    - Description:  'Update for AWS VPN. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.36/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.36'


### PR DESCRIPTION
Update scipool products to allow access from new AWS VPN.
This PR updates for scipool dev env only.  We update dev then will
update prod in a separate PR

depends on https://github.com/Sage-Bionetworks/service-catalog-library/pull/275

