### PR TITLE
update AWS CDK version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache2",
       "dependencies": {
-        "aws-cdk": "^2.59.0",
+        "aws-cdk": "^2.65.0",
         "aws-organization-formation": "^1.0.3"
       }
     },
@@ -160,9 +160,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.59.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.59.0.tgz",
-      "integrity": "sha512-5xKh+nC6wLsjYGwA+YYbX9ZonJLYmthxSZy8pK/Bm9rL2mFpnMKvQZJz67L6ghOt1XumoB1vZbIhptln68jTuw==",
+      "version": "2.65.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.65.0.tgz",
+      "integrity": "sha512-a1xtdf95N7MLPcwCs+IkE6kCD1utLMuDh+1RIyYbX7SYzAjlNJzOXQ7M16kBktt4KflVWseZnYsGbKWJ2DraMw==",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -1940,9 +1940,9 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "aws-cdk": {
-      "version": "2.59.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.59.0.tgz",
-      "integrity": "sha512-5xKh+nC6wLsjYGwA+YYbX9ZonJLYmthxSZy8pK/Bm9rL2mFpnMKvQZJz67L6ghOt1XumoB1vZbIhptln68jTuw==",
+      "version": "2.65.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.65.0.tgz",
+      "integrity": "sha512-a1xtdf95N7MLPcwCs+IkE6kCD1utLMuDh+1RIyYbX7SYzAjlNJzOXQ7M16kBktt4KflVWseZnYsGbKWJ2DraMw==",
       "requires": {
         "fsevents": "2.3.2"
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "homepage": "https://github.com/Sage-Bionetworks-IT/organizations-infra.git/README.md",
   "dependencies": {
     "aws-organization-formation": "^1.0.3",
-    "aws-cdk": "^2.59.0"
+    "aws-cdk": "^2.65.0"
   }
 }


### PR DESCRIPTION
CDK deployments report the following message..
```
AssertDescription: CDK bootstrap stack version 6 required. Please run 'cdk bootstrap'
with a recent version of the CDK CLI.
```

Fix by updating the CDK and boostrap template.

