### PR TITLE
IT-2744 - Add GitHub OIDC integration for synapse-web-monorepo

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -223,14 +223,20 @@ GithubOidcSageBionetworksWebMonorepoInfra:
           {
               "Sid": "ListObjectsInBucket",
               "Effect": "Allow",
-              "Action": [ "s3:GetBucketLocation", "s3:ListBucket" ],
+              "Action": [ "s3:GetBucketLocation", "s3:ListBucket", "s3:ListBucketMultipartUploads" ],
               "Resource": [ "arn:aws:s3:::prod.accounts.sagebionetworks.org" ]
           },
           {
               "Sid": "AllObjectActions",
               "Effect": "Allow",
-              "Action": [ "s3:PutObject", "s3:GetObject" ],
-              "Resource": ["arn:aws:s3:::prod.accounts.sagebionetworks.org/*"]
+              "Action": [ "s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:*Multipart*" ],
+              "Resource": ["arn:aws:s3:::prod.accounts.sagebionetworks.org/*", "arn:aws:s3:::staging.accounts.sagebionetworks.org/*" ]
+          },
+          {
+              "Sid": "CloudfrontActions",
+              "Effect": "Allow",
+              "Action": [ "cloudfront:CreateInvalidation" ],
+              "Resource": ["arn:aws:cloudfront::797640923903:distribution/E2656IE63W1MXI", "arn:aws:cloudfront::797640923903:distribution/E2656IE63W1MXI" ]
           }
         ]
       }

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -207,3 +207,38 @@ GithubOidcSageBionetworksScicompProvisioner:
   DefaultOrganizationBinding:
     Account: !Ref ScicompAccount
     Region: us-east-1
+
+GithubOidcSageBionetworksWebMonorepoInfra:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: github-oidc-provider-access.njk
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-web-monorepo-infra
+  Parameters:
+    GitHubOrg: "Sage-Bionetworks"
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    PolicyDocument: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+              "Sid": "ListObjectsInBucket",
+              "Effect": "Allow",
+              "Action": [ "s3:GetBucketLocation", "s3:ListBucket" ],
+              "Resource": [ "arn:aws:s3:::prod.accounts.sagebionetworks.org" ]
+          },
+          {
+              "Sid": "AllObjectActions",
+              "Effect": "Allow",
+              "Action": [ "s3:PutObject", "s3:GetObject" ],
+              "Resource": ["arn:aws:s3:::prod.accounts.sagebionetworks.org/*"]
+          }
+        ]
+      }
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "synapse-web-monorepo"
+        branch: "main"
+  DefaultOrganizationBinding:
+    Account: !Ref SageITAccount
+    Region: us-east-1


### PR DESCRIPTION
PR Checklist:
[x] Describe and explain your intentions for this change
[ ] Setup pre-commit and run the validators (info in README.md)

See [IT-2744](https://sagebionetworks.jira.com/browse/IT-2744)

[SageAccountWeb](https://github.com/Sage-Bionetworks/SageAccountWeb) had its deployments configured by AWS credentials that were manually supplied to the repo.

That repository has been moved, to [synapse-web-monorepo](https://github.com/Sage-Bionetworks/synapse-web-monorepo), so it needs to be reconfigured. Rather than a manual reconfiguration, I'm trying to get this direct OIDC  integration set up. The current deployment script is [here](https://github.com/Sage-Bionetworks/synapse-web-monorepo/blob/main/.github/workflows/deploy-sage-account-web.yml).

This is my first pass, but I don't really know what I'm doing, so this will definitely need to be refined.

[IT-2744]: https://sagebionetworks.jira.com/browse/IT-2744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ