### PR TITLE
[IT-2248] Align Security Group with Routing Table.

### DIFF
--- a/org-formation/720-client-vpn/vpn.yaml
+++ b/org-formation/720-client-vpn/vpn.yaml
@@ -50,7 +50,7 @@ Resources:
       GroupDescription: !Sub '${AWS::StackName} Security Group'
       VpcId: !Ref VpcId
       SecurityGroupIngress:
-        - CidrIp: "0.0.0.0/0"
+        - CidrIp: !Ref ClientCidrBlock
           FromPort: -1
           ToPort: -1
           IpProtocol: "-1"


### PR DESCRIPTION
The security group is applied to the VPC that VPN clients land on after authenticating. This VPC does not need to allow inbound connections since the only hosts on the subnet are VPN clients.

The routing table only has a configuration for local traffic, restrict the security group similarly.
