### PR TITLE
[IT-1708] Setup IP address manager

### DIFF
--- a/org-formation/705-ipam/_tasks.yaml
+++ b/org-formation/705-ipam/_tasks.yaml
@@ -1,0 +1,12 @@
+Parameters:
+  <<: !Include '../_parameters.yaml'
+
+Ipam:
+  Type: update-stacks
+  Template: ipam.yaml
+  StackName: ipam
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+    Account:
+      - !Ref IpamAccount
+    Region: us-east-1

--- a/org-formation/705-ipam/ipam.yaml
+++ b/org-formation/705-ipam/ipam.yaml
@@ -1,0 +1,28 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'IP Address Manager'
+Resources:
+  Ipam:
+    Type: AWS::EC2::IPAM
+    Properties:
+      Description: SageOrganization
+Outputs:
+  IpamArn:
+    Description: 'IPAM ARN'
+    Value: !GetAtt Ipam.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-IpamArn'
+  IpamId:
+    Description: 'IPAM ID'
+    Value: !GetAtt Ipam.IpamId
+    Export:
+      Name: !Sub '${AWS::StackName}-IpamId'
+  IpamPrivateDefaultScopedId:
+    Description: 'IPAM private default scoped ID'
+    Value: !GetAtt Ipam.PrivateDefaultScopeId
+    Export:
+      Name: !Sub '${AWS::StackName}-IpamPrivateDefaultScopeId'
+  IpamPublicDefaultScopedId:
+    Description: 'IPAM public default scoped ID'
+    Value: !GetAtt Ipam.PublicDefaultScopeId
+    Export:
+      Name: !Sub '${AWS::StackName}-IpamPublicDefaultScopeId'

--- a/org-formation/_tasks.yaml
+++ b/org-formation/_tasks.yaml
@@ -71,6 +71,11 @@ AwsSso:
   DependsOn: [ Types, SeviceControlPolicies ]
   Path: ./700-aws-sso/_tasks.yaml
 
+AwsIpam:
+  Type: include
+  DependsOn: [ Types, SeviceControlPolicies ]
+  Path: ./705-ipam/_tasks.yaml
+
 TransitGateway:
   Type: include
   DependsOn: [ Types ]


### PR DESCRIPTION
Setup the AWS IP address manager in the IPAM account, which
is a delgate account[1] in the Sage organizations.  This will
allow giving a separate set of groups/users access to the
accoun to manage IPs.

[1] https://docs.aws.amazon.com/vpc/latest/ipam/enable-integ-ipam.html

