### PR TITLE
[IT-2139] Update cloudwatch retention for cloudtrail

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -254,7 +254,6 @@ Organization:
       Tags:
         <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
-        CloudwatchCloudTrailLogRetentionPeriod: 3653
 
   SecurityCentralAccount:
     Type: OC::ORG::Account


### PR DESCRIPTION
Reduce the cloudwatch retention period for cloudtrail to 90 days (our default) as suggested by our CISO.

In addition to cloudwatch we have the cloudtrail logs going to a central S3 bucket and have
setup on a lifecycle policy in PR #619 