### PR TITLE
[IT-2075] Update bucket policy generator lambda

### DIFF
--- a/sceptre/scipool/config/bmgfki/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-cr-sc-bucket-policy.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.2/cfn-cr-sc-bucket-policy.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.3/cfn-cr-sc-bucket-policy.yaml
 stack_name: cfn-cr-sc-bucket-policy
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-sc-bucket-policy.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.2/cfn-cr-sc-bucket-policy.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.3/cfn-cr-sc-bucket-policy.yaml
 stack_name: cfn-cr-sc-bucket-policy
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-sc-bucket-policy.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.2/cfn-cr-sc-bucket-policy.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.3/cfn-cr-sc-bucket-policy.yaml
 stack_name: cfn-cr-sc-bucket-policy
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-sc-bucket-policy.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.2/cfn-cr-sc-bucket-policy.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.3/cfn-cr-sc-bucket-policy.yaml
 stack_name: cfn-cr-sc-bucket-policy
 stack_tags:
   Department: "Platform"


### PR DESCRIPTION
Update the service catalog bucket policy generator lambda to support
non ACL based buckets.

depends on https://github.com/Sage-Bionetworks-IT/cfn-cr-sc-bucket-policy/pull/7

