### PR TITLE
[IT-2051] Always deploy the ebs lambda

### DIFF
--- a/org-formation/300-account-defaults/_tasks.yaml
+++ b/org-formation/300-account-defaults/_tasks.yaml
@@ -23,6 +23,7 @@ Ec2NoVpcDefaults:
 EbsVolumeCleanup:
   Type: update-stacks
   Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-ebs-cleanup/master/lambda-ebs-cleanup.yaml'
+  ForceDeploy: true
   StackName: lambda-ebs-cleanup
   DefaultOrganizationBinding:
     IncludeMasterAccount: true


### PR DESCRIPTION
Since the template URL references the template for the master branch, the template may change without the URL changing. Force deploy the lambda since a hash match doesn't mean the template is unchanged.