### PR TITLE
[DCA-37] Add CNAME for dca-test application

### DIFF
--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -1,6 +1,8 @@
 Parameters:
   <<: !Include '../_parameters.yaml'
 
+# *.sageit.org
+
 SsoRedirect:   # Redirect sso.sageit.org to the AWS SSO Start URL
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.8/templates/s3-redirector.yaml
@@ -35,3 +37,22 @@ FinopsApiRedirect:  # redirect finops-api.sageit.org to lambda-mips-api cloudfro
     SourceHostedZoneId: "Z0478495257GEB73WFM63"
     # the value of the CNAME record
     TargetHostName: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-mips-microservice-CloudfrontDomain', !Ref AdminCentralAccount]
+
+
+# *.app.sagebionetworks.org
+
+DcaDevAppRedirect:  # redirect dca-test.app.sagebionetworks.org to data_curator-infra ALB
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.4/templates/R53/cname.yaml
+  StackName: !Sub '${resourcePrefix}-finops-api-redirect'
+  StackDescription: Setup a redirect to the lambda-mips-api cloudfront distribution
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref SageITAccount
+  Parameters:
+    # the name of the CNAME record
+    SourceHostName: "dca-test.app.sagebionetworks.org"
+    # ID of the app.sagebionetworks.org zone (in sageit account)
+    SourceHostedZoneId: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sagebio-app-zone-HostedZoneId']
+    # the value of the CNAME record
+    TargetHostName: !CopyValue [!Sub 'dca-dev-DockerFargateStack-LoadBalancerDNS', !Ref DnTDevAccount]

--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -41,17 +41,19 @@ FinopsApiRedirect:  # redirect finops-api.sageit.org to lambda-mips-api cloudfro
 
 # *.app.sagebionetworks.org
 
-DcaDevAppRedirect:  # redirect dca-test.app.sagebionetworks.org to data_curator-infra ALB
+# redirect dca-dev.app.sagebionetworks.org to data_curator-infra ALB
+# https://github.com/Sage-Bionetworks/data_curator-infra
+DcaDevAppRedirect:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.4/templates/R53/cname.yaml
-  StackName: !Sub '${resourcePrefix}-finops-api-redirect'
-  StackDescription: Setup a redirect to the lambda-mips-api cloudfront distribution
+  StackName: !Sub '${resourcePrefix}-dca-dev-cname'
+  StackDescription: Setup a CNAME for data_curator-infra ALB
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     Account: !Ref SageITAccount
   Parameters:
     # the name of the CNAME record
-    SourceHostName: "dca-test.app.sagebionetworks.org"
+    SourceHostName: "dca-dev.app.sagebionetworks.org"
     # ID of the app.sagebionetworks.org zone (in sageit account)
     SourceHostedZoneId: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sagebio-app-zone-HostedZoneId']
     # the value of the CNAME record


### PR DESCRIPTION
Now that we have created a wildcard certificate for our application subdomain and are using it in our application, set up a CNAME redirect so that the application domain matches the certificate domain.

Depends on: https://github.com/Sage-Bionetworks/data_curator-infra/pull/29