### PR TITLE
[IT-2089] Create the resource group in all member accounts

### DIFF
--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -23,10 +23,11 @@ PatchResourceGroup:
   Type: update-stacks
   Template: patch-resource-group.yaml
   StackName: !Sub '${resourcePrefix}-${appName}-patch-resource-group'
-  StackDescription: A resource group for the patch managemer
+  StackDescription: A group of resources to apply patches to
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
-    Account: !Ref accountId
+    Account: '*'
+    IncludeMasterAccount: true
 
 PatchManager:
   Type: update-stacks


### PR DESCRIPTION
The multi-account patch manager will assume a role in each member account then execute patching on each account.  Therefore the resource group needs to be defined in each account so that the patch manager can use the resource group to identify the resources that it needs to patch.

