### PR TITLE
[ETL-275] Set up JumpCloud access for RECOVER Prod account

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -1326,6 +1326,9 @@ SsoRecoverProdAdmin:
     instanceArn: !Ref instanceArn
     principalId: !Ref recoverProdAdminGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
+    recoverProdAdminGroup:      #JC aws-recover-prod-admins
+    Type: String
+    Default: '54d83448-10a1-7000-7e72-cae28f0caacf'
 
 SsoRecoverProdDeveloper:
   Type: update-stacks
@@ -1343,6 +1346,9 @@ SsoRecoverProdDeveloper:
     instanceArn: !Ref instanceArn
     principalId: !Ref recoverProdDeveloperGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
+    recoverProdDeveloperGroup:      #JC aws-recover-prod-developers
+    Type: String
+    Default: 'a468b478-f021-7010-535b-4ad779417559'
 
 SsoRecoverProdViewer:
   Type: update-stacks
@@ -1360,3 +1366,6 @@ SsoRecoverProdViewer:
     instanceArn: !Ref instanceArn
     principalId: !Ref recoverProdViewerGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-viewer-permission-set-arn' ]
+    recoverProdViewerGroup:      #JC aws-recover-prod-viewers
+    Type: String
+    Default: 'b4e86468-f091-70e2-0ea9-64cf3addcdf1'

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -1309,3 +1309,54 @@ Sso8dxfh53Admin:
     instanceArn: !Ref instanceArn
     principalId: !Ref 8dxfh53AdminGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
+
+SsoRecoverProdAdmin:
+  Type: update-stacks
+  DependsOn: SsoAdministrator
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-recover-prod-admin'
+  StackDescription: 'SSO: Administrator role used by recover admin group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref RecoverProdAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref recoverProdAdminGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
+
+SsoRecoverProdDeveloper:
+  Type: update-stacks
+  DependsOn: SsoDeveloper
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-recover-prod-developer'
+  StackDescription: 'SSO: Developer role used by recover developer group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref RecoverProdAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref recoverProdDeveloperGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
+
+SsoRecoverProdViewer:
+  Type: update-stacks
+  DependsOn: SsoViewer
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-recover-prod-viewer'
+  StackDescription: 'SSO: Viewer role used by recover viewer group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref RecoverProdAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref recoverProdViewerGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-viewer-permission-set-arn' ]

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -201,6 +201,18 @@ Parameters:
     Type: String
     Default: 'e4880448-e061-70b3-2487-e2c54abce711'
 
+  recoverProdAdminGroup:      #JC aws-recover-prod-admins
+    Type: String
+    Default: '54d83448-10a1-7000-7e72-cae28f0caacf'
+
+  recoverProdDeveloperGroup:      #JC aws-recover-prod-developers
+    Type: String
+    Default: 'a468b478-f021-7010-535b-4ad779417559'
+
+  recoverProdViewerGroup:      #JC aws-recover-prod-viewers
+    Type: String
+    Default: 'b4e86468-f091-70e2-0ea9-64cf3addcdf1'
+
   #------------- personal AWS accounts ------------------
   8dxfh53AdminGroup:             #JC aws-8dxfh53-admins
     Type: String
@@ -1326,9 +1338,6 @@ SsoRecoverProdAdmin:
     instanceArn: !Ref instanceArn
     principalId: !Ref recoverProdAdminGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
-    recoverProdAdminGroup:      #JC aws-recover-prod-admins
-    Type: String
-    Default: '54d83448-10a1-7000-7e72-cae28f0caacf'
 
 SsoRecoverProdDeveloper:
   Type: update-stacks
@@ -1346,9 +1355,6 @@ SsoRecoverProdDeveloper:
     instanceArn: !Ref instanceArn
     principalId: !Ref recoverProdDeveloperGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
-    recoverProdDeveloperGroup:      #JC aws-recover-prod-developers
-    Type: String
-    Default: 'a468b478-f021-7010-535b-4ad779417559'
 
 SsoRecoverProdViewer:
   Type: update-stacks
@@ -1366,6 +1372,3 @@ SsoRecoverProdViewer:
     instanceArn: !Ref instanceArn
     principalId: !Ref recoverProdViewerGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-viewer-permission-set-arn' ]
-    recoverProdViewerGroup:      #JC aws-recover-prod-viewers
-    Type: String
-    Default: 'b4e86468-f091-70e2-0ea9-64cf3addcdf1'


### PR DESCRIPTION
Hi,
This PR builds on top of now merged [#650](https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/650) and sets up access to the AWS account via JumpCloud.
Ideally, admin, developer and viewer roles are created.

A blank placeholder document (for the purpose of creating the initial PR and will be deleted later prior to merging) has been generated at _/.../org-formation/600-access/etl_275_blank_file.txt

PR Checklist:
[X] Describe and explain your intentions for this change
[X] Setup pre-commit and run the validators (info in README.md)
