### PR TITLE
Update bucket policy lambda

### DIFF
--- a/sceptre/scipool/config/bmgfki/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-cr-sc-bucket-policy.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.3/cfn-cr-sc-bucket-policy.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.4/cfn-cr-sc-bucket-policy.yaml
 stack_name: cfn-cr-sc-bucket-policy
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/develop/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-sc-bucket-policy.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.3/cfn-cr-sc-bucket-policy.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.4/cfn-cr-sc-bucket-policy.yaml
 stack_name: cfn-cr-sc-bucket-policy
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/prod/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-sc-bucket-policy.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.3/cfn-cr-sc-bucket-policy.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.4/cfn-cr-sc-bucket-policy.yaml
 stack_name: cfn-cr-sc-bucket-policy
 stack_tags:
   Department: "Platform"

--- a/sceptre/scipool/config/strides/cfn-cr-sc-bucket-policy.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-sc-bucket-policy.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.3/cfn-cr-sc-bucket-policy.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-sc-bucket-policy/1.0.4/cfn-cr-sc-bucket-policy.yaml
 stack_name: cfn-cr-sc-bucket-policy
 stack_tags:
   Department: "Platform"


### PR DESCRIPTION
This updates the bucket lambda in the service catalog with changes
from https://github.com/Sage-Bionetworks-IT/cfn-cr-sc-bucket-policy/pull/9

depends on https://github.com/Sage-Bionetworks-IT/cfn-cr-sc-bucket-policy/pull/9

