### PR TITLE
[IT-2431] Require HTTPS for GuardDuty bucket

### DIFF
--- a/org-formation/070-guard-duty/_tasks.yaml
+++ b/org-formation/070-guard-duty/_tasks.yaml
@@ -72,7 +72,7 @@ GuardDutyConnectStridesAmpadWorkflows:
 # bucket that contains the trusted IP addresses that are excluded from GuardDuty findings
 GuardDutyTrustedIpsBucket:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/GuardDuty/trusted-ips-bucket.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.2/templates/GuardDuty/trusted-ips-bucket.yaml
   StackName: !Sub '${resourcePrefix}-${appName}-trusted-ips-bucket'
   StackDescription: GuardDuty - Trusted IPs bucket
   DefaultOrganizationBindingRegion: !Ref primaryRegion


### PR DESCRIPTION
Add a bucket policy that requires HTTPS when accessing the list of IPs for GuardDuty to ignore.

Depends on: Sage-Bionetworks/aws-infra#370
