### PR TITLE
[DCA-34] Setup GH OIDC for schematic-infra

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -93,6 +93,7 @@ GithubOidcSageBionetworksSchematicInfra:
   DefaultOrganizationBinding:
     Account:
       - !Ref DnTDevAccount
+      - !Ref SchematicProdAccount
     Region: us-east-1
 
 GithubOidcSageBionetworksSecuityHubToJira:

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -93,7 +93,7 @@ GithubOidcSageBionetworksSchematicInfra:
   DefaultOrganizationBinding:
     Account:
       - !Ref DnTDevAccount
-      - !Ref SchematicProdAccount
+      - !Ref DCAProdAccount
     Region: us-east-1
 
 GithubOidcSageBionetworksSecuityHubToJira:


### PR DESCRIPTION
Allow github action from the Sage-Bionetworks/schematic-infra repo to deploy to the AWS org-sagebase-dca-prod account.


