### PR TITLE
Fix aws config deployment

### DIFF
--- a/org-formation/080-aws-config-inventory/_tasks.yaml
+++ b/org-formation/080-aws-config-inventory/_tasks.yaml
@@ -8,7 +8,7 @@ Parameters:
 # Enable AWS Config in all member accounts and send Findings and Config history to the centralized s3 bucket in the archive account
 ConfigBase:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.13/templates/Config/config.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.1/templates/Config/config.yaml
   StackName: !Sub '${resourcePrefix}-${appName}-base'
   StackDescription: AWS Config - Base
   DefaultOrganizationBindingRegion: !Ref primaryRegion


### PR DESCRIPTION
This fixes AWS config deployment which was failing when vending new AWS accounts. Update aws config template with updated role name.  The AWS built in role name was deprecated and replaced with AWS_ConfigRole.

The build failed with following message..

```
Policy arn:aws:iam::aws:policy/service-role/AWSConfigRole does not exist or is not attachable
```

depends on https://github.com/Sage-Bionetworks/aws-infra/pull/369

