### PR TITLE
[IT-2607] Remove deprecated `aws-portal:*` actions

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -189,7 +189,6 @@ CostExplorerAccessPolicy:
           {
             "Effect": "Allow",
             "Action": [
-                "aws-portal:ViewUsage",
                 "ce:Describe*",
                 "ce:Get*",
                 "ce:List*",

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -983,12 +983,14 @@ SsoScipoolDevCommunityManager:
           {
             "Effect": "Allow",
             "Action": [
-              "aws-portal:ViewUsage",
-              "aws-portal:ViewBilling",
+              "billing:GetBilling*",
+              "consolidatedbilling:Get*",
+              "consolidatedbilling:List*",
               "cur:DescribeReportDefinitions",
               "cur:PutReportDefinition",
               "cur:DeleteReportDefinition",
-              "cur:ModifyReportDefinition"
+              "cur:ModifyReportDefinition",
+              "freetier:Get*",
             ],
             "Resource": "*"
           }

--- a/sceptre/strides-ampad-workflows/templates/jumpcloud-idp.yaml
+++ b/sceptre/strides-ampad-workflows/templates/jumpcloud-idp.yaml
@@ -21,7 +21,6 @@ Resources:
           -
             Effect: "Allow"
             Action:
-              - aws-portal:ViewUsage
               - ce:Describe*
               - ce:Get*
               - ce:List*

--- a/sceptre/strides/templates/jumpcloud-idp.yaml
+++ b/sceptre/strides/templates/jumpcloud-idp.yaml
@@ -78,11 +78,14 @@ Resources:
           -
             Effect: "Allow"
             Action:
-              - aws-portal:ViewUsage
+              - billing:GetBilling*
+              - consolidatedbilling:Get*
+              - consolidatedbilling:List*
               - cur:DescribeReportDefinitions
               - cur:PutReportDefinition
               - cur:DeleteReportDefinition
               - cur:ModifyReportDefinition
+              - freetier:Get*
             Resource: "*"
   AWSIAMCostExplorerAccessPolicy:
     Type: "AWS::IAM::ManagedPolicy"
@@ -93,7 +96,6 @@ Resources:
           -
             Effect: "Allow"
             Action:
-              - aws-portal:ViewUsage
               - ce:Describe*
               - ce:Get*
               - ce:List*


### PR DESCRIPTION
AWS has deprecated several IAM actions, including `aws-portal:*`, remove occurrences of `aws-portal:ViewUsage` from cost-explore policies because it is no longer needed, and replace occurrences of `aws-portal:ViewBilling` with appropriate actions from `billing`, `consolidatedbilling`, and `freetier`.

Also align strides community manager role with the org-formation role by granting billing access.

Announcement:
https://aws.amazon.com/blogs/aws-cloud-financial-management/changes-to-aws-billing-cost-management-and-account-consoles-permissions/