### PR TITLE
[IT-1766] Refactor organization SCPs

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -6,21 +6,14 @@ Organization:
   #------- Service Control Policies -----------
   <<: !Include ./_scp.yaml
 
-  MasterAccount:
-    Type: OC::ORG::MasterAccount
-    Properties:
-      AccountName: organizations
-      AccountId: '531805629419'
-      RootEmail: aws.organizations@sagebase.org
-      Alias: org-sagebase-organizations
-      Tags:
-        <<: !Include ./_default_org_tags.yaml
-        <<: !Include ./_platform_org_tags.yaml
-
   OrganizationRoot:
     Type: OC::ORG::OrganizationRoot
     Properties:
       DefaultOrganizationAccessRoleName: OrganizationAccountAccessRole
+      ServiceControlPolicies:
+        - !Ref RestrictDisableCloudtrailSCP
+        - !Ref RestrictDisableCloudwatchSCP
+        - !Ref RestrictIamLoginProfileSCP
 
   #------- Organizational Units -----------
   ScienceDevOU:
@@ -28,9 +21,6 @@ Organization:
     Properties:
       OrganizationalUnitName: ScienceDev
       ServiceControlPolicies:
-        - !Ref RestrictDisableCloudtrailSCP
-        - !Ref RestrictDisableCloudwatchSCP
-        - !Ref RestrictIamLoginProfileSCP
         - !Ref RestrictDnsRegistrationSCP
         - !Ref RestrictUnsupportedRegionsSCP
       Accounts:
@@ -47,9 +37,6 @@ Organization:
     Properties:
       OrganizationalUnitName: ScienceProd
       ServiceControlPolicies:
-        - !Ref RestrictDisableCloudtrailSCP
-        - !Ref RestrictDisableCloudwatchSCP
-        - !Ref RestrictIamLoginProfileSCP
         - !Ref RestrictDnsRegistrationSCP
         - !Ref RestrictUnsupportedRegionsSCP
       Accounts:
@@ -66,9 +53,6 @@ Organization:
     Properties:
       OrganizationalUnitName: Platform
       ServiceControlPolicies:
-        - !Ref RestrictDisableCloudtrailSCP
-        - !Ref RestrictDisableCloudwatchSCP
-        - !Ref RestrictIamLoginProfileSCP
         - !Ref RestrictDnsRegistrationSCP
         - !Ref RestrictUnsupportedRegionsSCP
       OrganizationalUnits:
@@ -80,9 +64,6 @@ Organization:
     Properties:
       OrganizationalUnitName: ItDev
       ServiceControlPolicies:
-        - !Ref RestrictDisableCloudtrailSCP
-        - !Ref RestrictDisableCloudwatchSCP
-        - !Ref RestrictIamLoginProfileSCP
         - !Ref RestrictDnsRegistrationSCP
         - !Ref RestrictUnsupportedRegionsSCP
       Accounts:
@@ -93,9 +74,6 @@ Organization:
     Properties:
       OrganizationalUnitName: ItProd
       ServiceControlPolicies:
-        - !Ref RestrictDisableCloudtrailSCP
-        - !Ref RestrictDisableCloudwatchSCP
-        - !Ref RestrictIamLoginProfileSCP
         - !Ref RestrictDnsRegistrationSCP
         - !Ref RestrictUnsupportedRegionsSCP
       Accounts:
@@ -121,9 +99,6 @@ Organization:
     Properties:
       OrganizationalUnitName: ServiceCatalog
       ServiceControlPolicies:
-        - !Ref RestrictDisableCloudtrailSCP
-        - !Ref RestrictDisableCloudwatchSCP
-        - !Ref RestrictIamLoginProfileSCP
         - !Ref RestrictDnsRegistrationSCP
         - !Ref RestrictUnsupportedRegionsSCP
       Accounts:
@@ -153,15 +128,23 @@ Organization:
     Properties:
       OrganizationalUnitName: personal
       ServiceControlPolicies:
-        - !Ref RestrictDisableCloudtrailSCP
-        - !Ref RestrictDisableCloudwatchSCP
-        - !Ref RestrictIamLoginProfileSCP
         - !Ref RestrictDnsRegistrationSCP
         - !Ref RestrictUnsupportedRegionsSCP
       Accounts:
         - !Ref 8dxfh53Account
 
   #------- Accounts -----------
+  MasterAccount:
+    Type: OC::ORG::MasterAccount
+    Properties:
+      AccountName: organizations
+      AccountId: '531805629419'
+      RootEmail: aws.organizations@sagebase.org
+      Alias: org-sagebase-organizations
+      Tags:
+        <<: !Include ./_default_org_tags.yaml
+        <<: !Include ./_platform_org_tags.yaml
+
   BridgeDevAccount:
     Type: OC::ORG::Account
     Properties:

--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -6,6 +6,7 @@ Organization:
   #------- Service Control Policies -----------
   <<: !Include ./_scp.yaml
 
+  #------- Organizational Units -----------
   OrganizationRoot:
     Type: OC::ORG::OrganizationRoot
     Properties:
@@ -15,7 +16,6 @@ Organization:
         - !Ref RestrictDisableCloudwatchSCP
         - !Ref RestrictIamLoginProfileSCP
 
-  #------- Organizational Units -----------
   ScienceDevOU:
     Type: OC::ORG::OrganizationalUnit
     Properties:


### PR DESCRIPTION
AWS only allow attaching 5 SCPs per OU[1] to work around this quota
we need to move some SCPs to the root level.

* Group accounts definitions together
* Move common SCP to root OU

Note: this is a redo of PR #624

[1] https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_limits.html

