### PR TITLE
Remove sumologic integration

### DIFF
--- a/org-formation/060-cloudtrail/_tasks.yaml
+++ b/org-formation/060-cloudtrail/_tasks.yaml
@@ -39,17 +39,3 @@ CloudTrail:
       - !Sub 'arn:aws:iam::${AWS::AccountId}:role/OrganizationAccountAccessRole'
       - 'arn:aws:iam::531805629419:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1EY1CRUF48VP5'
 
-CloudTrailSumoLogicRole:
-  Type: update-stacks
-  DependsOn: [ "CloudTrail" ]
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.13/templates/sumologic-role.yaml
-  StackName: !Sub '${resourcePrefix}-cloudtrail-sumologic-role'
-  StackDescription: Allow Sumologic to access cloudTrail data
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    Account: !Ref LogCentralAccount
-    IncludeMasterAccount: false
-  Parameters:
-    ExternalID: "us2:00000000001E813D"
-    Actions: 's3:GetObject,s3:GetObjectVersion,s3:ListBucketVersions,s3:ListBucket'
-    Resource: !CopyValue [ !Sub '${primaryRegion}-${resourcePrefix}-cloudtrail-CloudTrailBucketArn' ]

--- a/org-formation/080-aws-config-inventory/_tasks.yaml
+++ b/org-formation/080-aws-config-inventory/_tasks.yaml
@@ -22,17 +22,3 @@ ConfigBase:
     resourcePrefix: !Ref resourcePrefix
     bucketName: !Sub '${resourcePrefix}-${appName}-${CurrentAccount.AccountId}'
 
-ConfigSumoLogicRole:
-  Type: update-stacks
-  DependsOn: [ "ConfigBase" ]
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.13/templates/sumologic-role.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-sumologic-role'
-  StackDescription: Allow Sumologic to access AWS config data
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    Account: !Ref LogCentralAccount
-    IncludeMasterAccount: false
-  Parameters:
-    ExternalID: "us2:00000000001E813D"
-    Actions: 's3:GetObject,s3:GetObjectVersion,s3:ListBucketVersions,s3:ListBucket'
-    Resource: !CopyValue [ !Sub '${primaryRegion}-${resourcePrefix}-${appName}-base-ConfigAuditBucketArn' ]


### PR DESCRIPTION
We are required to keep 90 days of cloudtrail logs for quering[1] which is what we have setup in watchwatch.  This means that we no longer need sumologic for querying the entire history of cloudtrail logs.  This removes sumologic integration with AWS cloudtrail and AWS configs.

[1] https://sagebionetworks.jira.com/browse/IT-2139

