### PR TITLE
[IT-1934] Use OIDC role

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -83,6 +83,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-admincentral:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -104,10 +107,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::745159704268:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::745159704268:role/github-oidc-sage-bionetwo-ProviderRoleorganization-93H11ERK3F4N
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -116,6 +117,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-itsandbox:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -137,10 +141,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::804034162148:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::804034162148:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1HOMAZA6V6MZF
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -149,6 +151,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-sandbox:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -170,10 +175,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::563295687221:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::563295687221:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1W3Y2BTXS0IHN
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -182,6 +185,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-scicomp:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -203,10 +209,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::055273631518:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::055273631518:role/github-oidc-sage-bionetwo-ProviderRoleorganization-4FAIL7WJ3XUJ
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -215,6 +219,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-strides:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -248,6 +255,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-strides-ampad-workflows:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -281,6 +291,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-scipooldev:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -302,10 +315,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::465877038949:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::465877038949:role/github-oidc-sage-bionetwo-ProviderRoleorganization-12N6ZXXUHHIAE
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -314,6 +325,9 @@ jobs:
           sceptre launch develop --yes
   sceptre-scipoolprod:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -335,10 +349,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::237179673806:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::237179673806:role/github-oidc-sage-bionetwo-ProviderRoleorganization-10OXGCTGE0A2S
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         # SC-26 & SC-219 workaround: dis-associate and re-associate SC actions on every deploy
@@ -353,6 +365,9 @@ jobs:
     needs:
       - org-formation
       - sceptre-strides
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -390,6 +405,9 @@ jobs:
           sceptre launch strides --yes
   sceptre-bmgfki:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -411,10 +429,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::464102568320:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::464102568320:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1I3FAZB5NGCL6
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         # SC-26 & SC-219 workaround: dis-associate and re-associate SC actions on every deploy
@@ -427,6 +443,9 @@ jobs:
           sceptre launch bmgfki --yes
   sceptre-sageit:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -448,10 +467,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::797640923903:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::797640923903:role/github-oidc-sage-bionetwo-ProviderRoleorganization-I97YJEULPXRB
           role-duration-seconds: 1200
       - name: Deploy staging with sceptre
         run: |
@@ -465,6 +482,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-logcentral:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -486,10 +506,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::231505186444:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::231505186444:role/github-oidc-sage-bionetwo-ProviderRoleorganization-VQLGWAN33424
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -498,6 +516,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-synapsedw:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -519,10 +540,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::383874245509:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::383874245509:role/github-oidc-sage-bionetwo-ProviderRoleorganization-5CKE8W1T0QQN
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -531,6 +550,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-synapsedev:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -552,10 +574,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::449435941126:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::449435941126:role/github-oidc-sage-bionetwo-ProviderRoleorganization-JYEP5VLBM0OD
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -564,6 +584,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-synapseprod:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -585,10 +608,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::325565585839:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::325565585839:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1VA1E6MRNQ9LY
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -597,6 +618,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-securitycentral:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -618,10 +642,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::140124849929:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::140124849929:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1Y0ZL6QUYBBXP
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -630,6 +652,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-bridgedev:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -651,10 +676,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::420786776710:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::420786776710:role/github-oidc-sage-bionetwo-ProviderRoleorganization-ZML8QW5KQAJI
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -663,6 +686,9 @@ jobs:
           sceptre launch develop --yes
   sceptre-bridgeprod:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -684,10 +710,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::649232250620:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::649232250620:role/github-oidc-sage-bionetwo-ProviderRoleorganization-2YBQPKY1HZSY
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -696,6 +720,9 @@ jobs:
           sceptre launch prod --yes
   sceptre-imagecentral:
     needs: org-formation
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -717,10 +744,8 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::867686887310:role/OrganizationFormationBuildAccessRole
+          role-to-assume: arn:aws:iam::867686887310:role/github-oidc-sage-bionetwo-ProviderRoleorganization-Q3961B67OXY7
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -219,9 +219,6 @@ jobs:
           sceptre launch prod --yes
   sceptre-strides:
     needs: org-formation
-    permissions:
-      id-token: write
-      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -255,9 +252,6 @@ jobs:
           sceptre launch prod --yes
   sceptre-strides-ampad-workflows:
     needs: org-formation
-    permissions:
-      id-token: write
-      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -365,9 +359,6 @@ jobs:
     needs:
       - org-formation
       - sceptre-strides
-    permissions:
-      id-token: write
-      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Setup github action to use the OIDC role in member accounts to deploy
cloudformation templates.  This sets up OIDC for all accounts
except for strides which is not in the organization.

depends on #492 #498

