### PR TITLE
[ETL-275] Add recover production account under ScienceProdOU

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -46,6 +46,7 @@ Organization:
         - !Ref CnbAccount
         - !Ref AgoraProdAccount
         - !Ref IncludeChopProdAccount
+        - !Ref RecoverProdAccount
 
   PlatformOU:
     Type: OC::ORG::OrganizationalUnit
@@ -562,6 +563,22 @@ Organization:
       Tags:
         <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
+
+  RecoverProdAccount:
+    Type: OC::ORG::Account
+    Properties:
+      AccountName: org-sagebase-recover-prod
+      AccountId: '634761300905'
+      RootEmail: aws-recover-prod@sagebase.org
+      Alias: org-sagebase-recover-prod
+      Tags:
+        <<: !Include ./_default_org_tags.yaml
+        Department: DNT
+        Project: RECOVER
+        AccountOwner: thomas.yu@sagebase.org
+        CostCenter: MGH RECOVER / 122500
+        budget-alarm-threshold: 10000
+        budget-alarm-threshold-email-recipient: aws-recover-prod@sagebase.org
 
   #------------ Personal Accounts -----------
   8dxfh53Account:

--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -568,7 +568,6 @@ Organization:
     Type: OC::ORG::Account
     Properties:
       AccountName: org-sagebase-recover-prod
-      AccountId: '634761300905'
       RootEmail: aws-recover-prod@sagebase.org
       Alias: org-sagebase-recover-prod
       Tags:


### PR DESCRIPTION
Hello,
I'm opening this PR to create a production AWS account. This production account paired with the development account will house all the ETL work required for the RECOVER project, such that all the work done in these accounts will be charged to the RECOVER grant.

See [PR #649](https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/649) for the PR creating the corresponding development account.

PR Checklist:
[X] Describe and explain your intentions for this change
[X] Setup pre-commit and run the validators (info in README.md)
