### PR TITLE
SC-404: Update dependency version

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-windows-jumpcloud.yaml
@@ -62,7 +62,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.42/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.42'
-    - Description: 'Remove JC user to instance assocation {{ range(1, 10000) | random }}'
+    - Description: 'Remove JC user to instance assocation'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.43/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.43'
+    - Description: 'Remove JC user to instance assocation {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.44/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.44'

--- a/sceptre/scipool/config/develop/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-windows-jumpcloud.yaml
@@ -61,7 +61,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.42/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.42'
-    - Description: 'Remove JC user to instance association {{ range(1, 10000) | random }}'
+    - Description: 'Remove JC user to instance association'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.43/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.43'
+    - Description: 'Remove instance assocation {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.44/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.44'

--- a/sceptre/scipool/config/prod/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-windows-jumpcloud.yaml
@@ -62,7 +62,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.42/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.42'
-    - Description: 'Remove JC user to instance association {{ range(1, 10000) | random }}'
+    - Description: 'Remove JC user to instance association'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.43/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.43'
+    - Description: 'Remove JC user to instance assocation {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.44/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.44'

--- a/sceptre/scipool/config/strides/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-windows-jumpcloud.yaml
@@ -62,7 +62,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.42/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.42'
-    - Description: 'Remove JC user to instance association {{ range(1, 10000) | random }}'
+    - Description: 'Remove JC user to instance association'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.43/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.43'
+    - Description: 'Remove JC user to instance assocation {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.44/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.44'


### PR DESCRIPTION
This PR updates the dependency on sc-ec2-windows-jumpcloud.yaml to v1.1.44 (remove the user association step).

Depends on Sage-Bionetworks/service-catalog-library#288
