### PR TITLE
DCA-130:  Enable simple-shiny-infra to deploy to dnt-dev account

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -117,6 +117,25 @@ GithubOidcSageBionetworksGenieBPCInfra:
       - !Ref GenieProdAccount
     Region: us-east-1
 
+GithubOidcSageBionetworksSimpleShinyInfra:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: github-oidc-provider-access.njk
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-simple-shiny-infra
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "simple-shiny-infra"
+        branch: "*"
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref DnTDevAccount
+    Region: us-east-1
+
 GithubOidcSageBionetworksDNTInfra:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks


### PR DESCRIPTION
To run load balancing experiments in DCA-130 we would like to deploy a 'simple Shiny' application.  This PR allows the `simple-shiny-infra` repo' to deploy the app' to the DnT account.
