### PR TITLE
Fix policy template for GH OIDC

### DIFF
--- a/org-formation/650-identity-providers/github-oidc-provider-access.njk
+++ b/org-formation/650-identity-providers/github-oidc-provider-access.njk
@@ -89,11 +89,11 @@ Resources:
               StringLike:
                 token.actions.githubusercontent.com:sub: [
   {% if Repository.branch == '*' %}
-                  "repo:{{ GitHubOrg }}/{{ Repository.name }}:{{Repository.branch }}",
+                  "repo:{{ GitHubOrg }}/{{ Repository.name }}:{{Repository.branch }}"
   {% else %}
                   "repo:{{ GitHubOrg}}/{{ Repository.name }}:ref:refs/heads/{{ Repository.branch }}",
-  {% endif %}
                   "repo:{{ GitHubOrg }}/{{ Repository.name }}:ref:refs/tags/*"
+  {% endif %}
                 ]
 {% endfor %}
 Outputs:


### PR DESCRIPTION
When passing in `branch: "*"` the jinja template generates this condition..

```
Condition:
  StringEquals:
	token.actions.githubusercontent.com:aud:
	  Ref: ClientIdList
  StringLike:
	token.actions.githubusercontent.com:sub:
	  - repo:Sage-Bionetworks/data_curator-infra:*
	  - repo:Sage-Bionetworks/data_curator-infra:ref:refs/tags/*
```

the condition `repo:Sage-Bionetworks/data_curator-infra:*` covers any branch or tag so the one for `ref:refs/tags/*` is not required.

