### PR TITLE
[IT-2750] Move CDK admin instructions to org-formation

### DIFF
--- a/org-formation/100-shared-dns/README.md
+++ b/org-formation/100-shared-dns/README.md
@@ -39,10 +39,11 @@ hosted zone with a value pointing to the AWS domain name of the ALB.
 
 Certificates must exist in the same account they will be used in, and so we
 must create a copy of our wildcard certificate in an application account before
-the application can be deployed to that account. For example, [the list of
-accounts for `app.sagebionetworks.org`](https://github.com/Sage-Bionetworks-IT/organizations-infra/blob/master/org-formation/100-shared-dns/_tasks.yaml#L70).
-When merging a change that creates new certificates, the deploy pipeline will
-fail if the certificates are not validated within the 30-minute timeout.
+the application can be deployed to that account. Ensure that the stack creating
+the desired wildcard certificate has an account binding for the application
+account in `_tasks.yaml`. When merging a change that creates new certificates,
+the deploy pipeline will fail if the certificates are not manually validated
+within the 30-minute timeout.
 
 ### Validating New Certificates
 

--- a/org-formation/100-shared-dns/README.md
+++ b/org-formation/100-shared-dns/README.md
@@ -41,6 +41,8 @@ Certificates must exist in the same account they will be used in, and so we
 must create a copy of our wildcard certificate in an application account before
 the application can be deployed to that account. For example, [the list of
 accounts for `app.sagebionetworks.org`](https://github.com/Sage-Bionetworks-IT/organizations-infra/blob/master/org-formation/100-shared-dns/_tasks.yaml#L70).
+When merging a change that creates new certificates, the deploy pipeline will
+fail if the certificates are not validated within the 30-minute timeout.
 
 ### Validating New Certificates
 

--- a/org-formation/100-shared-dns/README.md
+++ b/org-formation/100-shared-dns/README.md
@@ -34,3 +34,35 @@ This zone is intended for application-facing applications, such as Schematic.
 CDK applications will export a CloudFormation output with the AWS domain
 name for the created ALB. Create a DNS CNAME record in the appropriate
 hosted zone with a value pointing to the AWS domain name of the ALB.
+
+## Per-Account Certificates
+
+Certificates must exist in the same account they will be used in, and so we
+must create a copy of our wildcard certificate in an application account before
+the application can be deployed to that account. For example, [the list of
+accounts for `app.sagebionetworks.org`](https://github.com/Sage-Bionetworks-IT/organizations-infra/blob/master/org-formation/100-shared-dns/_tasks.yaml#L70).
+
+### Validating New Certificates
+
+When adding a new account to the list for a certificate, the newly-created
+certificate must be validated before the CloudFormation stack will succeed.
+To validate the certificate:
+
+1. Log in to AWS Console for the application account.
+1. Navigate to the new certificate in AWS Certificate Manager.
+1. Note the name and value of the needed CNAME record. We only need the host portion of the name (before the first period).
+1. Log out of the application account.
+1. Log in to AWS Console for the SageIT account.
+1. Navigate to the appropriate zone for our new certificate in Route 53.
+1. Add a CNAME record with the noted name and value.
+
+It can take several minutes for the validation to complete once the CNAME
+record has been created. If the CloudFormation stack fails due to a
+timeout validating the certificate, the deploy pipeline can be re-run.
+
+### Providing Certificate ARNs
+
+CDK applications need to configure their certificate ARN in `cdk.json`.
+To provide this value to CDK application developers, navigate to the
+desired certificate in AWS Certificate Manager. The ARN is listed under
+"Certificate status".

--- a/org-formation/800-redirects/README.md
+++ b/org-formation/800-redirects/README.md
@@ -1,3 +1,12 @@
 ### Purpose of these templates
 The templates in this folder set up convenient redirects to other difficult to
 remember URL locations.
+
+### DNS for CDK ALBs
+Some CDK applications create an ALB configured with a custom host name but are
+not able to create the corresponding CNAME record because DNS is managed
+centrally in the SageIT account, and so the record is created in org-formation
+here. The CDK application will export its load balancer's name so that it can
+easily be referenced when creating the CNAME record here. Once the application
+has been deployed, a record can be created for each load balancer like in
+[this example commit](https://github.com/Sage-Bionetworks-IT/organizations-infra/commit/1753dfab78cee0956ec4e265110131c3d73d8053).


### PR DESCRIPTION
Migrate some instructions for CDK certificate and DNS setup from confluence to github.
