### PR TITLE
IT-2030: Update VPC

### DIFF
--- a/sceptre/scipool/config/bmgfki/gatespoolvpc.yaml
+++ b/sceptre/scipool/config/bmgfki/gatespoolvpc.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.10/vpc.yaml
 stack_name: gatespoolvpc
 dependencies:
   - bmgfki/bootstrap.yaml

--- a/sceptre/scipool/config/prod/internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/internalpoolvpc.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.10/vpc.yaml
 stack_name: internalpoolvpc
 dependencies:
   - prod/bootstrap.yaml

--- a/sceptre/scipool/config/strides/stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/stridespoolvpc.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.10/vpc.yaml
 stack_name: stridespoolvpc
 dependencies:
   - strides/bootstrap.yaml


### PR DESCRIPTION
This PR updates the VPCs in scipool/prod to 4.10 to remove 10.1.0.0/16 from VpnSecGroup. Same as previous ones, should be last ones.