### PR TITLE
IT-2673: OIDC for scicomp-provisioner repo

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -169,3 +169,21 @@ GithubOidcSageBionetworksAwsInfra:
   DefaultOrganizationBinding:
     Account: !Ref AdminCentralAccount
     Region: us-east-1
+
+GithubOidcSageBionetworksSciCompProvisioner:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: github-oidc-provider-access.njk
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-scicomp-provisioner
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "scicomp-provisioner"
+        branch: "master"
+  DefaultOrganizationBinding:
+    Account: !Ref SciCompAccount
+    Region: us-east-1


### PR DESCRIPTION
This PR sets up OIDC for the scicomp-provisioner repo. To be used for moving provisioning from TravisCI to GHA.
