### PR TITLE
IT-2428: Suppress CIS2.1.5.1 for securitycentral

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -384,11 +384,11 @@ Resources:
           - Arn
         Id: Target0
 
-  # This rule suppresses findings with the given generator IDs only for the bootstrap and essentials buckets
+  # This rule suppresses findings with the given generator IDs only for the infra resources
   SuppressFindingsForPublicBucketsRule:
     Type: AWS::Events::Rule
     Properties:
-      Description: SecHubSuppress findings (identified by generatorId) for the bootstrap and essentials buckets in all accounts
+      Description: SecHubSuppress findings (identified by generatorId) for the infra resources in all accounts
       EventPattern:
         detail:
           findings:
@@ -397,9 +397,12 @@ Resources:
                 - prefix: 'arn:aws:s3:::bootstrap-awss3cloudformationbucket-'
                 - prefix: 'arn:aws:s3:::essentials-awss3lambdaartifactsbucket-'
                 - prefix: 'arn:aws:s3:::cf-templates-'
+                # This should only match with 2.1.5.1
+                - 'AWS::::Account:140124849929'
             GeneratorId:
               - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.1'
               - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.5.2'
+              - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.5.1'
             Workflow:
               Status:
               - NEW


### PR DESCRIPTION
This PR suppresses the finding for CIS 2.1.5.1 (Block all on S3 at account level. I put it in the same rule as the ones that work at the bucket level, it should work because only that combo generatorId/resourceId should match, renamed the description accordingly. Not sure why other accounts did not get flagged (checked SecHub). Note: S3 behavior is changing to block all access by default so I'd expect this control to disappear in future version of CIS.
