### PR TITLE
IT-2752: Need service-user instead of service-account

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -173,10 +173,10 @@ DnTDevCIServiceAccounts:
       - !Ref DnTDevAccount
     Region: us-east-1
 
-SynapseProdRedashServiceAccount:
+SynapseProdRedashServiceUser:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/IAM/service-account.yaml
-  StackName: synapseprod-redash-service-account
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/IAM/service-user.yaml
+  StackName: synapseprod-redash-service-user
   Parameters:
     ManagedPolicyArns:
       - arn:aws:iam::aws:policy/service-role/AWSQuicksightAthenaAccess


### PR DESCRIPTION
The previous attempt (#773, #774) created a user, a role and the permission for the user to assume the role. For Redash, the permissions need to be directly on the user. This PR uses the service-user.yaml template which does just that...
