### PR TITLE
[IT-1934] Use OIDC role to deploy cfn to all accounts

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -99,11 +99,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::745159704268:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -132,11 +135,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::804034162148:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -165,11 +171,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::563295687221:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -198,11 +207,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::055273631518:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -231,11 +243,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::423819316185:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -264,11 +279,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::751556145034:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -297,11 +315,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::465877038949:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -330,11 +351,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::237179673806:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -369,11 +393,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::423819316185:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -406,11 +433,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::464102568320:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -443,11 +473,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::797640923903:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -481,11 +514,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::231505186444:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -514,11 +550,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::383874245509:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -547,11 +586,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::449435941126:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -580,11 +622,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::325565585839:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -613,11 +658,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::140124849929:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -646,11 +694,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::420786776710:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -679,11 +730,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::649232250620:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200
@@ -712,11 +766,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install sceptre sceptre-ssm-resolver
+      - name: Assume organizations role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::531805629419:role/bootstrap-ci-service-access-CiServiceRole-VVXK9EUQNPUZ
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::867686887310:role/OrganizationFormationBuildAccessRole
           role-duration-seconds: 1200

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -83,6 +83,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-admincentral:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -119,6 +122,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-itsandbox:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -155,6 +161,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-sandbox:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -191,6 +200,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-scicomp:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -227,6 +239,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-strides:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -263,6 +278,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-strides-ampad-workflows:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -299,6 +317,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-scipooldev:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -335,6 +356,9 @@ jobs:
           sceptre launch develop --yes
   sceptre-scipoolprod:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -377,6 +401,9 @@ jobs:
     needs:
       - org-formation
       - sceptre-strides
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -417,6 +444,9 @@ jobs:
           sceptre launch strides --yes
   sceptre-bmgfki:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -457,6 +487,9 @@ jobs:
           sceptre launch bmgfki --yes
   sceptre-sageit:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -498,6 +531,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-logcentral:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -534,6 +570,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-synapsedw:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -570,6 +609,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-synapsedev:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -606,6 +648,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-synapseprod:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -642,6 +687,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-securitycentral:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -678,6 +726,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-bridgedev:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -714,6 +765,9 @@ jobs:
           sceptre launch develop --yes
   sceptre-bridgeprod:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -750,6 +804,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-imagecentral:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Setup github action to assume the org role that has cross account
access to assume one a role in one of it's child accounts. Then
use the child account's role to deploy templates.

depends on #495

