### PR TITLE
[IT-2089] Configure patch concurreny and error threshold

### DIFF
--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -48,6 +48,8 @@ PatchManager:
     ResourceGroupName: !CopyValue sagebase-systemsmanager-patch-resource-group-TagBasedGroupName
     RunPatchBaselineOperation: "Install"
     TargetRegionIds: "us-east-1"
+    TargetLocationMaxConcurrency: "10%"
+    TargetLocationMaxErrors: "10%"
 
 PatchMembers:
   Type: update-stacks


### PR DESCRIPTION
* Run patching on 10% of the accounts concurrently
* Continue patching as long as errors do not exceed 10% failure rate in each account.

