### PR TITLE
Add an AWS role-session-name to deployment

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::531805629419:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1EY1CRUF48VP5
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Use Node.js
         uses: actions/setup-node@v1
@@ -75,6 +76,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::531805629419:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1EY1CRUF48VP5
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -109,6 +111,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::745159704268:role/github-oidc-sage-bionetwo-ProviderRoleorganization-93H11ERK3F4N
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -143,6 +146,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::804034162148:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1HOMAZA6V6MZF
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -177,6 +181,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::563295687221:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1W3Y2BTXS0IHN
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -211,6 +216,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::055273631518:role/github-oidc-sage-bionetwo-ProviderRoleorganization-4FAIL7WJ3XUJ
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -244,6 +250,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::423819316185:role/OrganizationFormationBuildAccessRole
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -277,6 +284,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::751556145034:role/OrganizationFormationBuildAccessRole
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -311,6 +319,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::465877038949:role/github-oidc-sage-bionetwo-ProviderRoleorganization-12N6ZXXUHHIAE
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -345,6 +354,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::237179673806:role/github-oidc-sage-bionetwo-ProviderRoleorganization-10OXGCTGE0A2S
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         # SC-26 & SC-219 workaround: dis-associate and re-associate SC actions on every deploy
@@ -384,6 +394,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::423819316185:role/OrganizationFormationBuildAccessRole
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         # SC-26 & SC-219 workaround: dis-associate and re-associate SC actions on every deploy
@@ -422,6 +433,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::464102568320:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1I3FAZB5NGCL6
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         # SC-26 & SC-219 workaround: dis-associate and re-associate SC actions on every deploy
@@ -460,6 +472,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::797640923903:role/github-oidc-sage-bionetwo-ProviderRoleorganization-I97YJEULPXRB
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy staging with sceptre
         run: |
@@ -499,6 +512,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::231505186444:role/github-oidc-sage-bionetwo-ProviderRoleorganization-VQLGWAN33424
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -533,6 +547,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::383874245509:role/github-oidc-sage-bionetwo-ProviderRoleorganization-5CKE8W1T0QQN
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -567,6 +582,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::449435941126:role/github-oidc-sage-bionetwo-ProviderRoleorganization-JYEP5VLBM0OD
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -601,6 +617,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::325565585839:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1VA1E6MRNQ9LY
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -635,6 +652,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::140124849929:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1Y0ZL6QUYBBXP
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -669,6 +687,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::420786776710:role/github-oidc-sage-bionetwo-ProviderRoleorganization-ZML8QW5KQAJI
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -703,6 +722,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::649232250620:role/github-oidc-sage-bionetwo-ProviderRoleorganization-2YBQPKY1HZSY
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |
@@ -737,6 +757,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::867686887310:role/github-oidc-sage-bionetwo-ProviderRoleorganization-Q3961B67OXY7
+          role-session-name: GitHubActions-${{ github.repository }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: Deploy with sceptre
         run: |


### PR DESCRIPTION
Assume a role with a role session name to allow us to easily audit
our CI deployments to AWS.
