### PR TITLE
IT-2344: Add perms and export policy

### DIFF
--- a/sceptre/synapsedev/templates/accounts.yaml
+++ b/sceptre/synapsedev/templates/accounts.yaml
@@ -113,6 +113,9 @@ Resources:
               - "iam:RemoveRoleFromInstanceProfile"
               - "iam:AddRoleToInstanceProfile"
               - "iam:AttachRolePolicy"
+              - "iam:CreatePolicy"
+              - "iam:ListPolicies"
+              - "kms:*"
             Resource: "*"
 
   AWSIAMAdminRole:
@@ -281,3 +284,7 @@ Outputs:
     Value: !GetAtt AWSIAMAdminRole.RoleId
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-AWSIAMAdminRoleId'
+  AWSIAMDevelopersDeployRightsPolicy:
+    Value: !Ref AWSIAMDevelopersDeployRightsPolicy
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-AWSIAMDevelopersDeployRightsPolicy'


### PR DESCRIPTION
This PR adds permissions needed by developers (already added to test) and exports the policy to allow the SSO dev group to gain same right (more prep to replace IAM users by IAM service accounts).
