### PR TITLE
IT-2308: Remove param

### DIFF
--- a/sceptre/synapsedw/config/prod/essentials.yaml
+++ b/sceptre/synapsedw/config/prod/essentials.yaml
@@ -4,5 +4,3 @@ template:
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
-parameters:
-  VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId

--- a/sceptre/synapseprod/config/prod/essentials.yaml
+++ b/sceptre/synapseprod/config/prod/essentials.yaml
@@ -4,5 +4,3 @@ template:
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
-parameters:
-  VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId


### PR DESCRIPTION
This PR removes the parameter for the peering account to match the new version of the essentials.yaml template.
Missed in previous PR...
