### PR TITLE
IT-2770 Set up JumpCloud access to DccValidator-Prod account for application manager

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -1838,4 +1838,3 @@ SsoDccValidatorProdApplicationManager:
     instanceArn: !Ref instanceArn
     principalId: !Ref dccvalidatorProdApplicationManagerGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-application-manager-permission-set-arn' ]
-

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -289,6 +289,10 @@ Parameters:
     Type: String
     Default: '04a83488-1041-70d0-e200-31472f87c82a'
 
+  dccvalidatorProdApplicationManagerGroup:      # JC aws-dccvalidator-prod-application-managers
+    Type: String
+    Default: '6498b478-20e1-7031-9648-00c20c410359'
+
   #------------- personal AWS accounts ------------------
   8dxfh53AdminGroup:             #JC aws-8dxfh53-admins
     Type: String
@@ -1407,7 +1411,7 @@ SsoDntDevViewer:
     principalId: !Ref dntDevViewerGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-viewer-permission-set-arn' ]
 
-SsoDntDevProdApplicationManager:
+SsoDntDevApplicationManager:
   Type: update-stacks
   DependsOn: SsoApplicationManager
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.1/templates/SSO/aws-sso.njk
@@ -1816,3 +1820,22 @@ SsoCnbDeveloper:
     instanceArn: !Ref instanceArn
     principalId: !Ref cnbDevDeveloperGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
+
+SsoDccValidatorProdApplicationManager:
+  Type: update-stacks
+  DependsOn: SsoApplicationManager
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.1/templates/SSO/aws-sso.njk
+  TemplatingContext: {}
+  StackName: !Sub '${resourcePrefix}-${appName}-dccvalidator-prod-application-manager'
+  StackDescription: 'SSO: Application Manager role used by DccValidator-Prod application-manager group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref DccvalidatorProdAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref dccvalidatorProdApplicationManagerGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-application-manager-permission-set-arn' ]
+


### PR DESCRIPTION
As part of the DccValidator-Prod account set-up, connect the JumpCloud `aws-dccvalidator-prod-application-managers` group to AWS.