### PR TITLE
[IT-1904] Fix policies for cloudtrail

### DIFF
--- a/org-formation/060-cloudtrail/_tasks.yaml
+++ b/org-formation/060-cloudtrail/_tasks.yaml
@@ -37,6 +37,7 @@ CloudTrail:
     KmsKeyAdminPrincipalArns:
       - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
       - !Sub 'arn:aws:iam::${AWS::AccountId}:role/OrganizationAccountAccessRole'
+      - 'arn:aws:iam::531805629419:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1EY1CRUF48VP5'
 
 CloudTrailSumoLogicRole:
   Type: update-stacks

--- a/org-formation/060-cloudtrail/cloudtrail-trail.yaml
+++ b/org-formation/060-cloudtrail/cloudtrail-trail.yaml
@@ -1,6 +1,5 @@
 # From https://github.com/org-formation/org-formation-reference/tree/master/src/templates/060-cloud-trail
 AWSTemplateFormatVersion: '2010-09-09-OC'
-
 Parameters:
   bucketName:
     Type: String
@@ -28,9 +27,7 @@ Resources:
         - Sid: Enable IAM User Permissions
           Effect: Allow
           Principal:
-            AWS:
-            - arn:aws:iam::231505186444:root
-            - arn:aws:iam::531805629419:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1EY1CRUF48VP5
+            AWS: !Ref KmsKeyAdminPrincipalArns
           Action: kms:*
           Resource: "*"
         - Sid: Allow CloudTrail to encrypt logs
@@ -41,9 +38,9 @@ Resources:
           Resource: "*"
           Condition:
             StringEquals:
-              AWS:SourceArn: arn:aws:cloudtrail:us-east-1:231505186444:trail/sagebase-cloudtrail-CloudTrail-168R5FX8JF4MG
+              AWS:SourceArn: !Sub 'arn:aws:cloudtrail:*:${AWS::AccountId}:trail/${AWS::StackName}*'
             StringLike:
-              kms:EncryptionContext:aws:cloudtrail:arn: arn:aws:cloudtrail:*:231505186444:trail/*
+              kms:EncryptionContext:aws:cloudtrail:arn: !Sub 'arn:aws:cloudtrail:*:${AWS::AccountId}:trail/*'
         - Sid: Allow CloudTrail to describe key
           Effect: Allow
           Principal:
@@ -60,9 +57,9 @@ Resources:
           Resource: "*"
           Condition:
             StringEquals:
-              kms:CallerAccount: '231505186444'
+              kms:CallerAccount: !Ref AWS::AccountId
             StringLike:
-              kms:EncryptionContext:aws:cloudtrail:arn: arn:aws:cloudtrail:*:231505186444:trail/*
+              kms:EncryptionContext:aws:cloudtrail:arn: !Sub 'arn:aws:cloudtrail:*:${AWS::AccountId}:trail/*'
         - Sid: Allow alias creation during setup
           Effect: Allow
           Principal:
@@ -72,7 +69,7 @@ Resources:
           Condition:
             StringEquals:
               kms:ViaService: ec2.us-east-1.amazonaws.com
-              kms:CallerAccount: '231505186444'
+              kms:CallerAccount: !Ref AWS::AccountId
         - Sid: Enable cross account log decryption
           Effect: Allow
           Principal:
@@ -83,9 +80,9 @@ Resources:
           Resource: "*"
           Condition:
             StringEquals:
-              kms:CallerAccount: '231505186444'
+              kms:CallerAccount: !Ref AWS::AccountId
             StringLike:
-              kms:EncryptionContext:aws:cloudtrail:arn: arn:aws:cloudtrail:*:231505186444:trail/*
+              kms:EncryptionContext:aws:cloudtrail:arn: !Sub 'arn:aws:cloudtrail:*:${AWS::AccountId}:trail/*'
 
   CloudTrailBucket:
     OrganizationBinding: !Ref MasterBinding
@@ -130,25 +127,24 @@ Resources:
           Principal:
             Service: cloudtrail.amazonaws.com
           Action: s3:GetBucketAcl
-          Resource: arn:aws:s3:::sagebase-cloudtrail-231505186444
+          Resource: !GetAtt CloudTrailBucket.Arn
           Condition:
             StringEquals:
-              AWS:SourceArn: arn:aws:cloudtrail:us-east-1:231505186444:trail/sagebase-cloudtrail-CloudTrail-168R5FX8JF4MG
+              AWS:SourceArn: !GetAtt CloudTrail.Arn
         - Sid: AWSCloudTrailWrite20150319
           Effect: Allow
           Principal:
             Service: cloudtrail.amazonaws.com
           Action: s3:PutObject
-          Resource: arn:aws:s3:::sagebase-cloudtrail-231505186444/AWSLogs/231505186444/*
+          Resource: !Sub '${CloudTrailBucket.Arn}/AWSLogs/${AWS::AccountId}/*'
           Condition:
             StringEquals:
               s3:x-amz-acl: bucket-owner-full-control
-              AWS:SourceArn: arn:aws:cloudtrail:us-east-1:231505186444:trail/sagebase-cloudtrail-CloudTrail-168R5FX8JF4MG
+              AWS:SourceArn: !GetAtt CloudTrail.Arn
 
   CloudTrail:
     OrganizationBinding: !Ref MasterBinding
     Type: AWS::CloudTrail::Trail
-    DependsOn: CloudTrailBucketPolicy
     Properties:
       S3BucketName: !Ref CloudTrailBucket
       IsLogging: true

--- a/org-formation/060-cloudtrail/cloudtrail-trail.yaml
+++ b/org-formation/060-cloudtrail/cloudtrail-trail.yaml
@@ -21,6 +21,7 @@ Resources:
       EnableKeyRotation: "true"
       PendingWindowInDays: 7
       KeyPolicy:
+        # policy copied from manual setup of cloudtrail with encryption
         Version: '2012-10-17'
         Id: Key policy created by CloudTrail
         Statement:
@@ -120,7 +121,8 @@ Resources:
     Properties:
       Bucket: !Ref CloudTrailBucket
       PolicyDocument:
-        Version: '2012-10-17'
+        # policy copied from manual setup of cloudtrail with encryption
+        Version: 2012-10-17
         Statement:
         - Sid: AWSCloudTrailAclCheck20150319
           Effect: Allow

--- a/org-formation/060-cloudtrail/cloudtrail-trail.yaml
+++ b/org-formation/060-cloudtrail/cloudtrail-trail.yaml
@@ -22,14 +22,15 @@ Resources:
       EnableKeyRotation: "true"
       PendingWindowInDays: 7
       KeyPolicy:
-        # derived from https://docs.aws.amazon.com/awscloudtrail/latest/userguide/default-kms-key-policy.html
         Version: '2012-10-17'
         Id: Key policy created by CloudTrail
         Statement:
         - Sid: Enable IAM User Permissions
           Effect: Allow
           Principal:
-            AWS: !Ref KmsKeyAdminPrincipalArns
+            AWS:
+            - arn:aws:iam::231505186444:root
+            - arn:aws:iam::531805629419:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1EY1CRUF48VP5
           Action: kms:*
           Resource: "*"
         - Sid: Allow CloudTrail to encrypt logs
@@ -40,9 +41,9 @@ Resources:
           Resource: "*"
           Condition:
             StringEquals:
-              AWS:SourceArn: !Sub 'arn:aws:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/*'
+              AWS:SourceArn: arn:aws:cloudtrail:us-east-1:231505186444:trail/sagebase-cloudtrail-CloudTrail-168R5FX8JF4MG
             StringLike:
-              kms:EncryptionContext:aws:cloudtrail:arn: !Sub 'arn:aws:cloudtrail:*:${AWS::AccountId}:trail/*'
+              kms:EncryptionContext:aws:cloudtrail:arn: arn:aws:cloudtrail:*:231505186444:trail/*
         - Sid: Allow CloudTrail to describe key
           Effect: Allow
           Principal:
@@ -59,9 +60,9 @@ Resources:
           Resource: "*"
           Condition:
             StringEquals:
-              kms:CallerAccount: !Sub '${AWS::AccountId}'
+              kms:CallerAccount: '231505186444'
             StringLike:
-              kms:EncryptionContext:aws:cloudtrail:arn: !Sub 'arn:aws:cloudtrail:*:${AWS::AccountId}:trail/*'
+              kms:EncryptionContext:aws:cloudtrail:arn: arn:aws:cloudtrail:*:231505186444:trail/*
         - Sid: Allow alias creation during setup
           Effect: Allow
           Principal:
@@ -70,8 +71,8 @@ Resources:
           Resource: "*"
           Condition:
             StringEquals:
-              kms:CallerAccount: !Sub '${AWS::AccountId}'
               kms:ViaService: ec2.us-east-1.amazonaws.com
+              kms:CallerAccount: '231505186444'
         - Sid: Enable cross account log decryption
           Effect: Allow
           Principal:
@@ -82,9 +83,9 @@ Resources:
           Resource: "*"
           Condition:
             StringEquals:
-              kms:CallerAccount: !Sub '${AWS::AccountId}'
+              kms:CallerAccount: '231505186444'
             StringLike:
-              kms:EncryptionContext:aws:cloudtrail:arn: !Sub 'arn:aws:cloudtrail:*:${AWS::AccountId}:trail/*'
+              kms:EncryptionContext:aws:cloudtrail:arn: arn:aws:cloudtrail:*:231505186444:trail/*
 
   CloudTrailBucket:
     OrganizationBinding: !Ref MasterBinding
@@ -122,23 +123,27 @@ Resources:
     Properties:
       Bucket: !Ref CloudTrailBucket
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
-          - Sid: AWSCloudTrailAclCheck
-            Effect: Allow
-            Principal:
-              Service: cloudtrail.amazonaws.com
-            Action: s3:GetBucketAcl
-            Resource: !GetAtt CloudTrailBucket.Arn
-          - Sid: AWSCloudTrailWrite
-            Effect: Allow
-            Principal:
-              Service: cloudtrail.amazonaws.com
-            Action: s3:PutObject
-            Resource: !Sub '${CloudTrailBucket.Arn}/AWSLogs/*'
-            Condition:
-              StringEquals:
-                s3:x-amz-acl: bucket-owner-full-control
+        - Sid: AWSCloudTrailAclCheck20150319
+          Effect: Allow
+          Principal:
+            Service: cloudtrail.amazonaws.com
+          Action: s3:GetBucketAcl
+          Resource: arn:aws:s3:::sagebase-cloudtrail-231505186444
+          Condition:
+            StringEquals:
+              AWS:SourceArn: arn:aws:cloudtrail:us-east-1:231505186444:trail/sagebase-cloudtrail-CloudTrail-168R5FX8JF4MG
+        - Sid: AWSCloudTrailWrite20150319
+          Effect: Allow
+          Principal:
+            Service: cloudtrail.amazonaws.com
+          Action: s3:PutObject
+          Resource: arn:aws:s3:::sagebase-cloudtrail-231505186444/AWSLogs/231505186444/*
+          Condition:
+            StringEquals:
+              s3:x-amz-acl: bucket-owner-full-control
+              AWS:SourceArn: arn:aws:cloudtrail:us-east-1:231505186444:trail/sagebase-cloudtrail-CloudTrail-168R5FX8JF4MG
 
   CloudTrail:
     OrganizationBinding: !Ref MasterBinding
@@ -152,7 +157,7 @@ Resources:
       EnableLogFileValidation: true
       CloudWatchLogsLogGroupArn: !Ref CloudWatchLogsLogGroupArn
       CloudWatchLogsRoleArn: !Ref CloudWatchLogsRoleArn
-#      KMSKeyId: !Ref KmsKey
+      KMSKeyId: !Ref KmsKey
 
   MemberCloudTrail:
     OrganizationBinding: !Ref MemberBinding


### PR DESCRIPTION
This is a follow on to PR #522 which only partially refactored
the cloudtrail for encryption.  The policies in that PR were
not quite correct.

This PR will do the following to finish it:

* Enable KMS key to encrypt the cloudtrail trail
* Fix policies to allow cloudtrail to correctly access
  the S3 bucket
* Fix policies to allow cloudtrail and users to access the KMS key

