### PR TITLE
[IT-2327] Enable cloudtrail log encryption

### DIFF
--- a/org-formation/060-cloudtrail/_tasks.yaml
+++ b/org-formation/060-cloudtrail/_tasks.yaml
@@ -24,6 +24,8 @@ CloudTrail:
     Account: '*'
     IncludeMasterAccount: true
   OrganizationBindings:
+    AllBinding:
+      Account: '*'
     MasterBinding:
       Account: !Ref LogCentralAccount
     MemberBinding:

--- a/org-formation/060-cloudtrail/cloudtrail-trail.yaml
+++ b/org-formation/060-cloudtrail/cloudtrail-trail.yaml
@@ -14,7 +14,7 @@ Parameters:
     Description: List of user/role/account ARNs that can administer the key
 Resources:
   KmsKey:
-    OrganizationBinding: !Ref MasterBinding
+    OrganizationBinding: !Ref AllBinding
     Type: "AWS::KMS::Key"
     Properties:
       Description: !Sub '${AWS::StackName} created key'
@@ -176,6 +176,7 @@ Resources:
       EnableLogFileValidation: true
       CloudWatchLogsLogGroupArn: !Ref CloudWatchLogsLogGroupArn
       CloudWatchLogsRoleArn: !Ref CloudWatchLogsRoleArn
+      KMSKeyId: !Ref KmsKey
 
 Outputs:
   CloudTrailBucketName:


### PR DESCRIPTION
We setup multi-account cloudtrail in a management and member configuration. This requires enabling cloudtrail on every account.  We only setup encryption on the management account's cloudtrail.  This will enable KMS encryption to all member accounts as well.

