### PR TITLE
[IT-2594] Move ACM certificate to Cloudfront

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -35,6 +35,8 @@ MipsMicroservice:
       - 'arn:aws:sts::745159704268:assumed-role/AWSReservedSSO_Administrator_30244677b3ea9498/joni.harker@sagebase.org'
       - !Sub 'arn:aws:iam::${CurrentAccount.AccountId}:root'
       - 'arn:aws:iam::745159704268:role/github-oidc-sage-bionetwo-ProviderRoleorganization-93H11ERK3F4N'
+    AcmCertificateArn: !CopyValue [!Sub '${primaryRegion}-sageit-org-acm-cert-CertificateArn']
+    DnsNames: "finops-api.sageit.org"
 
 CostCategories:
   Type: update-stacks

--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -31,7 +31,6 @@ FinopsApiRedirect:  # redirect finops-api.sageit.org to lambda-mips-api cloudfro
   Parameters:
     # the name of the CNAME record
     SourceHostName: "finops-api.sageit.org"
-    SourceAcmCertificateArn: !CopyValue [!Sub '${primaryRegion}-sageit-org-acm-cert-CertificateArn']
     # ID of the sageit.org zone (in sageit account)
     SourceHostedZoneId: "Z0478495257GEB73WFM63"
     # the value of the CNAME record


### PR DESCRIPTION
Give the sageit ACM cert to the mips cloudfront distribution, not to the CNAME record.