### PR TITLE
[IT-2089] Update patching configs

### DIFF
--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -43,8 +43,9 @@ PatchManager:
       IncludeMasterAccount: true
   Parameters:
     EventBridgeRuleSchedule: "cron(15 22 ? * TUE *)"
+    RunPatchBaselineRebootOption: "RebootIfNeeded"
     ResourceGroupName: !CopyValue sagebase-systemsmanager-patch-resource-group-TagBasedGroupName
-    RunPatchBaselineOperation: "Scan"
+    RunPatchBaselineOperation: "Install"
     TargetRegionIds: "us-east-1"
 
 PatchMembers:


### PR DESCRIPTION
The patching configuration was set to only scan for patches, we change it to install patches on instances.  Also changed setting to reboot instance after patching if needed. Instance are marked as non-compliant until a subsequent reboot and scan

