### PR TITLE
[IT-1046] Update cost report lambda version

### DIFF
--- a/org-formation/040-budgets/_tasks.yaml
+++ b/org-formation/040-budgets/_tasks.yaml
@@ -25,7 +25,7 @@ CostAndUsageReports:
 
 CostReportLambda:
   Type: update-stacks
-  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-cost-reports/0.0.1/lambda-cost-reports.yaml'
+  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-cost-reports/0.0.2/lambda-cost-reports.yaml'
   StackName: lambda-cost-reports
   DefaultOrganizationBinding:
     Account: !Ref MasterAccount


### PR DESCRIPTION
The initial version released is too large to successfully deploy to AWS. Update to a version that meets AWS' requirements.

Depends on: Sage-Bionetworks-IT/lambda-cost-reports#3
