### PR TITLE
IT-1874: Remove routes to spoke, pcx etc. for sandcastle

### DIFF
--- a/sceptre/admincentral/config/prod/peering-sandcastlevpc.yaml
+++ b/sceptre/admincentral/config/prod/peering-sandcastlevpc.yaml
@@ -1,8 +1,0 @@
-template:
-  path: VPCPeer.yaml
-stack_name: peering-sandcastlevpc
-parameters:
-  PeerVPC: vpc-0e9b80dc470a797d5
-  PeerVPCOwner: !ssm /infra/SandboxAwsAccountId
-  PeerVPCCIDR: 10.23.0.0/16
-  PeerRoleName: essentials-VPCPeeringAuthorizerRole-ZEGJ99TU4YVM


### PR DESCRIPTION
This PR tests step2, in admincentral remove the routes to spoke, the peering etc. 
Don't merge until #477 is in.
