### PR TITLE
[IT-1967] Create an identity central account

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -103,6 +103,7 @@ Organization:
         - !Ref SecurityCentralAccount
         - !Ref IpamAccount
         - !Ref SysmanCentralAccount
+        - !Ref IdentityCentralAccount
 
   PolicyStagingOU:
     Type: OC::ORG::OrganizationalUnit
@@ -570,6 +571,16 @@ Organization:
       AccountName: org-sagebase-sysmancentral
       RootEmail: aws.sysmancentral@sagebase.org
       Alias: org-sagebase-sysmancentral
+      Tags:
+        <<: !Include ./_default_org_tags.yaml
+        <<: !Include ./_platform_org_tags.yaml
+
+  IdentityCentralAccount:
+    Type: OC::ORG::Account
+    Properties:
+      AccountName: org-sagebase-identitycentral
+      RootEmail: aws.identitycentral@sagebase.org
+      Alias: org-sagebase-identitycentral
       Tags:
         <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml


### PR DESCRIPTION
The idea behind identity-central is to have an AWS account that’s basically a shell account containing only IAM users and nothing else.  The purpose is to allow these IAM users to access resources in other AWS accounts but not resources in the identity-central account. Identity-central would be integrated with our Jumpcloud IDP so that we can manage AWS IAM users via Jumpcloud.

