### PR TITLE
[IT-2317] Enable KMS key rotation

### DIFF
--- a/sceptre/scipool/templates/sc-kms-key.yaml
+++ b/sceptre/scipool/templates/sc-kms-key.yaml
@@ -35,6 +35,7 @@ Resources:
     Type: AWS::KMS::Key
     Properties:
       Description: !Sub '${AWS::StackName}-KmsKey'
+      EnableKeyRotation: "true"
       KeyPolicy:
         Version: "2012-10-17"
         Statement:


### PR DESCRIPTION
Enable key rotation for KMS key used for the Service Catalog in org-sagebase-scipooldev, org-sagebase-scipoolprod, org-sagebase-strides, and org-sagebase-bmgfki accounts