### PR TITLE
IT-2393: Remove IAM accounts

### DIFF
--- a/sceptre/synapseprod/templates/accounts.yaml
+++ b/sceptre/synapseprod/templates/accounts.yaml
@@ -21,39 +21,6 @@ Resources:
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
-  AWSIAMKhaiDoUser:
-    Type: 'AWS::IAM::User'
-    Properties:
-      UserName: khai.do@sagebase.org
-      Groups:
-        - !Ref AWSIAMAllUsersGroup
-        - !Ref AWSIAMDeveloperUsersGroup
-        - !Ref AWSIAMBillingManagersGroup
-      LoginProfile:
-        Password: !Ref InitNewUserPassword
-        PasswordResetRequired: true
-  AWSIAMBruceHoffUser:
-    Type: 'AWS::IAM::User'
-    Properties:
-      UserName: bruce.hoff@sagebase.org
-      Groups:
-        - !Ref AWSIAMAllUsersGroup
-        - !Ref AWSIAMDeveloperUsersGroup
-        - !Ref AWSIAMBillingManagersGroup
-        - !Ref AWSIAMAnalyticsUsersGroup
-      LoginProfile:
-        Password: !Ref InitNewUserPassword
-        PasswordResetRequired: true
-  AWSIAMJayHodgsonUser:
-    Type: 'AWS::IAM::User'
-    Properties:
-      UserName: jay.hodgson@sagebase.org
-      Groups:
-        - !Ref AWSIAMAllUsersGroup
-        - !Ref AWSIAMDeveloperUsersGroup
-      LoginProfile:
-        Password: !Ref InitNewUserPassword
-        PasswordResetRequired: true
   AWSIAMJohnHillUser:
     Type: 'AWS::IAM::User'
     Properties:
@@ -71,17 +38,6 @@ Resources:
       Groups:
         - !Ref AWSIAMAllUsersGroup
         - !Ref AWSIAMDeveloperUsersGroup
-      LoginProfile:
-        Password: !Ref InitNewUserPassword
-        PasswordResetRequired: true
-  AWSIAMNickGrosenbacherUser:
-    Type: 'AWS::IAM::User'
-    Properties:
-      UserName: nick.grosenbacher@sagebase.org
-      Groups:
-        - !Ref AWSIAMAllUsersGroup
-        - !Ref AWSIAMDeveloperUsersGroup
-        - !Ref AWSIAMWebEngineerUsersGroup
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
@@ -124,7 +80,6 @@ Resources:
             Principal:
               AWS:
                 - !GetAtt AWSIAMXavierSchildwachterUser.Arn
-                - !GetAtt AWSIAMKhaiDoUser.Arn
                 - !GetAtt AWSIAMSynapseEmergencyUser.Arn
             Action:
               - "sts:AssumeRole"


### PR DESCRIPTION
This PR removes some IAM accounts from SynapseProd to resolve SecurityHub findings. A couple of other accounts will be put in compliance by updating the creds and rotating the access keys (and ultimately all will be replaced by SSO access).
