### PR TITLE
[IT-1931] Allow SC launch role access to secrets manager

### DIFF
--- a/sceptre/scipool/templates/sc-scheduled-jobs-launchrole.yaml
+++ b/sceptre/scipool/templates/sc-scheduled-jobs-launchrole.yaml
@@ -14,6 +14,7 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonAPIGatewayAdministrator
         - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
         - arn:aws:iam::aws:policy/AWSLambda_FullAccess
+        - arn:aws:iam::aws:policy/SecretsManagerReadWrite
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -51,9 +52,6 @@ Resources:
                   - "iam:AttachRolePolicy"
                   - "iam:DeletePolicy"
                   - "iam:TagRole"
-                  - "secretsmanager:CreateSecret"
-                  - "secretsmanager:TagResource"
-                  - "secretsmanager:DeleteSecret"
                   - "events:*"
                 Resource: '*'
 Outputs:


### PR DESCRIPTION
We need to give the SC launch role access to the secrets
manager to allow it to update secrets that are passed in
from the service catalog wizard.

