### PR TITLE
[IT-2594] Rename host for lambda-mips-api

### DIFF
--- a/org-formation/100-shared-dns/README.md
+++ b/org-formation/100-shared-dns/README.md
@@ -12,16 +12,12 @@ used by the hosting service.
 
 Each wildcard cert will need to be manually verified before it can be used.
 
-### sageit.org
+### finops.sageit.org
 
-This hosted zone was created manually and is shared between finops
-microservices and some auth redirects (SSO and VPN).
+This zone is intended for cost-tracking automation, such as lambda-mips-api.
 
-A wildcard certificate has been created for this zone in sceptre:
-./sceptre/sageit/config/prod/sageit-org-acm-cert.yaml
-
-This directory is used for creating additional certificates in other
-accounts and their associated DNS records.
+The wildcard certificate created for this zone is expected to be used elsewhere
+in org-formation, but not by external infra projects (such as CDK applications).
 
 ### app.sagebionetworks.org
 

--- a/org-formation/100-shared-dns/_tasks.yaml
+++ b/org-formation/100-shared-dns/_tasks.yaml
@@ -1,6 +1,24 @@
 Parameters:
   <<: !Include '../_parameters.yaml'
 
+# The dns zone for this certificate was created manually, and a
+# certificate for the zone is created in the sageit account in sceptre:
+# ./sceptre/sageit/config/prod/sageit-org-acm-cert.yaml
+#
+# Create a second sageit certificate in admincentral for the finops lambdas
+# This certificate is deprecated by the finops wildcard certificate below
+SageItCertificate:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.8/templates/acm-certificate.yaml
+  StackName: !Sub '${resourcePrefix}-sageit-cert'
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+    Account:
+      - !Ref AdminCentralAccount
+    Region: !Ref primaryRegion
+  Parameters:
+    DnsDomainName: 'sageit.org'
+
 # Zone for finops lambdas in admincentral
 SageITFinopsZone:
   Type: update-stacks

--- a/org-formation/100-shared-dns/_tasks.yaml
+++ b/org-formation/100-shared-dns/_tasks.yaml
@@ -1,24 +1,33 @@
 Parameters:
   <<: !Include '../_parameters.yaml'
 
-# The dns zone for this certificate was created manually, and a
-# certificate for the zone is created in the sageit account in sceptre:
-# ./sceptre/sageit/config/prod/sageit-org-acm-cert.yaml
-#
-# Create a second sageit certificate in admincentral for the finops lambdas
-SageItCertificate:
+# Zone for finops lambdas in admincentral
+SageITFinopsZone:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.8/templates/R53-hostedzone.yaml
+  StackName: !Sub '${resourcePrefix}-sageit-finops-zone'
+  StackDescription: Create a shared hosted zone for application domains
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref SageITAccount
+  Parameters:
+    DnsDomainName: "finops.sageit.org"
+
+# Wildcard certificate for '*.finops.sageit.org'
+SageITFinopsCertificate:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.8/templates/acm-certificate.yaml
-  StackName: !Sub '${resourcePrefix}-sageit-cert'
+  StackName: !Sub '${resourcePrefix}-sageit-finops-cert'
   DefaultOrganizationBinding:
     IncludeMasterAccount: false
     Account:
       - !Ref AdminCentralAccount
     Region: !Ref primaryRegion
   Parameters:
-    DnsDomainName: 'sageit.org'
+    DnsDomainName: 'finops.sageit.org'
 
-SagebioAppZone:  # Zone for application front-end DNS names, e.g. 'dca.app.sagebionetworks.org'
+# Zone for application front-end DNS names, e.g. 'dca.app.sagebionetworks.org'
+SagebioAppZone:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.8/templates/R53-hostedzone.yaml
   StackName: !Sub '${resourcePrefix}-sagebio-app-zone'
@@ -29,7 +38,8 @@ SagebioAppZone:  # Zone for application front-end DNS names, e.g. 'dca.app.sageb
   Parameters:
     DnsDomainName: "app.sagebionetworks.org"
 
-SagebioAppZoneAcmCertificate:  # Wildcard certificate for '*.app.sagebionetworks.org'
+# Wildcard certificate for '*.app.sagebionetworks.org'
+SagebioAppZoneAcmCertificate:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.8/templates/acm-certificate.yaml
   StackName: !Sub '${resourcePrefix}-sagebio-app-cert'
@@ -45,7 +55,8 @@ SagebioAppZoneAcmCertificate:  # Wildcard certificate for '*.app.sagebionetworks
   Parameters:
     DnsDomainName: "app.sagebionetworks.org"
 
-SagebioApiZone:  # Zone for intra-API DNS names, e.g. 'schematic.api.sagebionetworks.org'
+# Zone for intra-API DNS names, e.g. 'schematic.api.sagebionetworks.org'
+SagebioApiZone:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.8/templates/R53-hostedzone.yaml
   StackName: !Sub '${resourcePrefix}-sagebio-api-zone'
@@ -56,7 +67,8 @@ SagebioApiZone:  # Zone for intra-API DNS names, e.g. 'schematic.api.sagebionetw
   Parameters:
     DnsDomainName: "api.sagebionetworks.org"
 
-SagebioApiZoneAcmCertificate:  # Wildcard certificate for '*.api.sagebionetworks.org'
+# Wildcard certificate for '*.api.sagebionetworks.org'
+SagebioApiZoneAcmCertificate:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.8/templates/acm-certificate.yaml
   StackName: !Sub '${resourcePrefix}-sagebio-api-cert'

--- a/org-formation/100-shared-dns/_tasks.yaml
+++ b/org-formation/100-shared-dns/_tasks.yaml
@@ -24,7 +24,7 @@ SageITFinopsZone:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.8/templates/R53-hostedzone.yaml
   StackName: !Sub '${resourcePrefix}-sageit-finops-zone'
-  StackDescription: Create a shared hosted zone for application domains
+  StackDescription: Create a shared hosted zone for finops lambdas
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     Account: !Ref SageITAccount
@@ -36,6 +36,7 @@ SageITFinopsCertificate:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.8/templates/acm-certificate.yaml
   StackName: !Sub '${resourcePrefix}-sageit-finops-cert'
+  StackDescription: Create a wildcard certificate for finops lambdas
   DefaultOrganizationBinding:
     IncludeMasterAccount: false
     Account:


### PR DESCRIPTION
Prepare for having two finops lambdas under the same domain by creating a zone and wildcard cert for `finops.sageit.org`, replacing the secondary wildcard certificate for `sageit.org`.
