### PR TITLE
IT-2754: Give 'application managers' read-only access to Certificate Manager

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -503,6 +503,7 @@ SsoApplicationManager:
       - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
       - arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess
       - arn:aws:iam::aws:policy/SecretsManagerReadWrite
+      - arn:aws:iam::aws:policy/AWSCertificateManagerReadOnly
 
 SsoViewerSupporter:
   Type: update-stacks


### PR DESCRIPTION
Give 'application managers' read-only access to Certificate Manager to allow them to configure the CNAME for their CDK-based application.