### PR TITLE
Give Travis CI and admins read access to the CUR bucket.

### DIFF
--- a/org-formation/040-budgets/cur.yaml
+++ b/org-formation/040-budgets/cur.yaml
@@ -32,6 +32,15 @@ Resources:
             Resource: !Sub '${CostReportBucket.Arn}/*'
             Principal:
               Service: "billingreports.amazonaws.com"
+          # Grant AWS admins and Travis CI access to view cost reports
+          - Action:
+              - 's3:GetObject'
+            Effect: Allow
+            Resource: !Sub '${CostReportBucket.Arn}/*'
+            Principal:
+              AWS:
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/OrganizationAccountAccessRole"
+                - arn:aws:iam::745159704268:role/service-accounts-CfnDeployerServiceRole-1OJK3OAN1IAI  # Travis CI
   MonthlyCostReport:
     Type: "AWS::CUR::ReportDefinition"
     Properties:


### PR DESCRIPTION
The lambda for grouping costs by cost center includes a test that
will download and process the current report without uploading the
results. Give read access to travis and to 'organizations' account
admins for running the test.

PR Checklist:
[x] Describe and explain your intentions for this change
[x] Setup pre-commit and run the validators (info in README.md)
