### PR TITLE
Update CFN deployer policy

### DIFF
--- a/sceptre/admincentral/templates/iam-policies.yaml
+++ b/sceptre/admincentral/templates/iam-policies.yaml
@@ -37,7 +37,7 @@ Resources:
           - Effect: Allow
             Action:
               - iam:ListPolicies       # required by sam validate
-            Resource: arn:aws:iam::* 
+            Resource: arn:aws:iam::*
           - Sid: ManageServerlessRepo
             Effect: Allow
             Action:

--- a/sceptre/admincentral/templates/iam-policies.yaml
+++ b/sceptre/admincentral/templates/iam-policies.yaml
@@ -34,6 +34,10 @@ Resources:
                   - ''
                   - - 'Fn::ImportValue': !Sub '${AWS::Region}-essentials-LambdaArtifactsBucketArn'
                     - '/*'
+          - Effect: Allow
+            Action:
+              - iam:ListPolicies       # required by sam validate
+            Resource: arn:aws:iam::* 
           - Sid: ManageServerlessRepo
             Effect: Allow
             Action:


### PR DESCRIPTION
We are getting an error when runing `sam validate` using the
current CFN policy..

```
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the ListPolicies
operation: User: arn:aws:sts::XXXXX4268:assumed-role/service-accounts-CfnDeployerServiceRole-1OJK3OAN1IAI/botocore-session-1661992869
is not authorized to perform: iam:ListPolicies on resource: policy path / because no
identity-based policy allows the iam:ListPolicies action
```

Update the CFN deployer policy to allow running the command
to validate sam templates

