### PR TITLE
[IT-1983] SCP to deny adding human users

### DIFF
--- a/org-formation/_scp.yaml
+++ b/org-formation/_scp.yaml
@@ -54,6 +54,22 @@
               - 'cloudtrail:DeleteTrail'
             Resource: '*'
 
+  # A login profile allows a user to access the AWS console.
+  # In effect this allows the creation of service users but will restrict creation of human users
+  RestrictIamLoginProfileSCP:
+    Type: OC::ORG::ServiceControlPolicy
+    Properties:
+      PolicyName: RestrictIamLoginProfile
+      Description: Restrict creation or adding IAM login profile to user accounts
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: DenyCreateIamLoginProfile
+            Effect: Deny
+            Action:
+              - 'iam:CreateLoginProfile'
+            Resource: '*'
+
   RestrictDisableGuarddutySCP:
     Type: OC::ORG::ServiceControlPolicy
     Properties:

--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -28,6 +28,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictIamLoginProfileSCP
       Accounts:
         - !Ref SandboxAccount
         - !Ref MobileHealthDataEngineeringDevAccount
@@ -44,6 +45,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictIamLoginProfileSCP
       Accounts:
         - !Ref ScicompAccount
         - !Ref iAtlasProdAccount
@@ -60,6 +62,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictIamLoginProfileSCP
       OrganizationalUnits:
         - !Ref SynapseOU
         - !Ref BridgeOU
@@ -71,6 +74,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictIamLoginProfileSCP
       Accounts:
         - !Ref SceptreDevAccount
         - !Ref SaturnCloudDevAccount
@@ -82,6 +86,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictIamLoginProfileSCP
       Accounts:
         - !Ref TransitAccount
         - !Ref AdminCentralAccount
@@ -105,6 +110,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictIamLoginProfileSCP
       Accounts:
         - !Ref BmgfkiAccount
         - !Ref ScipoolDevAccount
@@ -134,6 +140,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictIamLoginProfileSCP
       Accounts:
         - !Ref 8dxfh53Account
 


### PR DESCRIPTION
Prevent accounts from circumventing Jumpcloud access
by restricting AWS console access to IAM users.
The only users that are allowed are service users.
