### PR TITLE
Remove duplicate mips-api deploy

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -21,25 +21,7 @@ AnomalyDetectorService:
     Subscriber: !GetAtt CurrentAccount.RootEmail
 
 # Deploy a general-use microservice for interacting with MIPS in admincentral
-MipsMicroserviceBlue:
-  Type: update-stacks
-  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-mips-api/master/lambda-mips-api.yaml'
-  StackName: !Sub '${resourcePrefix}-mips-microservice-old'
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: false
-    Account: !Ref AdminCentralAccount
-    Region: !Ref primaryRegion
-  Parameters:
-    AcmCertificateArn: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sageit-cert-CertificateArn']
-    DnsNames: "finops-api.sageit.org"
-    MipsOrganization: 'SAGE_24146'
-    SsmKeyAdminArns:
-      - 'arn:aws:sts::745159704268:assumed-role/AWSReservedSSO_Administrator_30244677b3ea9498/joni.harker@sagebase.org'
-      - !Sub 'arn:aws:iam::${CurrentAccount.AccountId}:root'
-      - 'arn:aws:iam::745159704268:role/github-oidc-sage-bionetwo-ProviderRoleorganization-93H11ERK3F4N'
-
-# Deploy a general-use microservice for interacting with MIPS in admincentral
-MipsMicroserviceGreen:
+MipsMicroservice:
   Type: update-stacks
   Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-mips-api/master/lambda-mips-api.yaml'
   StackName: !Sub '${resourcePrefix}-mips-microservice'

--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -23,25 +23,7 @@ SsoRedirect:   # Redirect sso.sageit.org to the AWS SSO Start URL
     TargetKey: "start#/"
 
 # forward finops-api.sageit.org to lambda-mips-api cloudfront distribution
-FinopsApiDnsForwardBlue:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.4/templates/R53/cname.yaml
-  StackName: !Sub '${resourcePrefix}-finops-api-redirect'
-  StackDescription: Setup a redirect to the lambda-mips-api cloudfront distribution
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    Account: !Ref SageITAccount
-  Parameters:
-    # the name of the CNAME record
-    SourceHostName: "finops-api.sageit.org"
-    # ID of the sageit.org zone (in sageit account)
-    SourceHostedZoneId: "Z0478495257GEB73WFM63"
-    # the value of the CNAME record
-    TargetHostName: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-mips-microservice-CloudfrontDomain', !Ref AdminCentralAccount]
-
-# forward finops-api.sageit.org to lambda-mips-api cloudfront distribution
-# create a second DNS entry while migrating to the new host name
-FinopsApiDnsForwardGreen:
+FinopsApiDnsForward:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.4/templates/R53/cname.yaml
   StackName: !Sub '${resourcePrefix}-finops-api-forward'
@@ -56,7 +38,6 @@ FinopsApiDnsForwardGreen:
     SourceHostedZoneId: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sageit-finops-zone-HostedZoneId']
     # the value of the CNAME record
     TargetHostName: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-mips-microservice-CloudfrontDomain', !Ref AdminCentralAccount]
-
 
 
 # *.app.sagebionetworks.org


### PR DESCRIPTION
The mips-api lambda template does not support deploying multiple stacks to the same account. Roll forward through the error, using the new dns name for the lambda.
