### PR TITLE
[DCA-34] Setup GH OIDC for data_curator-infra

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -74,6 +74,7 @@ GithubOidcSageBionetworksDataCuratorInfra:
   DefaultOrganizationBinding:
     Account:
       - !Ref DnTDevAccount
+      - !Ref DCAProdAccount
     Region: us-east-1
 
 GithubOidcSageBionetworksSchematicInfra:


### PR DESCRIPTION
Allow github action from the Sage-Bionetworks/data_curator-infra repo to deploy to the AWS org-sagebase-dca-prod account.

