### PR TITLE
[IT-1046] Roll back cost report lambda

### DIFF
--- a/org-formation/040-budgets/_tasks.yaml
+++ b/org-formation/040-budgets/_tasks.yaml
@@ -22,11 +22,3 @@ CostAndUsageReports:
     Region: !Ref primaryRegion
   Parameters:
     resourcePrefix: !Ref resourcePrefix
-
-CostReportLambda:
-  Type: update-stacks
-  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-cost-reports/0.0.2/lambda-cost-reports.yaml'
-  StackName: lambda-cost-reports
-  DefaultOrganizationBinding:
-    Account: !Ref MasterAccount
-    Region: !Ref primaryRegion


### PR DESCRIPTION
Event bridge does not support suffix matching of event details, only prefix matching. This won't work for our needs, roll back the lambda while triggering is reworked.