### PR TITLE
[IT-2221] Restrict ssh access to scipool prod

### DIFF
--- a/sceptre/scipool/config/bmgfki/gatespoolvpc.yaml
+++ b/sceptre/scipool/config/bmgfki/gatespoolvpc.yaml
@@ -1,9 +1,10 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.10/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.5.2/vpc.yaml
 stack_name: gatespoolvpc
 dependencies:
   - bmgfki/bootstrap.yaml
 parameters:
   VpcSubnetPrefix: "10.67"
   VpcName: gatespoolvpc
+  IncludeBastianSecurityGroup: "false"

--- a/sceptre/scipool/config/develop/cesspoolvpc.yaml
+++ b/sceptre/scipool/config/develop/cesspoolvpc.yaml
@@ -1,9 +1,10 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.10/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.5.2/vpc.yaml
 stack_name: cesspoolvpc
 dependencies:
   - develop/bootstrap.yaml
 parameters:
   VpcSubnetPrefix: "10.31"
   VpcName: "cesspoolvpc"
+  IncludeBastianSecurityGroup: "false"

--- a/sceptre/scipool/config/develop/scheduledjobsvpc.yaml
+++ b/sceptre/scipool/config/develop/scheduledjobsvpc.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/VPC/vpc-mini.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.5.2/VPC/vpc-mini.yaml
 stack_name: scheduledjobsvpc
 stack_tags:
   Department: "Platform"
@@ -11,3 +11,4 @@ dependencies:
 parameters:
   VpcSubnetPrefix: "10.255.39"
   VpcName: "scheduledjobsvpc"
+  IncludeBastianSecurityGroup: "false"

--- a/sceptre/scipool/config/prod/internalpoolvpc.yaml
+++ b/sceptre/scipool/config/prod/internalpoolvpc.yaml
@@ -1,9 +1,10 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.10/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.5.2/vpc.yaml
 stack_name: internalpoolvpc
 dependencies:
   - prod/bootstrap.yaml
 parameters:
   VpcSubnetPrefix: "10.41"
   VpcName: internalpoolvpc
+  IncludeBastianSecurityGroup: "false"

--- a/sceptre/scipool/config/prod/scheduledjobsvpc.yaml
+++ b/sceptre/scipool/config/prod/scheduledjobsvpc.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/VPC/vpc-mini.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.5.2/VPC/vpc-mini.yaml
 stack_name: scheduledjobsvpc
 stack_tags:
   Department: "Platform"
@@ -11,3 +11,4 @@ dependencies:
 parameters:
   VpcSubnetPrefix: "10.255.40"
   VpcName: "scheduledjobsvpc"
+  IncludeBastianSecurityGroup: "false"

--- a/sceptre/scipool/config/strides/scheduledjobsvpc.yaml
+++ b/sceptre/scipool/config/strides/scheduledjobsvpc.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/VPC/vpc-mini.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.5.2/VPC/vpc-mini.yaml
 stack_name: scheduledjobsvpc
 stack_tags:
   Department: "Platform"
@@ -11,3 +11,4 @@ dependencies:
 parameters:
   VpcSubnetPrefix: "10.255.41"
   VpcName: "scheduledjobsvpc"
+  IncludeBastianSecurityGroup: "false"

--- a/sceptre/scipool/config/strides/stridespoolvpc.yaml
+++ b/sceptre/scipool/config/strides/stridespoolvpc.yaml
@@ -1,9 +1,10 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.10/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.5.2/vpc.yaml
 stack_name: stridespoolvpc
 dependencies:
   - strides/bootstrap.yaml
 parameters:
   VpcSubnetPrefix: "10.49"
   VpcName: stridespoolvpc
+  IncludeBastianSecurityGroup: "false"


### PR DESCRIPTION
Remove bastian ssh access from `internalpoolvpc` and `scheduledjobsvpc`, ssh access is still available from the vpn.

depends-on: https://github.com/Sage-Bionetworks/aws-infra/pull/361
