### PR TITLE
[IT-2460] Deploy lambda-finops-cost-rules

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -51,7 +51,7 @@ CostCategoryRulesMicroservice:
     DnsName: "cost-rules.finops.sageit.org"
     ChartOfAccountsURL: "https://mips-api.finops.sageit.org/accounts?enable_code_filter"
     ProgramCodeTagList: "CostCenterOther,CostCenter"
-    OwnerEmailTagList: "OwnerEmail,synapseEmail"
+    OwnerEmailTagList: "OwnerEmail,synapse:email"
 
 CostCategories:
   Type: update-stacks

--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -38,6 +38,21 @@ MipsMicroservice:
       - !Sub 'arn:aws:iam::${CurrentAccount.AccountId}:root'
       - 'arn:aws:iam::745159704268:role/github-oidc-sage-bionetwo-ProviderRoleorganization-93H11ERK3F4N'
 
+CostCategoryRulesMicroservice:
+  Type: update-stacks
+  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-finops-cost-rules/master/lambda-finops-cost-rules.yaml'
+  StackName: !Sub '${resourcePrefix}-rules-microservice'
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+    Account: !Ref AdminCentralAccount
+    Region: !Ref primaryRegion
+  Parameters:
+    AcmCertificateArn: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sageit-finops-cert-CertificateArn']
+    DnsName: "cost-rules.finops.sageit.org"
+    ChartOfAccountsURL: "https://mips-api.finops.sageit.org/accounts?enable_code_filter"
+    ProgramCodeTagList: "CostCenterOther,CostCenter"
+    OwnerEmailTagList: "OwnerEmail,synapseEmail"
+
 CostCategories:
   Type: update-stacks
   Template: categories.yaml


### PR DESCRIPTION
Deploy our new lambda for generating cost category rules, deprecating our custom transform macro.

depends on: #775 Sage-Bionetworks-IT/lambda-finops-cost-rules#3 Sage-Bionetworks-IT/lambda-mips-api#13
