### PR TITLE
IT-2142: Give cross account access to external dev

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -30,6 +30,21 @@ iAtlasCIServiceAccount:
     Account: !Ref iAtlasProdAccount
     Region: us-east-1
 
+# Setup iAtlas collaborator access
+iAtlasCollaboratorAccess:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.8/templates/IAM/cross-account-access.yaml
+  StackName: iatlas-collaborator-access
+  Parameters:
+    PrincipalArns:
+      - arn:aws:iam::556856096938:user/ebs_automation    # Jon Ryser from GenUI
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AdministratorAccess
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+    Account: !Ref iAtlasProdAccount
+    Region: us-east-1
+
 # A service account for https://github.com/nlpsandbox/aws-cloudformation
 NlpSandboxServiceAccount:
   Type: update-stacks


### PR DESCRIPTION
This PR should give external collaborator access to the iAtlas account.
