### PR TITLE
Test longer host name with fixed template

### DIFF
--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -192,7 +192,7 @@ GenieBPCProdAppDnsForward:
 # https://github.com/Sage-Bionetworks/dccvalidator_1kD-infra
 DccValidator1kDDevAppDnsForward:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.4/templates/R53/cname.yaml
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/R53/cname.yaml
   StackName: !Sub '${resourcePrefix}-dccvalidator-1kD-dev-cname'
   StackDescription: Setup a CNAME for dccvalidator-1kD-infra dev ALB
   DefaultOrganizationBindingRegion: !Ref primaryRegion
@@ -204,6 +204,6 @@ DccValidator1kDDevAppDnsForward:
     # ID of the app.sagebionetworks.org zone (in sageit account)
     SourceHostedZoneId: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sagebio-app-zone-HostedZoneId']
     # the value of the CNAME record
-    #TargetHostName: 'dccva-dccva-1LFCR8U325PQ3-1454849979.us-east-1.elb.amazonaws.com'
-    TargetHostName: 'genie-genie-4R49TZYDXAS9-1514334147.us-east-1.elb.amazonaws.com'
+    TargetHostName: 'dccva-dccva-1LFCR8U325PQ3-1454849979.us-east-1.elb.amazonaws.com'
+    #TargetHostName: 'genie-genie-4R49TZYDXAS9-1514334147.us-east-1.elb.amazonaws.com'
     #TargetHostName: !CopyValue ['dccvalidator-1kD-dev-DockerFargateStack-LoadBalancerDNS', !Ref DccvalidatorDevAccount]


### PR DESCRIPTION
Now that we've loosened the constraint on the template to match the actual limit, try creating our longer CNAME with the updated template.
