### PR TITLE
Update SSO viewer plus role

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -435,6 +435,19 @@ SsoViewerPlus:
       - arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess
       - arn:aws:iam::aws:policy/AWSNetworkManagerReadOnlyAccess
       - arn:aws:iam::aws:policy/AWSOrganizationsReadOnlyAccess
+    inlinePolicy: >-
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "ec2:Get*"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
 
 # Role for a user that manages an application deployed to AWS
 SsoApplicationManager:

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -440,9 +440,11 @@ SsoViewerPlus:
         "Version": "2012-10-17",
         "Statement": [
           {
+            "Sid": "IpamReadOnlyAccess",
             "Effect": "Allow",
             "Action": [
-              "ec2:Get*"
+              "ec2:GetIpam*",
+              "ec2:DescribeIpam*"
             ],
             "Resource": "*"
           }


### PR DESCRIPTION
Commit 8bb7131d2 attempted to give the SsoViewerPlus role read only access to the IP address manager however it did not provide enought permissions.  To view IPAM the role also needs access to `EC2:Get*` actions[1]

[1] https://docs.aws.amazon.com/AWSEC2/latest/APIReference/operation-list-ipam.html

