### PR TITLE
It-2147: Remove old infra VPC

### DIFF
--- a/sceptre/synapseprod/config/prod/vpc.yaml
+++ b/sceptre/synapseprod/config/prod/vpc.yaml
@@ -8,3 +8,4 @@ parameters:
   PrivateSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
   IncludeBastianSecurityGroup: "false"
+obsolete: true


### PR DESCRIPTION
This PR removes the infra VPC at 10.10.0.0/16 using the new 'obsolete' feature

Depends on #587 