### PR TITLE
IT-2672: Move GitHubOrg to templating context

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -24,11 +24,11 @@ GithubOidcSageBionetworksIt:
   Template: github-oidc-provider-access.njk
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-it
   Parameters:
-    GitHubOrg: "Sage-Bionetworks-IT"
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks-IT"
     Repositories:
       - name: "organizations-infra"
         branch: "master"
@@ -43,11 +43,11 @@ GithubOidcSageBionetworksRecover:
   Template: github-oidc-provider-access.njk
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-recover
   Parameters:
-    GitHubOrg: "Sage-Bionetworks"
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "recover"
         branch: "*"
@@ -63,11 +63,11 @@ GithubOidcSageBionetworksDataCuratorInfra:
   Template: github-oidc-provider-access.njk
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-data-curator-infra
   Parameters:
-    GitHubOrg: "Sage-Bionetworks"
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "data_curator-infra"
         branch: "*"
@@ -83,11 +83,11 @@ GithubOidcSageBionetworksSchematicInfra:
   Template: github-oidc-provider-access.njk
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-schematic-infra
   Parameters:
-    GitHubOrg: "Sage-Bionetworks"
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "schematic-infra"
         branch: "*"
@@ -103,11 +103,11 @@ GithubOidcSageBionetworksDNTInfra:
   Template: github-oidc-provider-access.njk
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dnt-infra
   Parameters:
-    GitHubOrg: "Sage-Bionetworks"
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "dnt-infra"
         branch: "*"
@@ -123,11 +123,11 @@ GithubOidcSageBionetworksSecuityHubToJira:
   Template: github-oidc-provider-access.njk
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-security-hub-to-jira
   Parameters:
-    GitHubOrg: "Sage-Bionetworks"
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AWSSecurityHubReadOnlyAccess"
   TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "security-hub-to-jira"
         branch: "main"
@@ -142,7 +142,6 @@ GithubOidcSageBionetworksAwsInfra:
   Template: github-oidc-provider-access.njk
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-awsinfra
   Parameters:
-    GitHubOrg: "Sage-Bionetworks"
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     PolicyDocument: |
       {
@@ -163,6 +162,7 @@ GithubOidcSageBionetworksAwsInfra:
         ]
       }
   TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "aws-infra"
         branch: "master"

--- a/org-formation/650-identity-providers/github-oidc-provider-access.njk
+++ b/org-formation/650-identity-providers/github-oidc-provider-access.njk
@@ -1,11 +1,11 @@
 {# Allow Github to access AWS without giving github AWS credentials               #}
 {# Must pass in the following templating parameters                               #}
 {#  Parameters:                                                                   #}
-{#    GitHubOrg: "Sage-Bionetworks"                                               #}
 {#    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ] #}
 {#    ManagedPolicyArns:                                                          #}
 {#      - "arn:aws:iam::aws:policy/AdministratorAccess"                           #}
 {#  TemplatingContext:                                                            #}
+{#    GitHubOrg: "Sage-Bionetworks"                                               #}
 {#    Repositories:                                                               #}
 {#      - name: "myrepo"                                                          #}
 {#        branch: "master"                                                        #}
@@ -27,9 +27,6 @@ Parameters:
   ProviderArn:
     Type: String
     Description: "The OIDC provider ARN"
-  GitHubOrg:
-    Type: String
-    Description: "The name of the github organization"
   # Must provide either a list of ManagePolicyArns or a custom PolicyDocument.
   # Can also provide both a list of ManagePolicyArns and a custom PolicyDocument.
   ManagedPolicyArns:
@@ -92,11 +89,11 @@ Resources:
               StringLike:
                 token.actions.githubusercontent.com:sub: [
   {% if Repository.branch == '*' %}
-                  "!Sub repo:${GitHubOrg}/{{ Repository.name }}:{{Repository.branch }}",
+                  "repo:{{ GitHubOrg }}/{{ Repository.name }}:{{Repository.branch }}",
   {% else %}
-                  "!Sub repo:${GitHubOrg}/{{ Repository.name }}:ref:refs/heads/{{ Repository.branch }}",
+                  "repo:{{ GitHubOrg}}/{{ Repository.name }}:ref:refs/heads/{{ Repository.branch }}",
   {% endif %}
-                  "!Sub repo:${GitHubOrg}/{{ Repository.name }}:ref:refs/tags/*"
+                  "repo:{{ GitHubOrg }}/{{ Repository.name }}:ref:refs/tags/*"
                 ]
 {% endfor %}
 Outputs:


### PR DESCRIPTION
This PR moves the parameter GitHubOrg to the templating context to fix the deployment issue.
