### PR TITLE
[IT-2124] Add a Cost Category for Program Codes

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -11,3 +11,11 @@ AnomalyDetectorService:
     Region: !Ref primaryRegion
   Parameters:
     Subscriber: !GetAtt CurrentAccount.RootEmail
+
+CostCategories:
+  Type: update-stacks
+  Template: categories.yaml
+  StackName: !Sub '${resourcePrefix}-cost-categories'
+  DefaultOrganizationBinding:
+    Account: !Ref MasterAccount
+    Region: !Ref primaryRegion

--- a/org-formation/050-costs/categories.yaml
+++ b/org-formation/050-costs/categories.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'All Cost Categories'
+Resources:
+  ProgramCodeCostCategory:
+    Type: 'AWS::CE::CostCategory'
+    Properties:
+      Name: 'Program Code'
+      RuleVersion: 'CostCategoryExpression.v1'
+      Rules: !ReadFile program-code-rules.json

--- a/org-formation/050-costs/program-code-rules.json
+++ b/org-formation/050-costs/program-code-rules.json
@@ -1,0 +1,398 @@
+[
+  {
+    "Type": "REGULAR",
+    "Value": "990300 Platform Infrastructure",
+    "Rule": {
+      "And": [
+        {
+          "Dimensions": {
+            "Key": "LINKED_ACCOUNT",
+            "Values": [
+              "531805629419",
+              "140124849929",
+              "254940560790",
+              "231505186444",
+              "153370007719",
+              "087547153226",
+              "797640923903",
+              "867686887310",
+              "420786776710",
+              "745159704268",
+              "325565585839",
+              "383874245509",
+              "449435941126",
+              "649232250620",
+              "804034162148",
+              "743644221192"
+            ],
+            "MatchOptions": [
+              "EQUALS"
+            ]
+          }
+        },
+        {
+          "Tags": {
+            "Key": "CostCenter",
+            "MatchOptions": [
+              "ABSENT"
+            ]
+          }
+        },
+        {
+          "Tags": {
+            "Key": "CostCenterOther",
+            "MatchOptions": [
+              "ABSENT"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "990300 Platform Infrastructure",
+    "Rule": {
+      "Tags": {
+        "Key": "CostCenter",
+        "Values": [
+          "990300"
+        ],
+        "MatchOptions": [
+          "ENDS_WITH"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "30144 BMGF Ki",
+    "Rule": {
+      "Tags": {
+        "Key": "CostCenter",
+        "Values": [
+          "30144"
+        ],
+        "MatchOptions": [
+          "ENDS_WITH"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "30144 BMGF Ki",
+    "Rule": {
+      "Tags": {
+        "Key": "CostCenterOther",
+        "Values": [
+          "30144"
+        ],
+        "MatchOptions": [
+          "ENDS_WITH"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "30144 BMGF Ki",
+    "Rule": {
+      "Dimensions": {
+        "Key": "LINKED_ACCOUNT",
+        "Values": [
+          "464102568320"
+        ],
+        "MatchOptions": [
+          "EQUALS"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "113300 CD2H CU",
+    "Rule": {
+      "Tags": {
+        "Key": "CostCenterOther",
+        "Values": [
+          "113300"
+        ],
+        "MatchOptions": [
+          "ENDS_WITH"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "113300 CD2H CU",
+    "Rule": {
+      "Dimensions": {
+        "Key": "LINKED_ACCOUNT",
+        "Values": [
+          "841415736403"
+        ],
+        "MatchOptions": [
+          "EQUALS"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "122000 INCLUDE CHOP",
+    "Rule": {
+      "Tags": {
+        "Key": "CostCenter",
+        "Values": [
+          "122000"
+        ],
+        "MatchOptions": [
+          "ENDS_WITH"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "122000 INCLUDE CHOP",
+    "Rule": {
+      "Dimensions": {
+        "Key": "LINKED_ACCOUNT",
+        "Values": [
+          "975466401039"
+        ],
+        "MatchOptions": [
+          "EQUALS"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "101600 NIH ITCR",
+    "Rule": {
+      "Tags": {
+        "Key": "CostCenter",
+        "Values": [
+          "101600"
+        ],
+        "MatchOptions": [
+          "ENDS_WITH"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "101600 NIH ITCR",
+    "Rule": {
+      "Dimensions": {
+        "Key": "LINKED_ACCOUNT",
+        "Values": [
+          "216152803258"
+        ],
+        "MatchOptions": [
+          "EQUALS"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "112501 Mobile Toolbox Project Core",
+    "Rule": {
+      "Tags": {
+        "Key": "CostCenter",
+        "Values": [
+          "112501"
+        ],
+        "MatchOptions": [
+          "ENDS_WITH"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "112501 Mobile Toolbox Project Core",
+    "Rule": {
+      "Dimensions": {
+        "Key": "LINKED_ACCOUNT",
+        "Values": [
+          "634761300905",
+          "611413694531"
+        ],
+        "MatchOptions": [
+          "EQUALS"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "314900 iAtlas",
+    "Rule": {
+      "Tags": {
+        "Key": "CostCenter",
+        "Values": [
+          "314900"
+        ],
+        "MatchOptions": [
+          "ENDS_WITH"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "314900 iAtlas",
+    "Rule": {
+      "Dimensions": {
+        "Key": "LINKED_ACCOUNT",
+        "Values": [
+          "386990716034"
+        ],
+        "MatchOptions": [
+          "EQUALS"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "120100 HTAN DFCI",
+    "Rule": {
+      "Tags": {
+        "Key": "CostCenter",
+        "Values": [
+          "120100"
+        ],
+        "MatchOptions": [
+          "ENDS_WITH"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "120100 HTAN DFCI",
+    "Rule": {
+      "Dimensions": {
+        "Key": "LINKED_ACCOUNT",
+        "Values": [
+          "888810830951"
+        ],
+        "MatchOptions": [
+          "EQUALS"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "101500 NIA AMP AD CC",
+    "Rule": {
+      "Tags": {
+        "Key": "CostCenterOther",
+        "Values": [
+          "101500"
+        ],
+        "MatchOptions": [
+          "ENDS_WITH"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "101500 NIA AMP AD CC",
+    "Rule": {
+      "Tags": {
+        "Key": "CostCenter",
+        "Values": [
+          "101500"
+        ],
+        "MatchOptions": [
+          "ENDS_WITH"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "101500 NIA AMP AD CC",
+    "Rule": {
+      "Dimensions": {
+        "Key": "LINKED_ACCOUNT",
+        "Values": [
+          "607346494281",
+          "681175625864"
+        ],
+        "MatchOptions": [
+          "EQUALS"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "312000 Genie AACR",
+    "Rule": {
+      "Tags": {
+        "Key": "CostCenterOther",
+        "Values": [
+          "312000"
+        ],
+        "MatchOptions": [
+          "ENDS_WITH"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "312000 Genie AACR",
+    "Rule": {
+      "Tags": {
+        "Key": "CostCenter",
+        "Values": [
+          "312000"
+        ],
+        "MatchOptions": [
+          "ENDS_WITH"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "REGULAR",
+    "Value": "NO PROGRAM",
+    "Rule": {
+      "Tags": {
+        "Key": "CostCenter",
+        "Values": [
+          "000000"
+        ],
+        "MatchOptions": [
+          "ENDS_WITH"
+        ]
+      }
+    }
+  },
+  {
+    "Type": "INHERITED_VALUE",
+    "InheritedValue": {
+      "DimensionName": "TAG",
+      "DimensionKey": "CostCenterOther"
+    }
+  },
+  {
+    "Type": "INHERITED_VALUE",
+    "InheritedValue": {
+      "DimensionName": "TAG",
+      "DimensionKey": "CostCenter"
+    }
+  }
+]


### PR DESCRIPTION
Replace our CUR ETL lambda with Cost Category rules. The purpose of the lambda is simply to collate our CostCenter and CostCenterOther tags, along with a fallback account mapping, into a single meaningful value. This can also be done with Cost Categories, which would allow us to use Cost Explorer for auditing/inspecting the resulting data.

The included rules were built using the online rules builder and copying the resulting JSON. Automatically updating the rules when program codes change will be challenging, but might be possible using a custom CloudFormation macro.
