### PR TITLE
bugfix: correctly apply platform account tags

### DIFF
--- a/org-formation/_platform_org_tags.yaml
+++ b/org-formation/_platform_org_tags.yaml
@@ -1,3 +1,4 @@
+CloudwatchCloudTrailLogRetentionPeriod: 90
 Department: Platform
 Project: Infrastructure
 CostCenter: 'Platform Infrastructure / 990300'

--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -145,7 +145,6 @@ Organization:
       RootEmail: aws.organizations@sagebase.org
       Alias: org-sagebase-organizations
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   BridgeDevAccount:
@@ -156,7 +155,6 @@ Organization:
       RootEmail: bridge.dev@sagebase.org
       Alias: org-sagebase-bridgedevelop
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   BridgeProdAccount:
@@ -167,7 +165,6 @@ Organization:
       RootEmail: bridgeIT@sagebase.org
       Alias: org-sagebase-bridgeprod
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   SynapseDevAccount:
@@ -178,7 +175,6 @@ Organization:
       RootEmail: synapse.dev@sagebase.org
       Alias: org-sagebase-synapsedev
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   SynapseDWAccount:
@@ -189,7 +185,6 @@ Organization:
       RootEmail: synapse.dw@sagebase.org
       Alias: org-sagebase-synapsedw
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   SynapseProdAccount:
@@ -203,7 +198,6 @@ Organization:
       RootEmail: platform@sagebase.org
       Alias: org-sagebase-synapseprod
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   TransitAccount:
@@ -214,7 +208,6 @@ Organization:
       RootEmail: aws.transit@sagebase.org
       Alias: org-sagebase-transit
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   AdminCentralAccount:
@@ -225,7 +218,6 @@ Organization:
       RootEmail: aws.admincentral@sagebase.org
       Alias: org-sagebase-admincentral
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   SageITAccount:
@@ -236,7 +228,6 @@ Organization:
       RootEmail: aws-it@sagebase.org
       Alias: org-sagebase-sageit
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   LogCentralAccount:
@@ -247,7 +238,6 @@ Organization:
       RootEmail: aws.logcentral@sagebase.org
       Alias: org-sagebase-logcentral
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   SecurityCentralAccount:
@@ -258,7 +248,6 @@ Organization:
       RootEmail: aws.securitycentral@sagebase.org
       Alias: org-sagebase-securitycentral
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   ImageCentralAccount:
@@ -269,7 +258,6 @@ Organization:
       RootEmail: aws.amirepo@sagebase.org
       Alias: org-sagebase-imagecentral
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   ITSandboxAccount:
@@ -280,7 +268,6 @@ Organization:
       RootEmail: aws.itsandbox@sagebase.org
       Alias: org-sagebase-itsandbox
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   ScipoolDevAccount:
@@ -536,7 +523,6 @@ Organization:
       RootEmail: aws.ipam@sagebase.org
       Alias: org-sagebase-ipam
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   SceptreDevAccount:
@@ -546,7 +532,6 @@ Organization:
       RootEmail: aws.sceptredev@sagebase.org
       Alias: org-sagebase-sceptredev
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   SysmanCentralAccount:
@@ -556,7 +541,6 @@ Organization:
       RootEmail: aws.sysmancentral@sagebase.org
       Alias: org-sagebase-sysmancentral
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   IdentityCentralAccount:
@@ -566,7 +550,6 @@ Organization:
       RootEmail: aws.identitycentral@sagebase.org
       Alias: org-sagebase-identitycentral
       Tags:
-        <<: !Include ./_default_org_tags.yaml
         <<: !Include ./_platform_org_tags.yaml
 
   GenieProdAccount:


### PR DESCRIPTION
YAML does not allow multiple `>>:` occurrences at the same level, duplicate the CloudwatchCloudTrailLogRetentionPeriod key in the included file so that we only include a single file.

