### PR TITLE
Revert updates

### DIFF
--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -75,11 +75,7 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.19/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
       Name: 'v1.1.19'
-    - Description: 'Reduce instance types.'
+    - Description: 'Reduce instance types. {{ range(1, 10000) | random }}'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
       Name: 'v1.1.21'
-    - Description: 'Update for AWS VPN. {{ range(1, 10000) | random }}'
-      Info:
-        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.36/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
-      Name: 'v1.1.36'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud.yaml
@@ -64,11 +64,7 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-jumpcloud.yaml'
       Name: 'v1.1.21'
-    - Description: 'Add instance types x2gd, g4dn, and i3en.'
+    - Description: 'Add instance types x2gd, g4dn, and i3en. {{ range(1, 10000) | random }}'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-jumpcloud.yaml'
       Name: 'v1.1.22'
-    - Description: 'Update for AWS VPN. {{ range(1, 10000) | random }}'
-      Info:
-        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.36/ec2/sc-ec2-linux-jumpcloud.yaml'
-      Name: 'v1.1.36'


### PR DESCRIPTION
Revert updates to sc-product-ec2-linux-jumpcloud-workflows and
sc-product-ec2-linux-jumpcloud products because there are no updated
versions for these.  We no longer support these products

