### PR TITLE
Remove sumologic role

### DIFF
--- a/sceptre/logcentral/config/prod/sumologic-role-s3cloudtrail.yaml
+++ b/sceptre/logcentral/config/prod/sumologic-role-s3cloudtrail.yaml
@@ -1,3 +1,4 @@
+obsolete: true
 template:
   type: http
   url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/sumologic-role.yaml

--- a/sceptre/logcentral/config/prod/sumologic-role-s3config.yaml
+++ b/sceptre/logcentral/config/prod/sumologic-role-s3config.yaml
@@ -1,3 +1,4 @@
+obsolete: true
 template:
   type: http
   url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/sumologic-role.yaml


### PR DESCRIPTION
These roles were setup to allow sumologic to ingest cloudtrail and config logs so that our security
engineer can use sumologic to query the logs. Requirements have changed and our previous
security guy has moved on therefore we don't really need this anymore.  Removing sumologic will
reduce cost and make the setup more simple.