### PR TITLE
Add service user for Leon's stack'

### DIFF
--- a/sceptre/synapsedev/templates/accounts.yaml
+++ b/sceptre/synapsedev/templates/accounts.yaml
@@ -71,6 +71,15 @@ Resources:
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
+# Attempt to setup a service user, the only use
+# is to provide a id/secret to run the dev synapse stack under
+  AWSIAMLeonLiSvc:
+    Type: 'AWS::IAM::User'
+    Properties:
+      UserName: svc.leon.li
+      Groups:
+        - !Ref AWSIAMAllUsersGroup
+        - !Ref AWSIAMDeveloperUsersGroup
 
   AWSIAMDeveloperUsersGroup:
     Type: 'AWS::IAM::Group'


### PR DESCRIPTION
This PR is an attempt to create a service IAM account to support a developer user's stack. This should pass the SCP blocking creation of user profiles.
