### PR TITLE
[IT-2075] Update S3 products

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-s3-synapse.yaml
@@ -69,7 +69,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.33/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.33'
-    - Description:  'Disable bucket ACLs. {{ range(1, 10000) | random }}'
+    - Description:  'Disable bucket ACLs.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.38/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.38'
+    - Description:  'Remove bucket ACL setting. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.39/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.39'

--- a/sceptre/scipool/config/develop/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/develop/sc-product-s3-synapse.yaml
@@ -66,7 +66,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.33/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.33'
-    - Description:  'Disable bucket ACLs. {{ range(1, 10000) | random }}'
+    - Description:  'Disable bucket ACLs.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.38/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.38'
+    - Description:  'Remove bucket ACL setting. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.39/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.39'

--- a/sceptre/scipool/config/prod/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/prod/sc-product-s3-synapse.yaml
@@ -69,7 +69,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.33/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.33'
-    - Description:  'Disable bucket ACLs. {{ range(1, 10000) | random }}'
+    - Description:  'Disable bucket ACLs.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.38/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.38'
+    - Description:  'Remove bucket ACL setting. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.39/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.39'

--- a/sceptre/scipool/config/strides/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/strides/sc-product-s3-synapse.yaml
@@ -69,7 +69,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.33/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.33'
-    - Description:  'Disable bucket ACLs. {{ range(1, 10000) | random }}'
+    - Description:  'Disable bucket ACLs.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.38/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.38'
+    - Description:  'Remove bucket ACL setting. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.39/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.39'


### PR DESCRIPTION
Remove bucket ACL setting in service catalog s3 products

depends on https://github.com/Sage-Bionetworks/service-catalog-library/pull/281

