### PR TITLE
[IT-2370] Create 'Owner Email' cost category

### DIFF
--- a/org-formation/050-costs/categories.yaml
+++ b/org-formation/050-costs/categories.yaml
@@ -1,6 +1,32 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'All Cost Categories'
 Resources:
+  OwnerEmailCostCategory:
+    Type: 'AWS::CE::CostCategory'
+    Properties:
+      Name: 'Owner Email'
+      RuleVersion: 'CostCategoryExpression.v1'
+      Rules: >-
+        {
+          "RuleVersion": "CostCategoryExpression.v1",
+          "Rules": [
+            {
+              "Type": "INHERITED_VALUE",
+              "InheritedValue": {
+                "DimensionName": "TAG",
+                "DimensionKey": "synapse:email"
+              }
+            },
+            {
+              "Type": "INHERITED_VALUE",
+              "InheritedValue": {
+                "DimensionName": "TAG",
+                "DimensionKey": "OwnerEmail"
+              }
+            }
+          ]
+        }
+
   ProgramCodeCostCategory:
     Type: 'AWS::CE::CostCategory'
     Properties:


### PR DESCRIPTION
A similar cost category was created manually, copy the JSON string from the existing category to automate its creation.
