### PR TITLE
IT-1874: Remove routes to synapseprod

### DIFF
--- a/sceptre/admincentral/config/prod/synapse-stack-prod-vpn-routes.yaml
+++ b/sceptre/admincentral/config/prod/synapse-stack-prod-vpn-routes.yaml
@@ -1,9 +1,0 @@
-template:
-  path: synapse-stack-vpn-routes.yaml
-stack_name: synapse-stack-prod-vpn-routes
-parameters:
-  # CIDR for the new Synapse prod stack
-  PeerVPCCIDR: 10.20.0.0/16
-  # Peering connection setup by the Synapse VPC stack builder
-  # Note: Synapse stacks request the peering from the spoke
-  VPCPeeringConnectionId: pcx-0ac676457c9136c8e


### PR DESCRIPTION
This PR removes the routes to the new synapse prod (10.20.0.0/16). Note: the pcx is already gone.
