### PR TITLE
[IT-1934] Make github access to aws more secure

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -4,7 +4,7 @@ Parameters:
 GithubOidcSageBionetworksIt:
   Type: update-stacks
   Template: github-oidc-provider.njk
-  StackName: github-oidc-sageb-bionetworks-it
+  StackName: github-oidc-sage-bionetworks-it
   Parameters:
     ThumbprintList:
       - "6938fd4d98bab03faadb97b34396831e3780aea1"

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -1,0 +1,19 @@
+Parameters:
+  <<: !Include '../_parameters.yaml'
+
+GithubOidcSageBionetworksIt:
+  Type: update-stacks
+  Template: github-oidc-provider.njk
+  StackName: github-oidc-sageb-bionetworks-it
+  Parameters:
+    ThumbprintList:
+      - "6938fd4d98bab03faadb97b34396831e3780aea1"
+    GitHubOrg: "Sage-Bionetworks-IT"
+  TemplatingContext:
+    Repositories:
+      - repo: "organizations-infra"
+        branch: "master"
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+    Region: us-east-1
+

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -16,4 +16,3 @@ GithubOidcSageBionetworksIt:
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
     Region: us-east-1
-

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -6,12 +6,14 @@ GithubOidcSageBionetworksIt:
   Template: github-oidc-provider.njk
   StackName: github-oidc-sage-bionetworks-it
   Parameters:
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
     ThumbprintList:
       - "6938fd4d98bab03faadb97b34396831e3780aea1"
     GitHubOrg: "Sage-Bionetworks-IT"
   TemplatingContext:
     Repositories:
-      - repo: "organizations-infra"
+      - name: "organizations-infra"
         branch: "master"
   DefaultOrganizationBinding:
     IncludeMasterAccount: true

--- a/org-formation/650-identity-providers/github-oidc-provider.njk
+++ b/org-formation/650-identity-providers/github-oidc-provider.njk
@@ -58,6 +58,11 @@ Resources:
       ClientIdList: !Ref ClientIdList
       ThumbprintList: !Ref ThumbprintList
       Url: !Ref Url
+  ServicePolicy:
+    Condition: HasPolicyDocument
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument: !Ref PolicyDocument
 {% for Repository in Repositories %}
   ProviderRole{{ Repository.name | replace('-','') | replace('_','') }}:
     Type: AWS::IAM::Role

--- a/org-formation/650-identity-providers/github-oidc-provider.njk
+++ b/org-formation/650-identity-providers/github-oidc-provider.njk
@@ -18,6 +18,39 @@ Parameters:
   GitHubOrg:
     Type: String
     Description: "The name of the github organization"
+  # Must provide either a list of ManagePolicyArns or a custom PolicyDocument.
+  # Can also provide both a list of ManagePolicyArns and a custom PolicyDocument.
+  ManagedPolicyArns:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: >-
+      A list of managed policies for the role. Required if PolicyDocument not provided.
+      Example:
+        ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess", "arn:aws:iam::1111111111:policy/MY-EXISTING-POLICY"]
+  PolicyDocument:
+    Type: String
+    Default: ""
+    Description: >-
+      A JSON policy document to define a custom policy for the role. Required if ManagedPolicyArns not provided.
+      Example:
+        {
+          "Version":"2012-10-17",
+          "Statement":[
+            {
+              "Sid":"PublicRead",
+              "Effect":"Allow",
+              "Principal": "*",
+              "Action":["s3:GetObject","s3:GetObjectVersion"],
+              "Resource":["arn:aws:s3:::EXAMPLE-BUCKET/*"]
+            }
+          ]
+        }
+Conditions:
+  HasManagedPolicyArns: !Not
+    - !Equals
+      - !Join ["", !Ref ManagedPolicyArns]
+      - ''
+  HasPolicyDocument: !Not [!Equals [!Ref PolicyDocument, ""]]
 Resources:
   Provider:
     Type: AWS::IAM::OIDCProvider
@@ -26,9 +59,16 @@ Resources:
       ThumbprintList: !Ref ThumbprintList
       Url: !Ref Url
 {% for Repository in Repositories %}
-  ProviderRole{{ Repository.repo | replace('-','') | replace('_','') }}:
+  ProviderRole{{ Repository.name | replace('-','') | replace('_','') }}:
     Type: AWS::IAM::Role
     Properties:
+      # Concatinate managed policy and custom policy
+      ManagedPolicyArns: !Split
+        - ","
+        - !Join
+            - ","
+            - - !If [HasPolicyDocument, !Ref ServicePolicy, !Ref 'AWS::NoValue']
+              - !If [HasManagedPolicyArns, !Join [",", !Ref "ManagedPolicyArns"], !Ref 'AWS::NoValue']
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow
@@ -36,11 +76,9 @@ Resources:
             Principal:
               Federated: !Ref Provider
             Condition:
-              StringLike:
-                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/{{ Repository.repo }}:*
               ForAllValues:StringEquals:
                 token.actions.githubusercontent.com:aud: !Ref ClientIdList
-                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/{{ Repository.repo }}:ref:refs/heads/{{ Repository.branch }}
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/{{ Repository.name }}:ref:refs/heads/{{ Repository.branch }}
 {% endfor %}
 Outputs:
   ProviderArn:
@@ -48,8 +86,8 @@ Outputs:
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ProviderArn'
 {% for Repository in Repositories %}
-  ProviderRoleArn{{ Repository.repo | replace('-','') | replace('_','') }}:
-    Value: !GetAtt ProviderRole{{ Repository.repo | replace('-','') | replace('_','') }}.Arn
+  ProviderRoleArn{{ Repository.name | replace('-','') | replace('_','') }}:
+    Value: !GetAtt ProviderRole{{ Repository.name | replace('-','') | replace('_','') }}.Arn
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ProviderRoleArn-{{ Repository.repo | replace('-','') | replace('_','') }}'
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ProviderRoleArn-{{ Repository.name | replace('-','') | replace('_','') }}'
 {% endfor %}

--- a/org-formation/650-identity-providers/github-oidc-provider.njk
+++ b/org-formation/650-identity-providers/github-oidc-provider.njk
@@ -1,0 +1,55 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  ClientIdList:
+    Type: List<String>
+    Description: >-
+      A list of client IDs (also known as audiences) that are associated with
+      the specified IAM OIDC provider resource object
+    Default: "sts.amazonaws.com"
+  ThumbprintList:
+    Type: List<String>
+    Description: >-
+      A list of certificate thumbprints that are associated with the specified
+      IAM OIDC provider resource object
+  Url:
+    Type: String
+    Description: "The URL that the IAM OIDC provider resource object is associated with"
+    Default: "https://token.actions.githubusercontent.com"
+  GitHubOrg:
+    Type: String
+    Description: "The name of the github organization"
+Resources:
+  Provider:
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      ClientIdList: !Ref ClientIdList
+      ThumbprintList: !Ref ThumbprintList
+      Url: !Ref Url
+{% for Repository in Repositories %}
+  ProviderRole{{ Repository.repo | replace('-','') | replace('_','') }}:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRoleWithWebIdentity
+            Principal:
+              Federated: !Ref Provider
+            Condition:
+              StringLike:
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/{{ Repository.repo }}:*
+              ForAllValues:StringEquals:
+                token.actions.githubusercontent.com:aud: !Ref ClientIdList
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/{{ Repository.repo }}:ref:refs/heads/{{ Repository.branch }}
+{% endfor %}
+Outputs:
+  ProviderArn:
+    Value: !Ref Provider
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ProviderArn'
+{% for Repository in Repositories %}
+  ProviderRoleArn{{ Repository.repo | replace('-','') | replace('_','') }}:
+    Value: !GetAtt ProviderRole{{ Repository.repo | replace('-','') | replace('_','') }}.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ProviderRoleArn-{{ Repository.repo | replace('-','') | replace('_','') }}'
+{% endfor %}

--- a/org-formation/650-identity-providers/github-oidc-provider.njk
+++ b/org-formation/650-identity-providers/github-oidc-provider.njk
@@ -1,4 +1,8 @@
-AWSTemplateFormatVersion: '2010-09-09'
+{# Allow Github to access AWS without giving github AWS credentials #}
+{# Must pass in the following templating parameters    #}
+{#   Repositories:                                     #}
+{#     - name: "organizations-infra"                   #}
+{#       branch: "master"                              #}
 Parameters:
   ClientIdList:
     Type: List<String>

--- a/org-formation/_tasks.yaml
+++ b/org-formation/_tasks.yaml
@@ -61,6 +61,11 @@ AccountAccess:
   DependsOn: [ Types ]
   Path: ./600-access/_tasks.yaml
 
+IdentityProviders:
+  Type: include
+  DependsOn: [ Types ]
+  Path: ./650-identity-providers/_tasks.yaml
+
 AwsSso:
   Type: include
   DependsOn: [ Types, SeviceControlPolicies ]


### PR DESCRIPTION
This is to configure Github OpenID connect in AWS[1].  This allows
us to use github actions to deploy cloud resources to AWS
without having to give github our AWS credentials.

[1] https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services