### PR TITLE
[IT-1766] Setup region restrictions

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -32,6 +32,7 @@ Organization:
         - !Ref RestrictDisableCloudwatchSCP
         - !Ref RestrictIamLoginProfileSCP
         - !Ref RestrictDnsRegistrationSCP
+        - !Ref RestrictUnsupportedRegionsSCP
       Accounts:
         - !Ref SandboxAccount
         - !Ref MobileHealthDataEngineeringDevAccount
@@ -50,6 +51,7 @@ Organization:
         - !Ref RestrictDisableCloudwatchSCP
         - !Ref RestrictIamLoginProfileSCP
         - !Ref RestrictDnsRegistrationSCP
+        - !Ref RestrictUnsupportedRegionsSCP
       Accounts:
         - !Ref ScicompAccount
         - !Ref iAtlasProdAccount
@@ -68,6 +70,7 @@ Organization:
         - !Ref RestrictDisableCloudwatchSCP
         - !Ref RestrictIamLoginProfileSCP
         - !Ref RestrictDnsRegistrationSCP
+        - !Ref RestrictUnsupportedRegionsSCP
       OrganizationalUnits:
         - !Ref SynapseOU
         - !Ref BridgeOU
@@ -81,6 +84,7 @@ Organization:
         - !Ref RestrictDisableCloudwatchSCP
         - !Ref RestrictIamLoginProfileSCP
         - !Ref RestrictDnsRegistrationSCP
+        - !Ref RestrictUnsupportedRegionsSCP
       Accounts:
         - !Ref SceptreDevAccount
         - !Ref SaturnCloudDevAccount
@@ -94,6 +98,7 @@ Organization:
         - !Ref RestrictDisableCloudwatchSCP
         - !Ref RestrictIamLoginProfileSCP
         - !Ref RestrictDnsRegistrationSCP
+        - !Ref RestrictUnsupportedRegionsSCP
       Accounts:
         - !Ref TransitAccount
         - !Ref AdminCentralAccount
@@ -121,6 +126,7 @@ Organization:
         - !Ref RestrictDisableCloudwatchSCP
         - !Ref RestrictIamLoginProfileSCP
         - !Ref RestrictDnsRegistrationSCP
+        - !Ref RestrictUnsupportedRegionsSCP
       Accounts:
         - !Ref BmgfkiAccount
         - !Ref ScipoolDevAccount
@@ -152,6 +158,7 @@ Organization:
         - !Ref RestrictDisableCloudwatchSCP
         - !Ref RestrictIamLoginProfileSCP
         - !Ref RestrictDnsRegistrationSCP
+        - !Ref RestrictUnsupportedRegionsSCP
       Accounts:
         - !Ref 8dxfh53Account
 


### PR DESCRIPTION
Setup our organization accounts to Only allow using AWS in US regions. Deploying to regions outside of the US will need to be managed as an exception case.
