### PR TITLE
step to validate cfn templates

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -46,6 +46,8 @@ jobs:
         run: npm install
       - name: Validate ofn templates
         run: npm run validate-tasks
+      - name: Validate with print-task
+        run: npm print-tasks-failfast
       - name: Deploy with ofn
         run: npm run ci-perform-tasks-parallel
   sceptre-organizations:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "print-tasks": "npx org-formation print-tasks ./org-formation/_tasks.yaml --verbose --print-stack --output yaml --max-concurrent-stacks 100 --max-concurrent-tasks 100",
-    "print-tasks-failfast": "npx org-formation print-tasks ./org-formation/_tasks.yaml --verbose --print-stack --output yaml --max-concurrent-stacks 1 --max-concurrent-tasks 1 --failed-tasks-tolerance 0  --failed-stacks-tolerance 0",
+    "print-tasks-failfast": "npx org-formation print-tasks ./org-formation/_tasks.yaml --verbose --print-stack --output yaml --max-concurrent-stacks 1 --max-concurrent-tasks 1 --failed-tasks-tolerance 1  --failed-stacks-tolerance 1",
     "perform-tasks": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 1 --max-concurrent-tasks 1",
     "ci-perform-tasks": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 1 --max-concurrent-tasks 1 --perform-cleanup",
     "ci-perform-tasks-parallel": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 10 --max-concurrent-tasks 10 --perform-cleanup",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "print-tasks": "npx org-formation print-tasks ./org-formation/_tasks.yaml --verbose --print-stack --output yaml --max-concurrent-stacks 100 --max-concurrent-tasks 100",
+    "print-tasks-failfast": "npx org-formation print-tasks ./org-formation/_tasks.yaml --verbose --print-stack --output yaml --max-concurrent-stacks 1 --max-concurrent-tasks 1 --failed-tasks-tolerance 0  --failed-stacks-tolerance 0",
     "perform-tasks": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 1 --max-concurrent-tasks 1",
     "ci-perform-tasks": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 1 --max-concurrent-tasks 1 --perform-cleanup",
     "ci-perform-tasks-parallel": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 10 --max-concurrent-tasks 10 --perform-cleanup",


### PR DESCRIPTION
Add an additional `print-task` step in CI to validate templates.
The `print-task` command will generate templates with inputs which
may find failures that the `validate` command may not

