### PR TITLE
PLFM-7700: Add wafv2:* perms

### DIFF
--- a/sceptre/synapsedev/templates/SynapseCMK-template.json
+++ b/sceptre/synapsedev/templates/SynapseCMK-template.json
@@ -208,6 +208,13 @@
                                         "athena:*"
                                     ],
                                     "Resource": "*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "wafv2:*"
+                                    ],
+                                    "Resource": "*"
                                 }
                             ]
                         }
@@ -230,7 +237,7 @@
             "Type": "AWS::KMS::Key",
             "Properties": {
                 "Description": "The master encryption key used to encypt/decrypt all Synapse master secrets",
-                "EnableKeyRotation": true,
+                "EnableKeyRotation": false,
                 "KeyPolicy": {
                     "Version": "2012-10-17",
                     "Id": "key-default-1",

--- a/sceptre/synapseprod/templates/SynapseCMK-template.json
+++ b/sceptre/synapseprod/templates/SynapseCMK-template.json
@@ -186,6 +186,13 @@
                                     "Effect": "Allow",
                                     "Action": "events:*",
                                     "Resource": "*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "wafv2:*"
+                                    ],
+                                    "Resource": "*"
                                 }
                             ]
                         }
@@ -208,7 +215,7 @@
             "Type": "AWS::KMS::Key",
             "Properties": {
                 "Description": "The master encryption key used to encypt/decrypt all Synapse master secrets",
-                "EnableKeyRotation": true,
+                "EnableKeyRotation": false,
                 "KeyPolicy": {
                     "Version": "2012-10-17",
                     "Id": "key-default-1",


### PR DESCRIPTION
This PR adds permissions to the deployment role. Note: this does not get deployed by infra (see PFLM-7725 to fix that).
The key rotation did not get deployed so I removed it to be in sync with deployed, will put it back after PLFM-7725 is done.
