### PR TITLE
Setup viewer access to org-sagebase-ipam account

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -261,6 +261,10 @@ Parameters:
     Type: String
     Default: '64284488-1061-70c9-eacb-f465d1988789'
 
+  ipamViewerGroup:      #JC aws-ipam-viewers
+    Type: String
+    Default: '0498c498-5041-704e-c4bb-c3eb14f2fdbb'
+
   #------------- personal AWS accounts ------------------
   8dxfh53AdminGroup:             #JC aws-8dxfh53-admins
     Type: String
@@ -397,6 +401,7 @@ SsoViewer:
     managedPolicies:
       - 'arn:aws:iam::aws:policy/job-function/ViewOnlyAccess'
       - 'arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess'
+      - 'arn:aws:iam::aws:policy/AWSNetworkManagerReadOnlyAccess'
     sessionDuration: 'PT12H'
     masterAccountId: !Ref MasterAccount
 
@@ -1652,4 +1657,21 @@ SsoDpeProdViewer:
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref dpeProdViewerGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-viewer-permission-set-arn' ]
+
+SsoIpamViewer:
+  Type: update-stacks
+  DependsOn: SsoViewer
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-ipam-viewer'
+  StackDescription: 'SSO: Viewer role used by ipam viewer group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref IpamAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref ipamViewerGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-viewer-permission-set-arn' ]


### PR DESCRIPTION
AWS recommends assigning non-overlapping CIDRs to VPCs[1]. We have been using the infra inventory wiki page[2] to keep track of our network CIDRs across our entire organization.  That wiki page is not really working anymore so we are going to replace it with info from our org-sagebase-ipam account.  The info in ipam is dynamic and will allow users to find unused CIDRs to assign to their VPCs.

[1] https://docs.aws.amazon.com/vpc/latest/userguide/configure-your-vpc.html#vpc-cidr-blocks
[2] https://sagebionetworks.jira.com/wiki/spaces/IT/pages/352976898/Infrastructure+Inventory
