### PR TITLE
IT-2673: Fix typo in ref'ed account

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -170,7 +170,7 @@ GithubOidcSageBionetworksAwsInfra:
     Account: !Ref AdminCentralAccount
     Region: us-east-1
 
-GithubOidcSageBionetworksSciCompProvisioner:
+GithubOidcSageBionetworksScicompProvisioner:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks
   Template: github-oidc-provider-access.njk
@@ -185,5 +185,5 @@ GithubOidcSageBionetworksSciCompProvisioner:
       - name: "scicomp-provisioner"
         branch: "master"
   DefaultOrganizationBinding:
-    Account: !Ref SciCompAccount
+    Account: !Ref ScicompAccount
     Region: us-east-1


### PR DESCRIPTION
This PR fixes the name of the Sci**c**omp account...
