### PR TITLE
[ETL-309] Add oidc integration for recover

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -19,3 +19,23 @@ GithubOidcSageBionetworksIt:
     IncludeMasterAccount: true
     Account: '*'
     Region: us-east-1
+
+GithubOidcSageBionetworksRecover:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.1/templates/IAM/github-oidc-provider.j2
+  StackName: github-oidc-sage-bionetworks-recover
+  Parameters:
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+    ThumbprintList:
+      - "6938fd4d98bab03faadb97b34396831e3780aea1"
+    GitHubOrg: "Sage-Bionetworks"
+  TemplatingContext:
+    Repositories:
+      - name: "recover"
+        branch: "main"
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref RecoverProdAccount
+      - !Ref RecoverDevAccount
+    Region: us-east-1

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -33,7 +33,7 @@ GithubOidcSageBionetworksRecover:
   TemplatingContext:
     Repositories:
       - name: "recover"
-        branch: "main"
+        branch: "*"
   DefaultOrganizationBinding:
     Account:
       - !Ref RecoverProdAccount


### PR DESCRIPTION
**Purpose:** Setup OIDC integration with an IAM role that a certain GitHub repo’ can assume to allow GitHub to deploy to the Recover AWS account.

See [#673](https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/673) for the previous course of action leading to this decision. 

PR Checklist:
[X] Describe and explain your intentions for this change
[X] Setup pre-commit and run the validators (info in README.md)
