### PR TITLE
[IT-2089] narrow resource group for patching

### DIFF
--- a/org-formation/090-systems-manager/patch-resource-group.yaml
+++ b/org-formation/090-systems-manager/patch-resource-group.yaml
@@ -11,7 +11,16 @@ Resources:
           "TAG_FILTERS_1_0"
         Query:
           ResourceTypeFilters:
-            - "AWS::AllSupported"
+            - "AWS::DMS::ReplicationInstance"
+            - "AWS::EC2::Instance"
+            - "AWS::EC2::ReservedInstance"
+            - "AWS::EC2::SpotInstance"
+            - "AWS::ECS::ContainerInstance"
+            - "AWS::OpsWork::Instance"
+            - "AWS::RDS::DBInstance"
+            - "AWS::RDS::ReservedDBInstance"
+            - "AWS::SSM::ManagedInstance"
+            - "AWS::SageMaker::NotebookInstance"
           TagFilters:
             - Key: "ManagedInstanceMaintenanceTarget"
               Values:


### PR DESCRIPTION
We apply tags to EC2 to identify which EC2s need patching.  The problem
is that the tags are also propogated to the EC2s attached volumes.
This means that the patch group query will return EBS volumes for
patching which will fail.  We narrow the scope of the query so that
only instances are returned to the patch manager to run patch update on.