### PR TITLE
[IT-1986] Give developers access to beanstalk

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -261,7 +261,9 @@ SsoDeveloper:
     instanceArn: !Ref instanceArn
     principalId: !Ref developerGroup
     permissionSetName: 'Developer'
-    managedPolicies: [ 'arn:aws:iam::aws:policy/PowerUserAccess' ]
+    managedPolicies:
+      - 'arn:aws:iam::aws:policy/PowerUserAccess'
+      - 'arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk'
     sessionDuration: 'PT12H'
     inlinePolicy: >-
       {


### PR DESCRIPTION
For some reason AWS PowerUser policy does not provide access to make
app deployments in AWS Beanstalk.  We explicitly give Develops
access to beanstalk so they can adequately use it.

