### PR TITLE
Update Sage VPN certificate

### DIFF
--- a/org-formation/720-client-vpn/_tasks.yaml
+++ b/org-formation/720-client-vpn/_tasks.yaml
@@ -64,7 +64,7 @@ Vpn:
     LogRetentionInDays: "3653"
     # manually generated and imported server cert, saved to lastpass "Sage VPN Certificate"
     # https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-getting-started.html#cvpn-getting-started-certs
-    ServerCertificateArn: !Sub 'arn:aws:acm:${primaryRegion}:${accountId}:certificate/8bdbf421-c38a-4d87-8a03-821a1b7acab6'
+    ServerCertificateArn: !Sub 'arn:aws:acm:${primaryRegion}:${accountId}:certificate/a720b333-8d21-43f1-856d-c2d63b1bc465'
     SplitTunnel: !Ref splitTunnel
     VpnDnsServers: ["10.50.0.2", "8.8.8.8"]
 


### PR DESCRIPTION
The VPN server certificate expired which caused the AWS client VPN to fail to connect with message..
"Connection failed because of a TLS handshake error"

The certificate was manually generated and deploy from AWS instruction: https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-getting-started.html#cvpn-getting-started-certs

