### PR TITLE
[IT-1974] SCP to deny registering domains

### DIFF
--- a/org-formation/_scp.yaml
+++ b/org-formation/_scp.yaml
@@ -95,3 +95,18 @@
               - 'guardduty:UpdatePublishingDestination'
               - 'guardduty:UpdateThreatIntelSet'
             Resource: '*'
+
+  RestrictDnsRegistrationSCP:
+    Type: OC::ORG::ServiceControlPolicy
+    Properties:
+      PolicyName: RestrictDnsRegistration
+      Description: Restrict users from registring domain names
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: DenyDnsRegistration
+            Effect: Deny
+            Action:
+              - 'route53domains:RegisterDomain'
+              - 'route53domains:TransferDomain'
+            Resource: '*'

--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -28,6 +28,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictDnsRegistrationSCP
       Accounts:
         - !Ref SandboxAccount
         - !Ref MobileHealthDataEngineeringDevAccount
@@ -44,6 +45,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictDnsRegistrationSCP
       Accounts:
         - !Ref ScicompAccount
         - !Ref iAtlasProdAccount
@@ -60,6 +62,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictDnsRegistrationSCP
       OrganizationalUnits:
         - !Ref SynapseOU
         - !Ref BridgeOU
@@ -71,6 +74,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictDnsRegistrationSCP
       Accounts:
         - !Ref SceptreDevAccount
         - !Ref SaturnCloudDevAccount
@@ -82,6 +86,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictDnsRegistrationSCP
       Accounts:
         - !Ref TransitAccount
         - !Ref AdminCentralAccount
@@ -105,6 +110,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictDnsRegistrationSCP
       Accounts:
         - !Ref BmgfkiAccount
         - !Ref ScipoolDevAccount
@@ -134,6 +140,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictDnsRegistrationSCP
       Accounts:
         - !Ref 8dxfh53Account
 


### PR DESCRIPTION
Setup a service control policy to prevent all accounts from registering
domains, except for the org-sagebase-sageit account. For security and
consolidation IT want to control the domains that are created at Sage.

