### PR TITLE
PLFM-1874: NLP-2-remove-peering

### DIFF
--- a/sceptre/admincentral/config/prod/peering-nlpsandbox.yaml
+++ b/sceptre/admincentral/config/prod/peering-nlpsandbox.yaml
@@ -1,8 +1,0 @@
-template:
-  path: VPCPeer.yaml
-stack_name: peering-nlpsandbox
-parameters:
-  PeerVPC: vpc-0f809761f28e9e350    # nlpsandbox VPC ID
-  PeerVPCOwner: "841415736403"      # nlpsandbox account ID
-  PeerVPCCIDR: 10.255.21.0/24       # nlpsandbox VPC CIDR
-  PeerRoleName: sagebase-vpc-peering-request-AuthorizerRole-NZ421S77TZ3Y  # authorizer role name created by sagebase-vpc-peering-request stack


### PR DESCRIPTION
After removing the routes in nlpsandbox, this PR removes the routes on admicentral side, as well as the peering and lambda used to accept the peering on nlp side.
