### PR TITLE
Disable SCP to restrict cloudtrail and config updates

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -12,10 +12,11 @@ Organization:
     Properties:
       DefaultOrganizationAccessRoleName: OrganizationAccountAccessRole
       ServiceControlPolicies:
-        - !Ref RestrictDisableCloudtrailSCP
-        - !Ref RestrictDisableCloudwatchSCP
-#        - !Ref RestrictDisableGuarddutySCP   # automation to vend aws accounts updates GD
         - !Ref RestrictIamLoginProfileSCP
+# automation attempts to update these services when vending new aws accounts
+#        - !Ref RestrictDisableCloudtrailSCP
+#        - !Ref RestrictDisableCloudwatchSCP
+#        - !Ref RestrictDisableGuarddutySCP
 
   ScienceDevOU:
     Type: OC::ORG::OrganizationalUnit


### PR DESCRIPTION
We need to disable the SCP to restrict disabling aws config and cloudtrail because that is preventing our automation from setting up those services when we vend new AWS accounts.

