### PR TITLE
IT-2636: Remove VPCAuthorizer role by updating essentials version

### DIFF
--- a/sceptre/imagecentral/config/prod/essentials.yaml
+++ b/sceptre/imagecentral/config/prod/essentials.yaml
@@ -1,8 +1,6 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.6/templates/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
-parameters:
-  VpcPeeringRequesterAwsAccountId: "745159704268"

--- a/sceptre/itsandbox/config/prod/essentials.yaml
+++ b/sceptre/itsandbox/config/prod/essentials.yaml
@@ -1,8 +1,6 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.6/templates/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
-parameters:
-  VpcPeeringRequesterAwsAccountId: !ssm "/infra/AdmincentralAwsAccountId"

--- a/sceptre/logcentral/config/prod/essentials.yaml
+++ b/sceptre/logcentral/config/prod/essentials.yaml
@@ -1,8 +1,6 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.6/templates/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
-parameters:
-  VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId

--- a/sceptre/sageit/config/prod/essentials.yaml
+++ b/sceptre/sageit/config/prod/essentials.yaml
@@ -1,8 +1,6 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.6/templates/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
-parameters:
-  VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId

--- a/sceptre/synapsedev/config/prod/essentials.yaml
+++ b/sceptre/synapsedev/config/prod/essentials.yaml
@@ -1,8 +1,6 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.6/templates/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
-parameters:
-  VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId


### PR DESCRIPTION
This PR updates the version of essentials.yaml (which will cause the removal of the authorizer role as well as remove the permissions to the bootstrapTravisUser account). The AWS accounts in this PR should not be affected by the changes (i.e. no sign of the bootstrapTravisUser having run recently).
