### PR TITLE
[IT-2394] Update AWS password policy

### DIFF
--- a/org-formation/200-baseline/_tasks.yaml
+++ b/org-formation/200-baseline/_tasks.yaml
@@ -3,7 +3,7 @@ Parameters:
 
 PasswordPolicy:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.0/templates/ORG/password-policy.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.1/templates/ORG/password-policy.yaml
   StackName: baseline-password-policy
   DefaultOrganizationBinding:
     IncludeMasterAccount: true


### PR DESCRIPTION
Update the password policy template to ver 0.6.1 which contains

```
PasswordReusePrevention: 24
```

That parameter was added in commit [f24cb41d](https://github.com/Sage-Bionetworks/aws-infra/commit/f24cb41ded8a1bf909177f49cc98f494a4069b7d) which will prevent password reuse.