### PR TITLE
IT-2308: Add suppress rule for CIS1.4

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -383,24 +383,21 @@ Resources:
           - Arn
         Id: Target0
 
-  # This rule suppresses findings with the given generator IDs only for the bootstrap account and service accounts
-  SuppressFindingsForPublicBucketsRule:
+  # This rule suppresses findings with the given generator IDs only for the IAM accounts specified
+  SuppressFindingsForIAMsRule:
     Type: AWS::Events::Rule
     Properties:
-      Description: SecHubSuppress findings (identified by generatorId) for the bootstrap and essentials buckets in all accounts
+      Description: SecHubSuppress findings (identified by generatorId) for given IAM accounts in all AWS accounts
       EventPattern:
         detail:
           findings:
             Resources:
               Id:
                 # synapsedw IT-2308, do not exempt human users
-                - prefix: 'arn:aws:iam::383874245509:user/bootstrap-AWSIAMTravisUser-'
                 - 'arn:aws:iam::383874245509:user/prod-warehouse'
                 # synapseprod IT-2396, do not exempt human users
-                - prefix: 'arn:aws:iam::325565585839:user/bootstrap-AWSIAMTravisUser-'
                 - 'arn:aws:iam::325565585839:user/ran-uploader'
                 # scipool IT-2315
-                - prefix: 'arn:aws:iam::237179673806:user/bootstrap-AWSIAMTravisUser-'
                 - prefix: 'arn:aws:iam::237179673806:user/synapse-login-scipoolprod-ServiceUser-'
             GeneratorId:
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/1.4'

--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -382,3 +382,39 @@ Resources:
           - SecurityHubFindingsQueue
           - Arn
         Id: Target0
+
+  # This rule suppresses findings with the given generator IDs only for the bootstrap account and service accounts
+  SuppressFindingsForPublicBucketsRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: SecHubSuppress findings (identified by generatorId) for the bootstrap and essentials buckets in all accounts
+      EventPattern:
+        detail:
+          findings:
+            Resources:
+              Id:
+                # synapsedw IT-2308, do not exempt human users
+                - prefix: 'arn:aws:iam::383874245509:user/bootstrap-AWSIAMTravisUser-'
+                - 'arn:aws:iam::383874245509:user/prod-warehouse'
+                # synapseprod IT-2396, do not exempt human users
+                - prefix: 'arn:aws:iam::325565585839:user/bootstrap-AWSIAMTravisUser-'
+                - 'arn:aws:iam::325565585839:user/ran-uploader'
+                # scipool IT-2315
+                - prefix: 'arn:aws:iam::237179673806:user/bootstrap-AWSIAMTravisUser-'
+                - prefix: 'arn:aws:iam::237179673806:user/synapse-login-scipoolprod-ServiceUser-'
+            GeneratorId:
+              - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/1.4'
+            Workflow:
+              Status:
+              - NEW
+        detail-type:
+        - Security Hub Findings - Imported
+        source:
+        - aws.securityhub
+      State: ENABLED
+      Targets:
+      - Arn:
+          Fn::GetAtt:
+          - SecurityHubFindingsQueue
+          - Arn
+        Id: Target0


### PR DESCRIPTION
This PR suppresses the findings for CIS1.4 (rotate IAM keys < 90 days) for bootstrap accounts and any service accounts.
Human accounts (synapseprod/dev/dw) are being decomissioned and the associated findings will disappear as they are.
