### PR TITLE
IT-2426: Add OIDC integration to deploy Genie-BPC Shiny application

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -113,7 +113,7 @@ GithubOidcSageBionetworksGenieBPCInfra:
         branch: "*"
   DefaultOrganizationBinding:
     Account:
-      - !Ref SynapseDevAccount
+      - !Ref DnTDevAccount
       - !Ref GenieProdAccount
     Region: us-east-1
 

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -97,6 +97,26 @@ GithubOidcSageBionetworksSchematicInfra:
       - !Ref DCAProdAccount
     Region: us-east-1
 
+GithubOidcSageBionetworksGenieBPCInfra:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: github-oidc-provider-access.njk
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-genie-bpc-infra
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "genie-bpc-infra"
+        branch: "*"
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref SynapseDevAccount
+      - !Ref GenieProdAccount
+    Region: us-east-1
+
 GithubOidcSageBionetworksDNTInfra:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks


### PR DESCRIPTION
Add OIDC integration to deploy Genie-BPC Shiny application from GitHub to AWS