### PR TITLE
[IT-1655] Move source of Other value to sceptre

### DIFF
--- a/sceptre/scipool/config/develop/sc-tag-options.yaml
+++ b/sceptre/scipool/config/develop/sc-tag-options.yaml
@@ -14,7 +14,7 @@ dependencies:
 sceptre_user_data:
   Departments: !file sc-tag-options/internal/Departments.json
   Projects: !file sc-tag-options/internal/Projects.json
-  CostCenters: !file https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.6/tags/SageFinancialProgramCodes.json
+  CostCenters: !rcmd 'wget -qO- https://mips-api.finops.sageit.org/tags?limit=24'
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/sceptre/scipool/config/prod/sc-tag-options.yaml
+++ b/sceptre/scipool/config/prod/sc-tag-options.yaml
@@ -14,7 +14,7 @@ dependencies:
 sceptre_user_data:
   Departments: !file sc-tag-options/internal/Departments.json
   Projects: !file sc-tag-options/internal/Projects.json
-  CostCenters: !file https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.6/tags/SageFinancialProgramCodes.json
+  CostCenters: !rcmd 'wget -qO- https://mips-api.finops.sageit.org/tags?limit=24'
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/sceptre/scipool/templates/sc-tag-options.j2
+++ b/sceptre/scipool/templates/sc-tag-options.j2
@@ -30,6 +30,12 @@ Resources:
       Key: "CostCenter"
       Value: {{ CostCenter }}
   {% endfor %}
+  OtherCostCenterTag:
+    Type: AWS::ServiceCatalog::TagOption
+    Properties:
+      Active: true
+      Key: "CostCenter"
+      Value: "Other / 000001"
 {% endif %}
 
 {% if sceptre_user_data.ProductIDs is defined %}
@@ -60,6 +66,11 @@ Resources:
       ResourceId: "{{ id }}"
       TagOptionId: !Ref "{{ CostCenter.replace(' ','').replace('+','').replace('.','').replace('-','').replace('_','').replace('/','') }}CostCenterTag"
       {% endfor %}
+  OtherTagAssociationProd{{ id.split('-')[1] }}:
+    Type: AWS::ServiceCatalog::TagOptionAssociation
+    Properties:
+      ResourceId: "{{ id }}"
+      TagOptionId: !Ref "OtherCostCenterTag"
     {% endif %}
   {% endfor %}
 {% endif %}


### PR DESCRIPTION
In order to avoid listing "Other / 000001" as a valid program code in the list we provide to users, stop configuring the lambda to add the code, and instead add it in the nunjucks template generating Tag Options for each valid tag.
