### PR TITLE
Fix S3 data lifecycle rule

### DIFF
--- a/org-formation/060-cloudtrail/cloudtrail-trail.yaml
+++ b/org-formation/060-cloudtrail/cloudtrail-trail.yaml
@@ -109,13 +109,12 @@ Resources:
               SSEAlgorithm: AES256
       VersioningConfiguration:
         Status: Enabled
-      # Move data to glacier after 90 days then move to deep archive after 180 days then delete after 360 days
+      # Move data to glacier after 90 days then move to deep archive after 180 days then delete after 365 days
       LifecycleConfiguration:
         Rules:
         - Id: DataLifecycleRule
           Status: Enabled
-          ExpirationInDays: 360
-          ExpiredObjectDeleteMarker: true
+          ExpirationInDays: 365
           Transitions:
             - TransitionInDays: 90
               StorageClass: GLACIER


### PR DESCRIPTION
AWS docs says the `ExpiredObjectDeleteMarker` cannot be specified with ExpirationInDays, ExpirationDate, or TagFilters[1]

This attempts to fix the failure from AWS:

```
  The XML you provided was not well-formed or did not validate against
  our published schema (Service: Amazon S3; Status Code: 400; Error Code:
  MalformedXML; Request ID: 1GH83JZQPKJ8V54M; S3 Extended Request ID:
  l/W7yBf+gvXSD+f/A/4OjMkonl5LuriZY4mckuIht3Z1CtFdGqw/x0PnqZ+xavaaYkq54urfPcE=; Proxy: null)
```

[1] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-lifecycleconfig-rule.html#cfn-s3-bucket-rule-expiredobjectdeletemarker