### PR TITLE
IT-2030: update vpc.yaml in synapsedev

### DIFF
--- a/sceptre/synapsedev/config/prod/vpc.yaml
+++ b/sceptre/synapsedev/config/prod/vpc.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.9/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.10/vpc.yaml
 stack_name: vpc
 parameters:
   VpcSubnetPrefix: "10.11"


### PR DESCRIPTION
This PR is part of the effort to remover references to 10.1.0.0/16 in security groups.

Depends on sage-bionetworks/aws-infra#356
