### PR TITLE
[DCA-34] fix github oidc role

### DIFF
--- a/org-formation/650-identity-providers/github-oidc-provider-access.njk
+++ b/org-formation/650-identity-providers/github-oidc-provider-access.njk
@@ -87,9 +87,14 @@ Resources:
             Principal:
               Federated: !Ref ProviderArn
             Condition:
-              ForAllValues:StringEquals:
+              StringEquals:
                 token.actions.githubusercontent.com:aud: !Ref ClientIdList
+  {% if Repository.branch == '*' %}
+              StringLike:
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/{{ Repository.name }}:{{Repository.branch }}
+  {% else %}
                 token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/{{ Repository.name }}:ref:refs/heads/{{ Repository.branch }}
+  {% endif %}
 {% endfor %}
 Outputs:
 {% for Repository in Repositories %}


### PR DESCRIPTION
The policy to allow multiple branches to access AWS was not correct. We fix it as documented in GH OIDC docs[1]

Note:
 AWS does not support lists in `StringEquals` or `StringLike` conditions.
 AWS supports matching either a single branch (i.e. main) or all branches
 (i.e. *) per OIDC resource.  If we want to match multiple single branches
 (i.e. dev/prod/etc..) we would need to deploy an OIDC resource for every
 each branch.

[1] https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services

