### PR TITLE
bugfix: correct JSON syntax

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -990,7 +990,7 @@ SsoScipoolDevCommunityManager:
               "cur:PutReportDefinition",
               "cur:DeleteReportDefinition",
               "cur:ModifyReportDefinition",
-              "freetier:Get*",
+              "freetier:Get*"
             ],
             "Resource": "*"
           }


### PR DESCRIPTION
JSON does not allow trailing commas in lists.

    ERROR: Resource PermissionSet failed because Resource handler returned message: "Invalid PermissionsPolicy JSON {
      "Version": "2012-10-17",
      "Statement": [
        {
          "Effect": "Allow",
          "Action": [
            "billing:GetBilling*",
            "consolidatedbilling:Get*",
            "consolidatedbilling:List*",
            "cur:DescribeReportDefinitions",
            "cur:PutReportDefinition",
            "cur:DeleteReportDefinition",
            "cur:ModifyReportDefinition",
            "freetier:Get*",
          ],
          "Resource": "*"
        }
      ]
    }.
