### PR TITLE
IT-2651: Test key access by infra

### DIFF
--- a/sceptre/synapsedev/config/prod/testCMK.yaml
+++ b/sceptre/synapsedev/config/prod/testCMK.yaml
@@ -1,0 +1,5 @@
+template:
+  path: testCMK.json
+stack_name: test-cmk
+parameters:
+  Stack: xtest2

--- a/sceptre/synapsedev/templates/testCMK.json
+++ b/sceptre/synapsedev/templates/testCMK.json
@@ -1,0 +1,104 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "The master encryption key used to encypt/decypt all Synapse master secrets",
+    "Parameters": {
+        "Stack": {
+            "Description": "The stack",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "SynapseCMK": {
+            "Type": "AWS::KMS::Key",
+            "Properties": {
+                "Description": "A master encryption key",
+                "EnableKeyRotation": false,
+                "KeyPolicy": {
+                    "Version": "2012-10-17",
+                    "Id": "key-default-1",
+                    "Statement": [
+                        {
+                            "Sid": "Allow administration of the key",
+                            "Effect": "Deny",
+                            "Principal": {
+                                "AWS": "*"
+                            },
+                            "Action": [
+                                "kms:*"
+                            ],
+                            "Resource": "*",
+                            "Condition": {
+                                "StringNotLike": {
+                                    "aws:PrincipalArn": [
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:iam::",
+                                                    {
+                                                        "Ref": "AWS::AccountId"
+                                                    },
+                                                    ":root"
+                                                ]
+                                            ]
+                                        },
+                                        "arn:aws:iam::449435941126:role/*"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "Sid": "Allow root administration of the key",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": [
+                                    {
+                                        "Fn::ImportValue": "us-east-1-accounts-AWSIAMAdminRoleArn"
+                                    },
+                                    {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "arn:aws:iam::",
+                                                {
+                                                    "Ref": "AWS::AccountId"
+                                                },
+                                                ":root"
+                                            ]
+                                        ]
+                                    },
+                                    "arn:aws:sts::449435941126:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/x.schildwachter@sagebase.org",
+                                    "arn:aws:iam::449435941126:role/sagebase-github-oidc-sage-ProviderRoleorganization-1K1MGUYPL5JUO"
+                                ]
+                            },
+                            "Action": [
+                                "kms:*"
+                            ],
+                            "Resource": "*"
+                        }
+                    ]
+                }
+            }
+        },
+        "SynapseCMKAlias": {
+            "Type": "AWS::KMS::Alias",
+            "Properties": {
+                "AliasName": {
+                    "Fn::Join": [
+                        "/",
+                        [
+                            "alias",
+                            {
+                                "Ref": "Stack"
+                            },
+                            "synapse"
+                        ]
+                    ]
+                },
+                "TargetKeyId": {
+                    "Ref": "SynapseCMK"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a test PR to create a key in the SynapseDev account that should be accessible by the old AWSIAMAdminRole (to be deleted), myself logged in as SSO and the infra (the deployment should fail if the deployer would not be able to manage the key). If it works, the changes will be merged back in the original script used to deploy the Synapse master key, and that script will be added to the infra
