### PR TITLE
Revert CUR bucket to Public

### DIFF
--- a/org-formation/040-budgets/cur.yaml
+++ b/org-formation/040-budgets/cur.yaml
@@ -8,7 +8,7 @@ Resources:
     Type: "AWS::S3::Bucket"
     Properties:
       BucketName: !Sub "${resourcePrefix}-cost-reports"
-      AccessControl: Private
+      AccessControl: Public
   CostReportBucketPolicy:
     Type: "AWS::S3::BucketPolicy"
     Properties:


### PR DESCRIPTION
We are seeing a permissions issue deploying the cost report stack,
revert the bucket policy to Public, which worked in a test stack.

PR Checklist:
[X] Describe and explain your intentions for this change
[X] Setup pre-commit and run the validators (info in README.md)
