### PR TITLE
Create a system manager account

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -102,6 +102,7 @@ Organization:
         - !Ref ImageCentralAccount
         - !Ref SecurityCentralAccount
         - !Ref IpamAccount
+        - !Ref SysmanCentralAccount
 
   PolicyStagingOU:
     Type: OC::ORG::OrganizationalUnit
@@ -559,6 +560,16 @@ Organization:
       AccountName: org-sagebase-saturncloud-dev
       RootEmail: saturncloud-dev@sagebase.org
       Alias: org-sagebase-saturncloud-dev
+      Tags:
+        <<: !Include ./_default_org_tags.yaml
+        <<: !Include ./_platform_org_tags.yaml
+
+  SysmanCentralAccount:
+    Type: OC::ORG::Account
+    Properties:
+      AccountName: org-sagebase-sysmancentral
+      RootEmail: aws.sysman@sagebase.org
+      Alias: org-sagebase-sysmancentral
       Tags:
         <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml

--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -568,7 +568,7 @@ Organization:
     Type: OC::ORG::Account
     Properties:
       AccountName: org-sagebase-sysmancentral
-      RootEmail: aws.sysman@sagebase.org
+      RootEmail: aws.sysmancentral@sagebase.org
       Alias: org-sagebase-sysmancentral
       Tags:
         <<: !Include ./_default_org_tags.yaml


### PR DESCRIPTION
This PR is related to IT-1729 and IT-2089

We want to setup a few new system management services:
  * AWS instance scheduler service[1]
  * AWS centralized patching service[2]

These services will manage instances across multiple AWS accounts so we need a central account to deploy these apps to.  I propose we create a new account called `org-sagebase-sysmancentral` for these types of services.  That way we can scope their access to systems operators.

[1] https://docs.aws.amazon.com/solutions/latest/instance-scheduler-on-aws/welcome.html
[2] https://aws.amazon.com/blogs/mt/scheduling-centralized-multi-account-multi-region-patching-aws-systems-manager-automation/

