### PR TITLE
Enable SCPs for PersonalAccountsOU

### DIFF
--- a/org-formation/010-scps/_tasks.yaml
+++ b/org-formation/010-scps/_tasks.yaml
@@ -36,6 +36,7 @@ PreventDisableCloudtrail:
       - !Ref SynapseOU
       - !Ref BridgeOU
       - !Ref ServiceCatalogOU
+      - !Ref PersonalAccountsOU
 
 PreventDisableCloudwatchConfigs:
   Type: update-stacks
@@ -54,6 +55,7 @@ PreventDisableCloudwatchConfigs:
       - !Ref SynapseOU
       - !Ref BridgeOU
       - !Ref ServiceCatalogOU
+      - !Ref PersonalAccountsOU
 
 #DenyAllRegionsOutsideUsEast1:
 #  Type: update-stacks


### PR DESCRIPTION
Prevent users from disabling cloudtrail and cloudwatch in their
personal accounts.

