### PR TITLE
[IT-1801] deploy updated cfn-s3-objects-macro

### DIFF
--- a/sceptre/admincentral/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/admincentral/config/prod/cfn-s3objects-macro.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.4/cfn-s3objects-macro.yaml"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.5/cfn-s3objects-macro.yaml"
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/sageit/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/sageit/config/prod/cfn-s3objects-macro.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/cfn-s3objects-macro/0.0.4/cfn-s3objects-macro.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/cfn-s3objects-macro/0.0.5/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/sandbox/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/sandbox/config/prod/cfn-s3objects-macro.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.4/cfn-s3objects-macro.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.5/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/scicomp/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/scicomp/config/prod/cfn-s3objects-macro.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.4/cfn-s3objects-macro.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.5/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/scipool/config/bmgfki/cfn-s3objects-macro.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-s3objects-macro.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.4/cfn-s3objects-macro.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.5/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "bmgfki/bootstrap.yaml"

--- a/sceptre/scipool/config/develop/cfn-s3objects-macro.yaml
+++ b/sceptre/scipool/config/develop/cfn-s3objects-macro.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.4/cfn-s3objects-macro.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.5/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "develop/bootstrap.yaml"

--- a/sceptre/scipool/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/scipool/config/prod/cfn-s3objects-macro.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.4/cfn-s3objects-macro.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.5/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/scipool/config/strides/cfn-s3objects-macro.yaml
+++ b/sceptre/scipool/config/strides/cfn-s3objects-macro.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.4/cfn-s3objects-macro.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.5/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "strides/bootstrap.yaml"


### PR DESCRIPTION
This updates the cloudformation S3Objects Macro[1] in our AWS accounts
with fixes to work for python 3.8

depends on https://github.com/Sage-Bionetworks-IT/cfn-s3objects-macro/pull/9

