### PR TITLE
Disable SCP to restrict guardduty changes

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -14,7 +14,7 @@ Organization:
       ServiceControlPolicies:
         - !Ref RestrictDisableCloudtrailSCP
         - !Ref RestrictDisableCloudwatchSCP
-        - !Ref RestrictDisableGuarddutySCP
+#        - !Ref RestrictDisableGuarddutySCP   # automation to vend aws accounts updates GD
         - !Ref RestrictIamLoginProfileSCP
 
   ScienceDevOU:


### PR DESCRIPTION
We need to disable the SCP to restrict disabling guard duty because that is preventing our automation to setup GD when vending new AWS accounts.  When the automation creates new accounts it sets up GD and integrates it with the GD in the management account (securitycentral) 

