### PR TITLE
[DCA-34] Allow deployment from multiple branches

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -70,7 +70,7 @@ GithubOidcSageBionetworksDataCuratorInfra:
   TemplatingContext:
     Repositories:
       - name: "data_curator-infra"
-        branch: "main"
+        branch: "*"
   DefaultOrganizationBinding:
     Account:
       - !Ref DnTDevAccount
@@ -90,7 +90,7 @@ GithubOidcSageBionetworksSchematicInfra:
   TemplatingContext:
     Repositories:
       - name: "schematic-infra"
-        branch: "main"
+        branch: "*"
   DefaultOrganizationBinding:
     Account:
       - !Ref DnTDevAccount


### PR DESCRIPTION
For deployments where there is a more involved change to the infrastructure we may want to manage the deployment of that change to one account/environment (dev) before propogating it to other accounts (prod).

For this we setup multiple git branches (dev/stage/prod) to allow us to propogate the deployments which means we need to allow OIDC to deploy from multiple branches.

