### PR TITLE
[IT-2594] Attach ACM cert to cloudfront

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -30,6 +30,8 @@ MipsMicroservice:
     Account: !Ref AdminCentralAccount
     Region: !Ref primaryRegion
   Parameters:
+    AcmCertificateArn: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sageit-cert-CertificateArn']
+    DnsNames: "finops-api.sageit.org"
     MipsOrganization: 'SAGE_24146'
     SsmKeyAdminArns:
       - 'arn:aws:sts::745159704268:assumed-role/AWSReservedSSO_Administrator_30244677b3ea9498/joni.harker@sagebase.org'


### PR DESCRIPTION
Once the ACM certificate in the dependent PR has been manually
validated, attach it to the cloudfront distribution in front of our
finops api lambda.
    
Depends on: #726