### PR TITLE
IT-2030: Update scicomp/computevpc

### DIFF
--- a/sceptre/scicomp/config/prod/computevpc.yaml
+++ b/sceptre/scicomp/config/prod/computevpc.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.10/vpc.yaml
 stack_name: computevpc
 parameters:
   VpcSubnetPrefix: "10.5"


### PR DESCRIPTION
This PR removes access from 10.1.0.0/16 in computevpc-VpnSecurityGroup-16YU33HUVTTRL SG. Same as previous ones.
