### PR TITLE
IT-2002: Remove bastion security group from sageVPC in synapsedev account

### DIFF
--- a/sceptre/synapsedev/config/prod/vpc.yaml
+++ b/sceptre/synapsedev/config/prod/vpc.yaml
@@ -1,9 +1,10 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.9/vpc.yaml
 stack_name: vpc
 parameters:
   VpcSubnetPrefix: "10.11"
   VpcName: sagevpc
   PrivateSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
+  IncludeBastianSecurityGroup: "false"


### PR DESCRIPTION
This PR is trial run for using the parameter, the security group should be removed and the corresponding securityHub finding should go away.
