### PR TITLE
Remove Genie-BPC dev stack

### DIFF
--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -116,24 +116,6 @@ SchematicProdAppDnsForward:
     # the value of the CNAME record
     TargetHostName: !CopyValue ['schematic-prod-DockerFargateStack-LoadBalancerDNS', !Ref DCAProdAccount]
 
-# forward https://genie-bpc-dev.app.sagebionetworks.org to genie-bpc-infra ALB
-# https://github.com/Sage-Bionetworks/genie-bpc-infra
-GenieBPCDevAppDnsForward:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.4/templates/R53/cname.yaml
-  StackName: !Sub '${resourcePrefix}-genie-bpc-dev-cname'
-  StackDescription: Setup a CNAME for genie-bpc-infra dev ALB
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    Account: !Ref SageITAccount
-  Parameters:
-    # the name of the CNAME record
-    SourceHostName: "genie-bpc-dev.app.sagebionetworks.org"
-    # ID of the app.sagebionetworks.org zone (in sageit account)
-    SourceHostedZoneId: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sagebio-app-zone-HostedZoneId']
-    # the value of the CNAME record
-    TargetHostName: !CopyValue ['genie-bpc-shiny-dev-DockerFargateStack-LoadBalancerDNS', !Ref DnTDevAccount]
-
 # forward https://genie-bpc.app.sagebionetworks.org to genie-bpc-infra ALB
 # https://github.com/Sage-Bionetworks/genie-bpc-infra
 GenieBPCProdAppDnsForward:


### PR DESCRIPTION
We don't have the ability to point the different genie applications (dev and prod) at different datasets, and running both on the same dataset would be problematic. Remove the dev application stack (which has already been manually deleted).
