### PR TITLE
IT-1874: Remove peering to stridespool

### DIFF
--- a/sceptre/admincentral/config/prod/peering-stridespoolvpc.yaml
+++ b/sceptre/admincentral/config/prod/peering-stridespoolvpc.yaml
@@ -1,8 +1,0 @@
-template:
-  path: VPCPeer.yaml
-stack_name: peering-stridespoolvpc
-parameters:
-  PeerVPC: "vpc-025cba6a01d73d32b"  # org-sagebase-strides stridespoolvpc ID
-  PeerVPCOwner: "423819316185"    # org-sagebase-strides account ID
-  PeerVPCCIDR: "10.49.0.0/16"       # org-sagebase-strides stridespoolvpc CIDR
-  PeerRoleName: "essentials-VPCPeeringAuthorizerRole-CVZEDVMU5NZX"   # org-sagebase-strides us-east-1-essentials-VPCPeeringAuthorizerRole


### PR DESCRIPTION
This PR removes the peering between admincentral and stridespoolvpc. It should be merged after removing the routes in strides account.
