### PR TITLE
replace VPN server certificate

### DIFF
--- a/org-formation/720-client-vpn/_tasks.yaml
+++ b/org-formation/720-client-vpn/_tasks.yaml
@@ -64,7 +64,7 @@ Vpn:
     LogRetentionInDays: "3653"
     # manually generated and imported server cert, saved to lastpass "Sage VPN Certificate"
     # https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-getting-started.html#cvpn-getting-started-certs
-    ServerCertificateArn: !Sub 'arn:aws:acm:${primaryRegion}:${accountId}:certificate/a720b333-8d21-43f1-856d-c2d63b1bc465'
+    ServerCertificateArn: !Sub 'arn:aws:acm:${primaryRegion}:${accountId}:certificate/e749946e-981f-42b9-869e-f2adf362b2a8'
     SplitTunnel: !Ref splitTunnel
     VpnDnsServers: ["10.50.0.2", "8.8.8.8"]
 


### PR DESCRIPTION
The current certificate was good for 2 years.  We created new one that's good for 5 years.  Use the 5 year certificate instead.
