### PR TITLE
Fix jinj2 linter

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -31,6 +31,8 @@ jobs:
             jinja2==3.0.1
             jinja2-ansible-filters
       - name: Install jinja linter tool
-        run: git clone --single-branch https://github.com/drm/jinja2-lint.git /tmp/jinja2-lint
+        run:
+          - git clone --single-branch https://github.com/drm/jinja2-lint.git /tmp/jinja2-lint
+          - pushd /tmp/jinja2-lint && git checkout 75dcd5a
       - name: Execute jinja linter
         run: find . -type f -name "*.j2" -exec /tmp/jinja2-lint/j2lint.py '{}' +

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -31,8 +31,6 @@ jobs:
             jinja2==3.0.1
             jinja2-ansible-filters
       - name: Install jinja linter tool
-        run:
-          - git clone --single-branch https://github.com/drm/jinja2-lint.git /tmp/jinja2-lint
-          - pushd /tmp/jinja2-lint && git checkout 75dcd5a
+        run: git clone --single-branch https://github.com/drm/jinja2-lint.git /tmp/jinja2-lint && pushd /tmp/jinja2-lint && git checkout 75dcd5a
       - name: Execute jinja linter
         run: find . -type f -name "*.j2" -exec /tmp/jinja2-lint/j2lint.py '{}' +

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -28,8 +28,7 @@ jobs:
         uses: BSFishy/pip-action@v1
         with:
           packages: |
-            ansible
-            jinja2
+            jinja2==3.0.1
             jinja2-ansible-filters
       - name: Install jinja linter tool
         run: git clone --single-branch https://github.com/drm/jinja2-lint.git /tmp/jinja2-lint

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -29,7 +29,6 @@ jobs:
         with:
           packages: |
             jinja2==3.0.1
-            jinja2-ansible-filters
       - name: Install jinja linter tool
         run: git clone --single-branch https://github.com/drm/jinja2-lint.git /tmp/jinja2-lint && pushd /tmp/jinja2-lint && git checkout 75dcd5a
       - name: Execute jinja linter

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -28,6 +28,7 @@ jobs:
         uses: BSFishy/pip-action@v1
         with:
           packages: |
+            ansible
             jinja2
             jinja2-ansible-filters
       - name: Install jinja linter tool

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -27,7 +27,9 @@ jobs:
       - name: Install jinja libraries
         uses: BSFishy/pip-action@v1
         with:
-          packages: jinja2==3.0.1
+          packages:
+            - jinja2==3.0.1
+            - jinja2-ansible-filters
       - name: Install jinja linter tool
         run: git clone --single-branch https://github.com/drm/jinja2-lint.git /tmp/jinja2-lint
       - name: Execute jinja linter

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -27,9 +27,9 @@ jobs:
       - name: Install jinja libraries
         uses: BSFishy/pip-action@v1
         with:
-          packages:
-            - jinja2==3.0.1
-            - jinja2-ansible-filters
+          packages: |
+            jinja2
+            jinja2-ansible-filters
       - name: Install jinja linter tool
         run: git clone --single-branch https://github.com/drm/jinja2-lint.git /tmp/jinja2-lint
       - name: Execute jinja linter


### PR DESCRIPTION
Running the linter caused the following error..
`ModuleNotFoundError: No module named 'jinja2-ansible-filters'`

Go back to a working jinja2-lint version due to issue https://github.com/drm/jinja2-lint/issues/18
