### PR TITLE
DCA-35: Add application manager role to D&T dev and DCA Prod accounts

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -445,6 +445,7 @@ SsoApplicationManager:
       Account: '*'
   Parameters:
     instanceArn: !Ref instanceArn
+    principalId: !Ref adminGroup # by default we admit admin's.  Below we 'inherit' this stack for specific user groups
     permissionSetName: 'application-manager'
     sessionDuration: 'PT12H'
     masterAccountId: !Ref MasterAccount
@@ -1381,7 +1382,7 @@ SsoDntDevViewer:
 SsoDntDevProdApplicationManager:
   Type: update-stacks
   DependsOn: SsoApplicationManager
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/SSO/aws-sso.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.1/templates/SSO/aws-sso.njk
   StackName: !Sub '${resourcePrefix}-${appName}-dntdev-application-manager'
   StackDescription: 'SSO: Application Manager role used by DntDev application-manager group'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
@@ -1551,7 +1552,7 @@ SsoDCAProdViewerPlus:
 SsoDCAProdApplicationManager:
   Type: update-stacks
   DependsOn: SsoApplicationManager
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/SSO/aws-sso.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.1/templates/SSO/aws-sso.njk
   StackName: !Sub '${resourcePrefix}-${appName}-dca-prod-application-manager'
   StackDescription: 'SSO: Application Manager role used by DCA application-manager group'
   DefaultOrganizationBindingRegion: !Ref primaryRegion

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -197,6 +197,10 @@ Parameters:
     Type: String
     Default: '906769aa66-1d010ba3-e9cd-451b-98fd-f60bb7e3965d'
 
+  dntDevApplicationManagerGroup:      #JC aws-dntdev-application-managers
+    Type: String
+    Default: 'd4f8f4d8-f051-7008-e356-7622368ce737'
+
   identityCentralS3ExternalCollabGroup:      #JC aws-identitycentral-s3-external-collab
     Type: String
     Default: 'e4880448-e061-70b3-2487-e2c54abce711'
@@ -232,6 +236,10 @@ Parameters:
   dcaProdViewersPlusGroup:      #JC aws-dca-prod-viewers-plus
     Type: String
     Default: 'c448e498-60d1-7084-5cf5-14d77b82a42b'
+
+  dcaProdApplicationManagerGroup:	#JC aws-dca-prod-application-managers
+    Type: String
+    Default: '540864c8-1021-7048-7142-4563c3f12645'
 
   genieProdViewerGroup:      #JC aws-genie-prod-viewers
     Type: String
@@ -421,6 +429,29 @@ SsoViewerPlus:
       - arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess
       - arn:aws:iam::aws:policy/AWSLambda_ReadOnlyAccess
       - arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess
+
+# Role for a user that manages an application deployed to AWS
+SsoApplicationManager:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.1/templates/SSO/aws-sso.njk
+  StackName: !Sub '${resourcePrefix}-${appName}-application-manager'
+  StackDescription: 'Read-only role plus access to secrets manager'
+  TerminationProtection: false
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: '*'
+  Parameters:
+    instanceArn: !Ref instanceArn
+    permissionSetName: 'application-manager'
+    sessionDuration: 'PT12H'
+    masterAccountId: !Ref MasterAccount
+    managedPolicies:
+      - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
+      - arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess
+      - arn:aws:iam::aws:policy/SecretsManagerReadWrite
 
 SsoViewerSupporter:
   Type: update-stacks
@@ -1347,6 +1378,23 @@ SsoDntDevViewer:
     principalId: !Ref dntDevViewerGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-viewer-permission-set-arn' ]
 
+SsoDntDevProdApplicationManager:
+  Type: update-stacks
+  DependsOn: SsoApplicationManager
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-dntdev-application-manager'
+  StackDescription: 'SSO: Application Manager role used by DntDev application-manager group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref DntDevAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref dntDevApplicationManagerGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-application-manager-permission-set-arn' ]
+
 Sso8dxfh53Admin:
   Type: update-stacks
   DependsOn: SsoAdministrator
@@ -1499,6 +1547,23 @@ SsoDCAProdViewerPlus:
     instanceArn: !Ref instanceArn
     principalId: !Ref dcaProdViewersPlusGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-viewer-plus-permission-set-arn' ]
+
+SsoDCAProdApplicationManager:
+  Type: update-stacks
+  DependsOn: SsoApplicationManager
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-dca-prod-application-manager'
+  StackDescription: 'SSO: Application Manager role used by DCA application-manager group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref DCAProdAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref dcaProdApplicationManagerGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-application-manager-permission-set-arn' ]
 
 SsoGenieProdViewer:
   Type: update-stacks

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -237,7 +237,7 @@ Parameters:
     Type: String
     Default: 'c448e498-60d1-7084-5cf5-14d77b82a42b'
 
-  dcaProdApplicationManagerGroup:	#JC aws-dca-prod-application-managers
+  dcaProdApplicationManagerGroup:      # JC aws-dca-prod-application-managers
     Type: String
     Default: '540864c8-1021-7048-7142-4563c3f12645'
 


### PR DESCRIPTION
This PR defines the 'application manager' roles which lets the creator of an application deployed to AWS monitor it and set up secrets.  The PR also deploys the role to the DnT dev and DCA prod accounts