### PR TITLE
it-1874-remove-peering-authorizer-role

### DIFF
--- a/org-formation/300-account-defaults/_tasks.yaml
+++ b/org-formation/300-account-defaults/_tasks.yaml
@@ -53,19 +53,3 @@ ItKmsKey:
     IncludeMasterAccount: true
     Account: '*'
     Region: !Ref primaryRegion
-
-VpcPeeringRequest:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.12/templates/VPC/vpc-peering-request.yaml
-  StackName: !Sub '${resourcePrefix}-vpc-peering-request'
-  StackDescription: 'Authorize VPC peering requests'
-  Parameters:
-    VpcPeeringRequesterAwsAccountId: !Ref AdminCentralAccount
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: false
-    Account:
-      - !Ref NlpSandboxAccount
-      - !Ref WorkflowsNextflowDevAccount
-      - !Ref WorkflowsNextflowProdAccount
-      - !Ref MobileHealthDataEngineeringDevAccount


### PR DESCRIPTION
This PR removes the peering authorizer role (used to accept peering in target account). Originally targeted at nlpsandbox but after looking at other accounts listed I think it can be removed everywhere.

Depends on #517
