### PR TITLE
PLFM-7774: Followup - create synapseprod-specific admin group

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -81,6 +81,10 @@ Parameters:
     Type: String
     Default: '44d844b8-60a1-70e5-cb5a-50137c984398'
 
+  synapseProdAdminGroup:  #JC aws-synapseprod-admins
+    Type: String
+    Default: '34783488-c0c1-701b-d093-6f4f8edcf2d7'
+
   synapseDevDeveloperGroup:     #JC aws-synapsedev-developers
     Type: String
     Default: '906769aa66-74e6487e-6e4e-4734-ba40-0de48cd03511'
@@ -778,6 +782,23 @@ SsoSynapseDevAdmin:
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref synapseDevAdminGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
+
+SsoSynapseProdAdmin:
+  Type: update-stacks
+  DependsOn: SsoAdministrator
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-synapseprod-admin'
+  StackDescription: 'SSO: admin role used by synapseprod admin group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref SynapseProdAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref synapseProdAdminGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
 
 SsoSynapseDevDeveloper:

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -73,10 +73,6 @@ Parameters:
     Type: String
     Default: '906769aa66-6cdd2cc1-6d3d-49d8-b105-37c22bb3d402'
 
-  synapseAdminGroup:      #JC aws-synapse-admins
-    Type: String
-    Default: '906769aa66-1c66a9b6-ae5e-473c-a51c-4b02918c4454'
-
   synapseDevAdminGroup:   #JC aws-synapsedev-admins
     Type: String
     Default: '44d844b8-60a1-70e5-cb5a-50137c984398'
@@ -748,23 +744,6 @@ SsoWorkflowNextflowProdAdmin:
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref workflowNextflowProdAdminGroup
-    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
-
-SsoSynapseAdmin:
-  Type: update-stacks
-  DependsOn: SsoAdministrator
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/SSO/aws-sso.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-synapse-admin'
-  StackDescription: 'SSO: admin role used by synapse admin group'
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: true
-  OrganizationBindings:
-    TargetBinding:
-      Account: !Ref SynapseProdAccount
-  Parameters:
-    instanceArn: !Ref instanceArn
-    principalId: !Ref synapseAdminGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
 
 SsoSynapseDevAdmin:


### PR DESCRIPTION
This PR is a followup to #803, remove the existing shared synapse admin group and replace it with one specific to synapseprod.
