### PR TITLE
Add AccountOwner as an owner-email tag name

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -51,7 +51,7 @@ CostCategoryRulesMicroservice:
     DnsName: "cost-rules.finops.sageit.org"
     ChartOfAccountsURL: "https://mips-api.finops.sageit.org/accounts?enable_code_filter"
     ProgramCodeTagList: "CostCenterOther,CostCenter"
-    OwnerEmailTagList: "OwnerEmail,synapse:email"
+    OwnerEmailTagList: "OwnerEmail,synapse:email,AccountOwner"
 
 CostCategories:
   Type: update-stacks


### PR DESCRIPTION
The accounts are tagged with AccountOwner tags for this value, so add that to the list.