### PR TITLE
IT-2308/2309: Update bootstrao/essentials version

### DIFF
--- a/sceptre/synapsedw/config/prod/bootstrap.yaml
+++ b/sceptre/synapsedw/config/prod/bootstrap.yaml
@@ -1,4 +1,4 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.6.3/bootstrap.yaml
 stack_name: bootstrap

--- a/sceptre/synapsedw/config/prod/essentials.yaml
+++ b/sceptre/synapsedw/config/prod/essentials.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.3/templates/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml

--- a/sceptre/synapseprod/config/prod/bootstrap.yaml
+++ b/sceptre/synapseprod/config/prod/bootstrap.yaml
@@ -1,4 +1,4 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.6.3/bootstrap.yaml
 stack_name: bootstrap

--- a/sceptre/synapseprod/config/prod/essentials.yaml
+++ b/sceptre/synapseprod/config/prod/essentials.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.3/templates/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml


### PR DESCRIPTION
This PR should remove the BootstrapTravisUser from the synapseprod/synapsedw accounts, it also removes the VPC peering authorizer role from the accounts (IT-2636).

Note1: The BootstrapTravisUser has not been used in these accounts since 2020 (see IT-2635)
Note2: Per comments in bootstrap.yaml, the BootstrapTravisUser should be stripped from groups etc. prior to merging/deploying.
