### PR TITLE
PLFM-7740: Add role to let users access Athena in Synapse prod account

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -541,15 +541,7 @@ SsoSynapseProdAthenaUser:
                     "athena:ListDatabases",
                     "athena:ListDataCatalogs",
                     "athena:ListTableMetadata",
-                    "athena:ListWorkGroups"
-                ],
-                "Resource": [
-                    "*"
-                ]
-            },
-            {
-                "Effect": "Allow",
-                "Action": [
+                    "athena:ListWorkGroups",
                     "athena:GetQueryExecution",
                     "athena:GetQueryResults",
                     "athena:GetWorkGroup",

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -532,41 +532,63 @@ SsoSynapseProdAthenaUser:
       {
         "Version": "2012-10-17",
         "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "athena:GetDatabase",
-                    "athena:GetDataCatalog",
-                    "athena:GetTableMetadata",
-                    "athena:ListDatabases",
-                    "athena:ListDataCatalogs",
-                    "athena:ListTableMetadata",
-                    "athena:ListWorkGroups",
-                    "athena:GetQueryExecution",
-                    "athena:GetQueryResults",
-                    "athena:GetWorkGroup",
-                    "athena:StartQueryExecution",
-                    "athena:StopQueryExecution"
-                ],
-                "Resource": [
-                    "*"
-                ]
-            },
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "glue:GetDatabase",
-                    "glue:GetDatabases",
-                    "glue:GetTable",
-                    "glue:GetTables",
-                    "glue:GetPartition",
-                    "glue:GetPartitions",
-                    "glue:BatchGetPartition"
-                ],
-                "Resource": [
-                    "*"
-                ]
-            },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "athena:ListDataCatalogs",
+                "athena:ListWorkGroups"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "athena:GetDataCatalog",
+                "athena:ListDatabases",
+                "athena:GetDatabase",
+                "athena:GetTableMetadata",
+                "athena:ListTableMetadata"
+            ],
+            "Resource": [
+                "arn:aws:athena:us-east-1:325565585839:datacatalog",
+                "arn:aws:athena:us-east-1:325565585839:datacatalog/AwsDataCatalog"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "glue:GetDatabases",
+                "glue:GetDatabase",
+                "glue:GetTables",
+                "glue:GetTable",
+                "glue:GetPartitions",
+                "glue:GetPartition",
+                "glue:BatchGetPartition"
+            ],
+            "Resource": [
+                "arn:aws:glue:us-east-1:325565585839:catalog",
+                "arn:aws:glue:us-east-1:325565585839:database/datawarehouse",
+                "arn:aws:glue:us-east-1:325565585839:table/datawarehouse/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "athena:StartQueryExecution",
+                "athena:GetQueryExecution",
+                "athena:StopQueryExecution",
+                "athena:GetQueryResults",
+                "athena:GetWorkGroup",
+                "athena:GetQueryResultsStream",
+                "athena:GetQueryRuntimeStatistics",
+                "athena:ListQueryExecutions"
+            ],
+            "Resource": [
+                "arn:aws:athena:us-east-1:325565585839:workgroup/primary"
+            ]
+        },
             {
                 "Effect": "Allow",
                 "Action": [

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -93,6 +93,10 @@ Parameters:
     Type: String
     Default: '906769aa66-f671b9c2-3131-4051-b712-4668914bbfe0'
 
+  synapseProdAthenaGroup:     #JC aws-synapseprod-athena-users
+    Type: String
+    Default: '74c8e468-b0d1-702d-5d09-f2193ebf20c3'
+
   imageCentralAmiLibrarianGroup:   #JC aws-imagecentral-ami-librarians
     Type: String
     Default: '906769aa66-8bfbe918-2d30-467e-9e98-92232e9f8410'
@@ -503,6 +507,105 @@ SsoApplicationManager:
       - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
       - arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess
       - arn:aws:iam::aws:policy/SecretsManagerReadWrite
+
+# Role for a user that can only access AWS Athena
+SsoSynapseProdAthenaUser:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.1/templates/SSO/aws-sso.njk
+  TemplatingContext: {}
+  StackName: !Sub '${resourcePrefix}-${appName}-synapse-prod-athena-user'
+  StackDescription: 'Access to AWS Athena in Synapse Prod account'
+  TerminationProtection: false
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: '*'
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref synapseProdAthenaGroup
+    permissionSetName: 'athena-user'
+    sessionDuration: 'PT12H'
+    masterAccountId: !Ref MasterAccount
+    inlinePolicy: >-
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "athena:GetDatabase",
+                    "athena:GetDataCatalog",
+                    "athena:GetTableMetadata",
+                    "athena:ListDatabases",
+                    "athena:ListDataCatalogs",
+                    "athena:ListTableMetadata",
+                    "athena:ListWorkGroups"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "athena:GetQueryExecution",
+                    "athena:GetQueryResults",
+                    "athena:GetWorkGroup",
+                    "athena:StartQueryExecution",
+                    "athena:StopQueryExecution"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "glue:GetDatabase",
+                    "glue:GetDatabases",
+                    "glue:GetTable",
+                    "glue:GetTables",
+                    "glue:GetPartition",
+                    "glue:GetPartitions",
+                    "glue:BatchGetPartition"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetBucketLocation",
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:ListBucketMultipartUploads",
+                    "s3:ListMultipartUploadParts",
+                    "s3:AbortMultipartUpload",
+                    "s3:PutObject"
+                ],
+                "Resource": [
+                    "arn:aws:s3:::athena-query-results-*",
+                    "arn:aws:s3:::athena-queries.sagebase.org",
+                    "arn:aws:s3:::athena-queries.sagebase.org/*"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetBucketLocation",
+                    "s3:GetObject",
+                    "s3:ListBucket"
+                ],
+                "Resource": [
+                    "arn:aws:s3:::datawarehouse.sagebase.org",
+                    "arn:aws:s3:::datawarehouse.sagebase.org/*"
+                ]
+            }
+        ]
+      }
 
 SsoViewerSupporter:
   Type: update-stacks

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -587,9 +587,10 @@ SsoSynapseProdAthenaUser:
                     "s3:PutObject"
                 ],
                 "Resource": [
-                    "arn:aws:s3:::athena-query-results-*",
-                    "arn:aws:s3:::athena-queries.sagebase.org",
-                    "arn:aws:s3:::athena-queries.sagebase.org/*"
+                    "arn:aws:s3:::aws-athena-query-results-325565585839-us-east-1",
+                    "arn:aws:s3:::aws-athena-query-results-325565585839-us-east-1/*",
+                    "arn:aws:s3:::prod.athena-queries.sagebase.org",
+                    "arn:aws:s3:::prod.athena-queries.sagebase.org/*"
                 ]
             },
             {
@@ -600,8 +601,8 @@ SsoSynapseProdAthenaUser:
                     "s3:ListBucket"
                 ],
                 "Resource": [
-                    "arn:aws:s3:::datawarehouse.sagebase.org",
-                    "arn:aws:s3:::datawarehouse.sagebase.org/*"
+                    "arn:aws:s3:::prod.datawarehouse.sagebase.org",
+                    "arn:aws:s3:::prod.datawarehouse.sagebase.org/*"
                 ]
             }
         ]


### PR DESCRIPTION
PLFM-7740
This gives a group, authenticated through JumpCloud, access to the Synapse prod' account, but only for the purpose of running Athena queries related to the Synapse data warehouse.  I.e. the only accessible data source is `AwsDataCatalog`, the only accessible database is `datawarehouse` and the only accessible Work Group is the `primary` workgroup.
