### PR TITLE
[IT-1766] Restore AWS region restriction

### DIFF
--- a/org-formation/010-scps/_tasks.yaml
+++ b/org-formation/010-scps/_tasks.yaml
@@ -74,9 +74,9 @@ DenyAllRegionsOutsideUs:
   StackName: !Sub '${resourcePrefix}-deny-all-regions-outside-us'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
-    IncludeMasterAccount: true
+    IncludeMasterAccount: false
   Parameters:
-    targetIds: "*"
+    targetIds:
       - !Ref ScienceDevOU
       - !Ref ScienceProdOU
       - !Ref ServiceCatalogOU

--- a/org-formation/010-scps/_tasks.yaml
+++ b/org-formation/010-scps/_tasks.yaml
@@ -68,14 +68,16 @@ PreventDisableCloudwatchConfigs:
 #      - !Ref ItProdOU
 #      - !Ref ScienceProdOU
 
-#DenyAllRegionsOutsideUs:
-#  Type: update-stacks
-#  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.4/templates/SCP/deny-all-regions-outside-us.yaml
-#  StackName: !Sub '${resourcePrefix}-deny-all-regions-outside-us'
-#  DefaultOrganizationBindingRegion: !Ref primaryRegion
-#  DefaultOrganizationBinding:
-#    IncludeMasterAccount: true
-#  Parameters:
-#    targetIds: "*"
-#      - !Ref ScienceDevOU
-#      - !Ref ServiceCatalogOU
+DenyAllRegionsOutsideUs:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.4/templates/SCP/deny-all-regions-outside-us.yaml
+  StackName: !Sub '${resourcePrefix}-deny-all-regions-outside-us'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  Parameters:
+    targetIds: "*"
+      - !Ref ScienceDevOU
+      - !Ref ScienceProdOU
+      - !Ref ServiceCatalogOU
+      - !Ref PersonalAccountsOU


### PR DESCRIPTION
Restrict accounts from creating resources in regions outside of the US
region.

