### PR TITLE
[IT-1532] The Policy Document should be a JSON string

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -181,20 +181,22 @@ CostExplorerAccessPolicy:
     Account: !Ref MasterAccount
     Region: !Ref primaryRegion
   Parameters:
-    PolicyDocument:
-      Version: 2012-10-17
-      Statement:
-        - Sid: CostExplorerAccess
-          Effect: Allow
-          Action:
-            - aws-portal:ViewUsage
-            - ce:Describe*
-            - ce:Get*
-            - ce:List*
-            - ce:*AnomalyMonitor
-            - ce:*AnomalySubscription
-            - ce:*Report
-          Resource: '*'
+    PolicyDocument: '{
+      "Version": "2012-10-17"
+      "Statement": [
+          "Sid": "CostExplorerAccess",
+          "Effect": "Allow",
+          "Action": [
+              "aws-portal:ViewUsage",
+              "ce:Describe*",
+              "ce:Get*",
+              "ce:List*",
+              "ce:*AnomalyMonitor",
+              "ce:*AnomalySubscription",
+              "ce:*Report"
+          ],
+          "Resource": "*"
+    }'
 
 # An access role allowing Saturn Cloud access to our AWS account running their product
 # https://dev.saturncloud.io/docs/enterprise/installation/


### PR DESCRIPTION
The managed-policy template expects the PolicyDocument to be a JSON string, not a template snippet.

This has been manually verified with `npm run validate-tasks`
