### PR TITLE
Remove duplicate Rules key

### DIFF
--- a/org-formation/050-costs/categories.yaml
+++ b/org-formation/050-costs/categories.yaml
@@ -7,25 +7,22 @@ Resources:
       Name: 'Owner Email'
       RuleVersion: 'CostCategoryExpression.v1'
       Rules: >-
-        {
-          "RuleVersion": "CostCategoryExpression.v1",
-          "Rules": [
-            {
-              "Type": "INHERITED_VALUE",
-              "InheritedValue": {
-                "DimensionName": "TAG",
-                "DimensionKey": "synapse:email"
-              }
-            },
-            {
-              "Type": "INHERITED_VALUE",
-              "InheritedValue": {
-                "DimensionName": "TAG",
-                "DimensionKey": "OwnerEmail"
-              }
+        [
+          {
+            "Type": "INHERITED_VALUE",
+            "InheritedValue": {
+              "DimensionName": "TAG",
+              "DimensionKey": "synapse:email"
             }
-          ]
-        }
+          },
+          {
+            "Type": "INHERITED_VALUE",
+            "InheritedValue": {
+              "DimensionName": "TAG",
+              "DimensionKey": "OwnerEmail"
+            }
+          }
+        ]
 
   ProgramCodeCostCategory:
     Type: 'AWS::CE::CostCategory'


### PR DESCRIPTION
The JSON editor in the AWS console for editing cost category rules provides a context Rules key that we don't want to copy.

