### PR TITLE
[IT-2549] Remove ACM cert from mips microservice

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -35,8 +35,6 @@ MipsMicroservice:
       - 'arn:aws:sts::745159704268:assumed-role/AWSReservedSSO_Administrator_30244677b3ea9498/joni.harker@sagebase.org'
       - !Sub 'arn:aws:iam::${CurrentAccount.AccountId}:root'
       - 'arn:aws:iam::745159704268:role/github-oidc-sage-bionetwo-ProviderRoleorganization-93H11ERK3F4N'
-    AcmCertificateArn: !CopyValue [!Sub '${primaryRegion}-sageit-org-acm-cert-CertificateArn', !Ref SageITAccount]
-    DnsNames: "finops-api.sageit.org"
 
 CostCategories:
   Type: update-stacks


### PR DESCRIPTION
Cloudfront needs to be given an ACM certificate in the same account. Remove cross-account reference to ACM cert.
