### PR TITLE
IT-2002: Remove bastion sg from infra vpc in synapsepro and dw

### DIFF
--- a/sceptre/synapsedw/config/prod/vpc.yaml
+++ b/sceptre/synapsedw/config/prod/vpc.yaml
@@ -1,9 +1,10 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.9/vpc.yaml
 stack_name: vpc
 parameters:
   VpcSubnetPrefix: "10.12"
   VpcName: synapsedw-vpc
   PrivateSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
+  IncludeBastianSecurityGroup: "false"

--- a/sceptre/synapseprod/config/prod/vpc.yaml
+++ b/sceptre/synapseprod/config/prod/vpc.yaml
@@ -1,9 +1,10 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.9/vpc.yaml
 stack_name: vpc
 parameters:
   VpcSubnetPrefix: "10.10"
   VpcName: sage-default-vpc
   PrivateSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
+  IncludeBastianSecurityGroup: "false"


### PR DESCRIPTION
Same as https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/581 for prod and dw accounts.

Depends on Sage-Bionetworks/aws-infra#355
