### PR TITLE
[IT-2317] Enable KMS key rotation

### DIFF
--- a/sceptre/bridge/templates/essentials.yaml
+++ b/sceptre/bridge/templates/essentials.yaml
@@ -29,6 +29,7 @@ Resources:
         - '-'
         - - !Ref AWS::StackName
           - "InfraKey"
+      EnableKeyRotation: "true"
       KeyPolicy:
         Version: "2012-10-17"
         Statement:

--- a/sceptre/synapsedev/templates/SynapseCMK-template.json
+++ b/sceptre/synapsedev/templates/SynapseCMK-template.json
@@ -230,7 +230,7 @@
             "Type": "AWS::KMS::Key",
             "Properties": {
                 "Description": "The master encryption key used to encypt/decrypt all Synapse master secrets",
-                "EnableKeyRotation": false,
+                "EnableKeyRotation": true,
                 "KeyPolicy": {
                     "Version": "2012-10-17",
                     "Id": "key-default-1",

--- a/sceptre/synapseprod/templates/SynapseCMK-template.json
+++ b/sceptre/synapseprod/templates/SynapseCMK-template.json
@@ -208,7 +208,7 @@
             "Type": "AWS::KMS::Key",
             "Properties": {
                 "Description": "The master encryption key used to encypt/decrypt all Synapse master secrets",
-                "EnableKeyRotation": false,
+                "EnableKeyRotation": true,
                 "KeyPolicy": {
                     "Version": "2012-10-17",
                     "Id": "key-default-1",


### PR DESCRIPTION
Automatically rotating keys is a security best practice. Enable key rotation for KMS key used by bridge and synapse.

