### PR TITLE
[IT-1960] Decommision saturncloud account

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -554,16 +554,6 @@ Organization:
         <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
-  SaturnCloudDevAccount:
-    Type: OC::ORG::Account
-    Properties:
-      AccountName: org-sagebase-saturncloud-dev
-      RootEmail: saturncloud-dev@sagebase.org
-      Alias: org-sagebase-saturncloud-dev
-      Tags:
-        <<: !Include ./_default_org_tags.yaml
-        <<: !Include ./_platform_org_tags.yaml
-
   SysmanCentralAccount:
     Type: OC::ORG::Account
     Properties:


### PR DESCRIPTION
Remove saturncloud account from org-formation control. This will also require a manual step to close the account[1]

[1] https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_close.html

depends on #627
