### PR TITLE
Remove Agora collaborator access

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -17,21 +17,6 @@ AgoraCIServiceAccount:
       - !Ref AgoraProdAccount
     Region: us-east-1
 
-# Setup Agora collaborator access
-AgoraCollaboratorAccess:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.10/templates/IAM/cross-account-access.yaml
-  StackName: agora-collaborator-access
-  Parameters:
-    PrincipalArns:
-      - arn:aws:iam::155057775224:user/MattC    # Matthias Courville from GenUI
-    ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: false
-    Account: !Ref AgoraDevAccount
-    Region: us-east-1
-
 # A service account for https://github.com/Sage-Bionetworks/iatlas-infra
 iAtlasCIServiceAccount:
   Type: update-stacks


### PR DESCRIPTION
We gave our Gen UI collaborator access to our AWS org-sagebase-agora-dev
account to help migrate the Agora app there.  Now that it's done we
are removing their access.

