### PR TITLE
Update pre-commit linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       entry: git-secrets
       args: [--scan, --recursive]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.3.0
     hooks:
       # On Windows, git will convert all CRLF to LF, but only after all hooks are done executing.
       # yamllint will fail before git has a chance to convert line endings, so it must be explicitly done before yamllint
@@ -16,20 +16,20 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.26.2
+    rev: v1.27.1
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.53.0
+    rev: v0.61.3
     hooks:
       - id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$
         exclude: templates/.*/lambda-budgets/.*\.(json|yml|yaml)$
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.10
+    rev: v1.3.0
     hooks:
       - id: remove-tabs
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.4.1
+    rev: 0.17.1
     hooks:
       - id: check-github-workflows

--- a/sceptre/sageit/templates/admodeladexplorer-redirector.yaml
+++ b/sceptre/sageit/templates/admodeladexplorer-redirector.yaml
@@ -122,10 +122,6 @@ Resources:
       FunctionConfig:
         Comment: If coming as admodel, redirect to modelad else redirect to shiny
         Runtime: cloudfront-js-1.0
-      FunctionMetadata:
-        FunctionARN: !Sub
-        - arn:aws:cloudfront::${AWS::AccountId}:function/${stackPrefix}-modeladexplorer-redirector-fct
-        - { stackPrefix: !Ref StackType }
       Name: !Sub
       - ${stackPrefix}-modeladexplorer-redirector-fct
       - { stackPrefix: !Ref StackType }


### PR DESCRIPTION
* Update pre-commit linter with the auto updater
* Fix a problem that cfn linter found

```
AWS CloudFormation Linter................................................Failed
- hook id: cfn-python-lint
- exit code: 2

E3002 Invalid Property Resources/RedirectFct/Properties/FunctionMetadata
sceptre/sageit/templates/admodeladexplorer-redirector.yaml:125:7
```

