### PR TITLE
IT-1874: Remove routes to new/current synapsedev VPC

### DIFF
--- a/sceptre/admincentral/config/prod/synapse-stack-dev-vpn-routes.yaml
+++ b/sceptre/admincentral/config/prod/synapse-stack-dev-vpn-routes.yaml
@@ -1,9 +1,0 @@
-template:
-  path: synapse-stack-vpn-routes.yaml
-stack_name: synapse-stack-dev-vpn-routes
-parameters:
-  # CIDR for the new Synapse dev stack
-  PeerVPCCIDR: 10.24.0.0/16
-  # Peering connection setup by the Synapse VPC stack builder
-  # Note: Synapse stacks request the peering from the spoke
-  VPCPeeringConnectionId: pcx-0d28b52d2cad54578


### PR DESCRIPTION
This PR removes the routes from admincentral to the current synapsedev VPC.
