### PR TITLE
[IT-1904] Fix policy for central cloudtrail bucket

### DIFF
--- a/org-formation/060-cloudtrail/cloudtrail-trail.yaml
+++ b/org-formation/060-cloudtrail/cloudtrail-trail.yaml
@@ -130,15 +130,12 @@ Resources:
             Service: cloudtrail.amazonaws.com
           Action: s3:GetBucketAcl
           Resource: !GetAtt CloudTrailBucket.Arn
-          Condition:
-            StringEquals:
-              AWS:SourceArn: !GetAtt CloudTrail.Arn
         - Sid: AWSCloudTrailWrite20150319
           Effect: Allow
           Principal:
             Service: cloudtrail.amazonaws.com
           Action: s3:PutObject
-          Resource: !Sub '${CloudTrailBucket.Arn}/AWSLogs/${AWS::AccountId}/*'
+          Resource: !Sub '${CloudTrailBucket.Arn}/AWSLogs/*'
           Condition:
             StringEquals:
               s3:x-amz-acl: bucket-owner-full-control


### PR DESCRIPTION
The policy for the central cloudtrail bucket was incorrect.
We need to fix it to allow other accounts to write to the bucket.
We are following the example from the AWS docs[1].

[1] https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-set-bucket-policy-for-multiple-accounts.html
