### PR TITLE
IT-2635: Update bootstrap version to remove boostrapTravisUser

### DIFF
--- a/sceptre/imagecentral/config/prod/bootstrap.yaml
+++ b/sceptre/imagecentral/config/prod/bootstrap.yaml
@@ -1,4 +1,4 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.6.7/bootstrap.yaml
 stack_name: bootstrap

--- a/sceptre/itsandbox/config/prod/bootstrap.yaml
+++ b/sceptre/itsandbox/config/prod/bootstrap.yaml
@@ -1,4 +1,4 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.6.7/bootstrap.yaml
 stack_name: bootstrap

--- a/sceptre/logcentral/config/prod/bootstrap.yaml
+++ b/sceptre/logcentral/config/prod/bootstrap.yaml
@@ -1,4 +1,4 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.6.7/bootstrap.yaml
 stack_name: bootstrap

--- a/sceptre/sageit/config/prod/bootstrap.yaml
+++ b/sceptre/sageit/config/prod/bootstrap.yaml
@@ -1,4 +1,4 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.6.7/bootstrap.yaml
 stack_name: bootstrap

--- a/sceptre/synapsedev/config/prod/bootstrap.yaml
+++ b/sceptre/synapsedev/config/prod/bootstrap.yaml
@@ -1,4 +1,4 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.6.7/bootstrap.yaml
 stack_name: bootstrap


### PR DESCRIPTION
This PR updates the bootstrap.yaml version, which removes the bootstrapTravisUser.
Depends on #732 to remove a dependency first.
