### PR TITLE
Refactor GitHub OIDC

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -19,3 +19,23 @@ GithubOidcSageBionetworksIt:
     IncludeMasterAccount: true
     Account: '*'
     Region: us-east-1
+
+GithubOidcSageBionetworksRecover:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.1/templates/IAM/github-oidc-provider.j2
+  StackName: github-oidc-sage-bionetworks-recover
+  Parameters:
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+    ThumbprintList:
+      - "6938fd4d98bab03faadb97b34396831e3780aea1"
+    GitHubOrg: "Sage-Bionetworks"
+  TemplatingContext:
+    Repositories:
+      - name: "recover"
+        branch: "main"
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref RecoverProdAccount
+      - !Ref RecoverDevAccount
+    Region: us-east-1

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -33,7 +33,7 @@ GithubOidcSageBionetworksRecover:
   TemplatingContext:
     Repositories:
       - name: "recover"
-        branch: "main"
+        branch: "*"
   DefaultOrganizationBinding:
     Account:
       - !Ref RecoverProdAccount

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -10,6 +10,7 @@ GithubOidcSageBionetworks:
   Template: oidc-provider.yaml
   StackName: !Sub ${resourcePrefix}-${appName}
   Parameters:
+    Url: "https://token.actions.githubusercontent.com"
     ThumbprintList:
       - "6938fd4d98bab03faadb97b34396831e3780aea1"
   DefaultOrganizationBinding:

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -1,16 +1,31 @@
 Parameters:
   <<: !Include '../_parameters.yaml'
 
-GithubOidcSageBionetworksIt:
+  appName:
+    Type: String
+    Default: 'github-oidc'
+
+GithubOidcSageBionetworks:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.1/templates/IAM/github-oidc-provider.j2
-  StackName: github-oidc-sage-bionetworks-it
+  Template: oidc-provider.yaml
+  StackName: !Sub ${resourcePrefix}-${appName}
   Parameters:
-    ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AdministratorAccess"
     ThumbprintList:
       - "6938fd4d98bab03faadb97b34396831e3780aea1"
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+    Account: '*'
+    Region: us-east-1
+
+GithubOidcSageBionetworksIt:
+  Type: update-stacks
+  Template: oidc-provider-access.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-it
+  Parameters:
     GitHubOrg: "Sage-Bionetworks-IT"
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
     Repositories:
       - name: "organizations-infra"
@@ -22,14 +37,12 @@ GithubOidcSageBionetworksIt:
 
 GithubOidcSageBionetworksRecover:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.1/templates/IAM/github-oidc-provider.j2
-  StackName: github-oidc-sage-bionetworks-recover
+  Template: oidc-provider-access.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-recover
   Parameters:
+    GitHubOrg: "Sage-Bionetworks"
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
-    ThumbprintList:
-      - "6938fd4d98bab03faadb97b34396831e3780aea1"
-    GitHubOrg: "Sage-Bionetworks"
   TemplatingContext:
     Repositories:
       - name: "recover"

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -20,6 +20,7 @@ GithubOidcSageBionetworks:
 
 GithubOidcSageBionetworksIt:
   Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
   Template: github-oidc-provider-access.j2
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-it
   Parameters:
@@ -38,6 +39,7 @@ GithubOidcSageBionetworksIt:
 
 GithubOidcSageBionetworksRecover:
   Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
   Template: github-oidc-provider-access.j2
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-recover
   Parameters:

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -19,7 +19,7 @@ GithubOidcSageBionetworks:
 
 GithubOidcSageBionetworksIt:
   Type: update-stacks
-  Template: oidc-provider-access.j2
+  Template: github-oidc-provider-access.j2
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-it
   Parameters:
     GitHubOrg: "Sage-Bionetworks-IT"
@@ -37,10 +37,11 @@ GithubOidcSageBionetworksIt:
 
 GithubOidcSageBionetworksRecover:
   Type: update-stacks
-  Template: oidc-provider-access.j2
+  Template: github-oidc-provider-access.j2
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-recover
   Parameters:
     GitHubOrg: "Sage-Bionetworks"
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:

--- a/org-formation/650-identity-providers/github-oidc-provider-access.j2
+++ b/org-formation/650-identity-providers/github-oidc-provider-access.j2
@@ -1,8 +1,14 @@
-{# Allow Github to access AWS without giving github AWS credentials #}
-{# Must pass in the following templating parameters                 #}
-{#   Repositories:                                                  #}
-{#     - name: "organizations-infra"                                #}
-{#       branch: "master"                                           #}
+{# Allow Github to access AWS without giving github AWS credentials               #}
+{# Must pass in the following templating parameters                               #}
+{#  Parameters:                                                                   #}
+{#    GitHubOrg: "Sage-Bionetworks"                                               #}
+{#    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ] #}
+{#    ManagedPolicyArns:                                                          #}
+{#      - "arn:aws:iam::aws:policy/AdministratorAccess"                           #}
+{#  TemplatingContext:                                                            #}
+{#    Repositories:                                                               #}
+{#      - name: "myrepo"                                                          #}
+{#        branch: "master"                                                        #}
 
 {# Make template compatible with both sceptre and org-formation     #}
 {% if sceptre_user_data.Repositories is defined %}
@@ -10,7 +16,7 @@
 {% endif %}
 
 AWSTemplateFormatVersion: 2010-09-09
-Description: Github OIDC
+Description: Setup github OIDC access
 Parameters:
   ClientIdList:
     Type: List<String>

--- a/org-formation/650-identity-providers/oidc-provider-access.j2
+++ b/org-formation/650-identity-providers/oidc-provider-access.j2
@@ -1,0 +1,94 @@
+{# Allow Github to access AWS without giving github AWS credentials #}
+{# Must pass in the following templating parameters                 #}
+{#   Repositories:                                                  #}
+{#     - name: "organizations-infra"                                #}
+{#       branch: "master"                                           #}
+
+{# Make template compatible with both sceptre and org-formation     #}
+{% if sceptre_user_data.Repositories is defined %}
+    {% set Repositories = sceptre_user_data.Repositories %}
+{% endif %}
+
+AWSTemplateFormatVersion: 2010-09-09
+Description: Github OIDC
+Parameters:
+  ClientIdList:
+    Type: List<String>
+    Description: >-
+      A list of client IDs (also known as audiences) that are associated with
+      the specified IAM OIDC provider resource object
+    Default: "sts.amazonaws.com"
+  ProviderArn:
+    Type: String
+    Description: "The OIDC provider ARN"
+  GitHubOrg:
+    Type: String
+    Description: "The name of the github organization"
+  # Must provide either a list of ManagePolicyArns or a custom PolicyDocument.
+  # Can also provide both a list of ManagePolicyArns and a custom PolicyDocument.
+  ManagedPolicyArns:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: >-
+      A list of managed policies for the role. Required if PolicyDocument not provided.
+      Example:
+        ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess", "arn:aws:iam::1111111111:policy/MY-EXISTING-POLICY"]
+  PolicyDocument:
+    Type: String
+    Default: ""
+    Description: >-
+      A JSON policy document to define a custom policy for the role. Required if ManagedPolicyArns not provided.
+      Example:
+        {
+          "Version":"2012-10-17",
+          "Statement":[
+            {
+              "Sid":"PublicRead",
+              "Effect":"Allow",
+              "Principal": "*",
+              "Action":["s3:GetObject","s3:GetObjectVersion"],
+              "Resource":["arn:aws:s3:::EXAMPLE-BUCKET/*"]
+            }
+          ]
+        }
+Conditions:
+  HasManagedPolicyArns: !Not
+    - !Equals
+      - !Join ["", !Ref ManagedPolicyArns]
+      - ''
+  HasPolicyDocument: !Not [!Equals [!Ref PolicyDocument, ""]]
+Resources:
+  ServicePolicy:
+    Condition: HasPolicyDocument
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument: !Ref PolicyDocument
+{% for Repository in Repositories %}
+  ProviderRole{{ Repository.name | replace('-','') | replace('_','') }}:
+    Type: AWS::IAM::Role
+    Properties:
+      # Concatinate managed policy and custom policy
+      ManagedPolicyArns: !Split
+        - ","
+        - !Join
+            - ","
+            - - !If [HasPolicyDocument, !Ref ServicePolicy, !Ref 'AWS::NoValue']
+              - !If [HasManagedPolicyArns, !Join [",", !Ref "ManagedPolicyArns"], !Ref 'AWS::NoValue']
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRoleWithWebIdentity
+            Principal:
+              Federated: !Ref ProviderArn
+            Condition:
+              ForAllValues:StringEquals:
+                token.actions.githubusercontent.com:aud: !Ref ClientIdList
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/{{ Repository.name }}:ref:refs/heads/{{ Repository.branch }}
+{% endfor %}
+Outputs:
+{% for Repository in Repositories %}
+  ProviderRoleArn{{ Repository.name | replace('-','') | replace('_','') }}:
+    Value: !GetAtt ProviderRole{{ Repository.name | replace('-','') | replace('_','') }}.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ProviderRoleArn-{{ Repository.name | replace('-','') | replace('_','') }}'
+{% endfor %}

--- a/org-formation/650-identity-providers/oidc-provider.yaml
+++ b/org-formation/650-identity-providers/oidc-provider.yaml
@@ -1,0 +1,30 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Setup an OIDC provider
+Parameters:
+  ClientIdList:
+    Type: List<String>
+    Description: >-
+      A list of client IDs (also known as audiences) that are associated with
+      the specified IAM OIDC provider resource object
+    Default: "sts.amazonaws.com"
+  ThumbprintList:
+    Type: List<String>
+    Description: >-
+      A list of certificate thumbprints that are associated with the specified
+      IAM OIDC provider resource object
+  Url:
+    Type: String
+    Description: "The URL that the IAM OIDC provider resource object is associated with"
+    Default: "https://token.actions.githubusercontent.com"
+Resources:
+  Provider:
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      ClientIdList: !Ref ClientIdList
+      ThumbprintList: !Ref ThumbprintList
+      Url: !Ref Url
+Outputs:
+  ProviderArn:
+    Value: !Ref Provider
+    Export:
+      Name: !Sub '${AWS::StackName}-ProviderArn'

--- a/org-formation/650-identity-providers/oidc-provider.yaml
+++ b/org-formation/650-identity-providers/oidc-provider.yaml
@@ -15,7 +15,6 @@ Parameters:
   Url:
     Type: String
     Description: "The URL that the IAM OIDC provider resource object is associated with"
-    Default: "https://token.actions.githubusercontent.com"
 Resources:
   Provider:
     Type: AWS::IAM::OIDCProvider


### PR DESCRIPTION
The current implementation of the template for github OIDC
creates multiple AWS::IAM::OIDCProvider with the same URL
which is not allowed in AWS.  This refactor will allow
us to decouple the creation of the OIDC provider with
setting up repos to access AWS using a single github OIDC
provider.

related to ETL-309
