### PR TITLE
[IT-1655] Deploy initial mips microservice

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -20,6 +20,22 @@ AnomalyDetectorService:
   Parameters:
     Subscriber: !GetAtt CurrentAccount.RootEmail
 
+# Deploy a general-use microservice for interacting with MIPS in admincentral
+MipsMicroservice:
+  Type: update-stacks
+  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-mips-api/master/lambda-mips-api.yaml'
+  StackName: !Sub '${resourcePrefix}-mips-microservice'
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+    Account: !Ref AdminCentralAccount
+    Region: !Ref primaryRegion
+  Parameters:
+    MipsOrganization: 'SAGE_24146'
+    SsmKeyAdminArns:
+      - 'arn:aws:sts::745159704268:assumed-role/AWSReservedSSO_Administrator_30244677b3ea9498/joni.harker@sagebase.org'
+      - !Sub 'arn:aws:iam::${CurrentAccount.AccountId}:root'
+      - 'arn:aws:iam::745159704268:role/github-oidc-sage-bionetwo-ProviderRoleorganization-93H11ERK3F4N'
+
 CostCategories:
   Type: update-stacks
   Template: categories.yaml


### PR DESCRIPTION
Deploy the initial version of our microservice for transforming chart of accounts data from mips. Once created, one of the listed admins will need to populate the following SSM secure parameters with appropriate mips credentials: `/lambda/mipsSecret/user`, `/lambda/mipsSecret/pass`.
