### PR TITLE
IT-2429: Add rule to suppress findings for cf-templates bucket being public

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -395,8 +395,10 @@ Resources:
               Id:
                 - prefix: 'arn:aws:s3:::bootstrap-awss3cloudformationbucket-'
                 - prefix: 'arn:aws:s3:::essentials-awss3lambdaartifactsbucket-'
+                - prefix: 'arn:aws:s3:::cf-templates-'
             GeneratorId:
               - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.1'
+              - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.5.2'
             Workflow:
               Status:
               - NEW


### PR DESCRIPTION
This PR adds a bucket and a generatorId for cis-aws-foundations-benchmark/v/1.4.0/2.1.5.2 to the existing rule. We suppress findings about infra buckets being public in any account.

