### PR TITLE
PLFM-7774: Account, not OU

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -757,8 +757,7 @@ SsoSynapseAdmin:
     IncludeMasterAccount: true
   OrganizationBindings:
     TargetBinding:
-      OrganizationalUnit:
-        - !Ref SynapseProdAccount
+      Account: !Ref SynapseProdAccount
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref synapseAdminGroup
@@ -775,8 +774,7 @@ SsoSynapseDevAdmin:
     IncludeMasterAccount: true
   OrganizationBindings:
     TargetBinding:
-      OrganizationalUnit:
-        - !Ref SynapseDevAccount
+      Account: !Ref SynapseDevAccount
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref synapseDevAdminGroup


### PR DESCRIPTION
This PR fixes the deployment error. The groups apply to accounts, not OUs.
