### PR TITLE
Pin cfn-cr-oidc-idp lambda to a specific version

### DIFF
--- a/sceptre/scipool/config/bmgfki/synapse-oidc-idp.yaml
+++ b/sceptre/scipool/config/bmgfki/synapse-oidc-idp.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/0.0.1/cfn-cr-oidc-idp.yaml
 stack_name: synapse-oidc-idp
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/synapse-oidc-idp.yaml
+++ b/sceptre/scipool/config/develop/synapse-oidc-idp.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/0.0.1/cfn-cr-oidc-idp.yaml
 stack_name: synapse-oidc-idp
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/synapse-oidc-idp.yaml
+++ b/sceptre/scipool/config/prod/synapse-oidc-idp.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/0.0.1/cfn-cr-oidc-idp.yaml
 stack_name: synapse-oidc-idp
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/synapse-oidc-idp.yaml
+++ b/sceptre/scipool/config/strides/synapse-oidc-idp.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/0.0.1/cfn-cr-oidc-idp.yaml
 stack_name: synapse-oidc-idp
 stack_tags:
   Department: "Platform"


### PR DESCRIPTION
We want to pin just in case we need to revert back to a working version.
