### PR TITLE
IT-2427: Add generatorId

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -368,6 +368,7 @@ Resources:
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/1.14'
               - 'aws-foundational-security-best-practices/v/1.0.0/IAM.6'
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/2.7'
+              - 'cis-aws-foundations-benchmark/v/1.4.0/3.7'
             Workflow:
               Status:
               - NEW


### PR DESCRIPTION
This PR adds a generatorId for cis-aws-foundations-benchmark/v/1.4.0/3.7(Cloudtrail logs encryption) to be suppressed for all accounts. This is the same resolution as arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/2.7.
