### PR TITLE
[IT-1960] Setup SSO for SaturnCloudDev account

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -193,13 +193,13 @@ Parameters:
     Type: String
     Default: '906769aa66-e78063c9-9fc6-4654-a089-ebb26854f202'
 
-  saturnCloudDevAdminGroup:     #JC aws-saturnclouddev-admins
+  saturnCloudDevAdminGroup:     #JC aws-saturncloud-dev-admins
     Type: String
-    Default: 'TBD'
+    Default: '906769aa66-810bed57-bb15-4f9f-a754-df4795e52a44'
 
-  saturnCloudDevDeveloperGroup:   #JC aws-saturnclouddev-developers
+  saturnCloudDevDeveloperGroup:   #JC aws-saturncloud-dev-developers
     Type: String
-    Default: 'TBD'
+    Default: '906769aa66-c6938d5f-605b-4ea8-9b1b-43b995b4fe4b'
 
 #----------------------------------------------------------------------------------------------
 

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -192,6 +192,15 @@ Parameters:
   dnTDevDeveloperGroup:   #JC aws-dntdev-developers
     Type: String
     Default: '906769aa66-e78063c9-9fc6-4654-a089-ebb26854f202'
+
+  saturnCloudDevAdminGroup:     #JC aws-saturnclouddev-admins
+    Type: String
+    Default: 'TBD'
+
+  saturnCloudDevDeveloperGroup:   #JC aws-saturnclouddev-developers
+    Type: String
+    Default: 'TBD'
+
 #----------------------------------------------------------------------------------------------
 
 SsoAdministrator:
@@ -1221,4 +1230,38 @@ SsoDntDevDeveloper:
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref dnTDevDeveloperGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
+
+SsoSaturnCloudDevAdmin:
+  Type: update-stacks
+  DependsOn: SsoAdministrator
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.11/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-saturnclouddev-admin'
+  StackDescription: 'SSO: admin role used by saturnclouddev admin group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref SaturnCloudDevAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref saturnCloudDevAdminGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
+
+SsoSaturnCloudDevDeveloper:
+  Type: update-stacks
+  DependsOn: SsoDeveloper
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.11/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-saturnclouddev-developer'
+  StackDescription: 'SSO: developer role used by staturnclouddev developer group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref SaturnCloudDevAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref saturnCloudDevDeveloperGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]


### PR DESCRIPTION
Setup SaturnCloudDev account integration with jumpcloud IDP.
This will allow jumpcloud groups `aws-saturncloud-dev-admins`
and `aws-saturncloud-dev-developers` access to SaturnCloudDev
AWS account.

