### PR TITLE
[IT-2369] Use lambda for Owner Email category

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -61,3 +61,5 @@ CostCategories:
   DefaultOrganizationBinding:
     Account: !Ref MasterAccount
     Region: !Ref primaryRegion
+  Parameters:
+    OwnerEmailRulesJSON: !Cmd 'wget -qO- https://cost-rules.finops.sageit.org/owner-emails'

--- a/org-formation/050-costs/categories.yaml
+++ b/org-formation/050-costs/categories.yaml
@@ -1,28 +1,17 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'All Cost Categories'
+Parameters:
+  OwnerEmailRulesJSON:
+    Type: String
+    Description: JSON string representing the Rules for the 'Owner Email' Cost Category
+
 Resources:
   OwnerEmailCostCategory:
     Type: 'AWS::CE::CostCategory'
     Properties:
       Name: 'Owner Email'
       RuleVersion: 'CostCategoryExpression.v1'
-      Rules: >-
-        [
-          {
-            "Type": "INHERITED_VALUE",
-            "InheritedValue": {
-              "DimensionName": "TAG",
-              "DimensionKey": "synapse:email"
-            }
-          },
-          {
-            "Type": "INHERITED_VALUE",
-            "InheritedValue": {
-              "DimensionName": "TAG",
-              "DimensionKey": "OwnerEmail"
-            }
-          }
-        ]
+      Rules: !Ref OwnerEmailRulesJSON
 
   ProgramCodeCostCategory:
     Type: 'AWS::CE::CostCategory'


### PR DESCRIPTION
Switch from hard-coded inherit rules to our rule-generating lambda so that we also add account-tag rules for the category.
