### PR TITLE
[SC-406] Add needed "lambda:TagResource" permission

### DIFF
--- a/sceptre/scipool/templates/sc-s3-launchrole.yaml
+++ b/sceptre/scipool/templates/sc-s3-launchrole.yaml
@@ -51,6 +51,7 @@ Resources:
                   - "lambda:AddPermission"
                   - "lambda:RemovePermission"
                   - "lambda:InvokeFunction"
+                  - "lambda:TagResource"
                   - "cloudformation:DescribeStackResource"
                   - "cloudformation:DescribeStackResources"
                   - "cloudformation:GetTemplate"


### PR DESCRIPTION
Allow the service catalog role to tag the lambda created for restricting region downloads.