### PR TITLE
[IT-1046] Deploy cost reports lambda with S3 notifications

### DIFF
--- a/org-formation/040-budgets/_tasks.yaml
+++ b/org-formation/040-budgets/_tasks.yaml
@@ -13,6 +13,16 @@ BudgetAlarms:
     budgetAmount: !GetAtt CurrentAccount.Tags.budget-alarm-threshold
     emailAddress: !GetAtt CurrentAccount.Tags.budget-alarm-threshold-email-recipient
 
+CostReportLambda:
+  Type: update-stacks
+  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-cost-reports/0.0.3/lambda-cost-reports.yaml'
+  StackName: !Sub '${resourcePrefix}-cost-reports-lambda'
+  DefaultOrganizationBinding:
+    Account: !Ref MasterAccount
+    Region: !Ref primaryRegion
+  Parameters:
+    bucketName: !Sub "${resourcePrefix}-cost-reports"
+
 CostAndUsageReports:
   Type: update-stacks
   Template: cur.yaml
@@ -22,3 +32,5 @@ CostAndUsageReports:
     Region: !Ref primaryRegion
   Parameters:
     resourcePrefix: !Ref resourcePrefix
+    bucketName: !Sub "${resourcePrefix}-cost-reports"
+    lambdaArn: !CopyValue [ !Sub "${resourcePrefix}-cost-reports-lambda-CostReportFunctionArn" ]

--- a/org-formation/040-budgets/cur.yaml
+++ b/org-formation/040-budgets/cur.yaml
@@ -3,12 +3,25 @@ Description: 'Monthly Cost and Usage Report'
 Parameters:
   resourcePrefix:
     Type: String
+  bucketName:
+    Type: String
+  lambdaArn:
+    Type: String
 Resources:
   CostReportBucket:
     Type: "AWS::S3::Bucket"
     Properties:
-      BucketName: !Sub "${resourcePrefix}-cost-reports"
+      BucketName: !Ref bucketName
       AccessControl: BucketOwnerFullControl
+      NotificationConfiguration:
+        LambdaConfigurations:
+          - Event: "s3:ObjectCreated:*"
+            Function: !Ref lambdaArn
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: suffix
+                    Value: ".snappy.parquet"
   CostReportBucketPolicy:
     # This policy MUST match https://docs.aws.amazon.com/cur/latest/userguide/cur-s3.html
     Type: "AWS::S3::BucketPolicy"


### PR DESCRIPTION
Add the cost report lambda to the budgets tasks, and trigger the lambda with S3 notifications for files written by AWS Billing.

Depends on: Sage-Bionetworks-IT/lambda-cost-reports#4
