### PR TITLE
DCA-51 adding OIDC integration for Schematic stack deployment

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -76,6 +76,25 @@ GithubOidcSageBionetworksDataCuratorInfra:
       - !Ref DnTDevAccount
     Region: us-east-1
 
+GithubOidcSageBionetworksSchematicInfra:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: github-oidc-provider-access.njk
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-schematic-infra
+  Parameters:
+    GitHubOrg: "Sage-Bionetworks"
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+  TemplatingContext:
+    Repositories:
+      - name: "schematic-infra"
+        branch: "main"
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref DnTDevAccount
+    Region: us-east-1
+
 GithubOidcSageBionetworksSecuityHubToJira:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks


### PR DESCRIPTION
OIDC integration to allow the `schematic-infra` repo' to deploy to the D&T dev' account.