### PR TITLE
PLFM-7337: Add athena permission for builds

### DIFF
--- a/sceptre/synapsedev/templates/SynapseCMK-template.json
+++ b/sceptre/synapsedev/templates/SynapseCMK-template.json
@@ -201,6 +201,13 @@
                                         "lambda:*"
                                     ],
                                     "Resource": "*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "athena:*"
+                                    ],
+                                    "Resource": "*"
                                 }
                             ]
                         }


### PR DESCRIPTION
This PR adds permissions required to execute the Synapse repo build in the instance profile (as opposed to specifying credentials to the build). Note: not deployed by the infra.
