### PR TITLE
PLFM-7740 fixed account binding

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -522,7 +522,7 @@ SsoSynapseProdAthenaUser:
     IncludeMasterAccount: true
   OrganizationBindings:
     TargetBinding:
-      Account: '*'
+      Account: !Ref SynapseProdAccount
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref synapseProdAthenaGroup


### PR DESCRIPTION
Accidentally deployed for all accounts instead of just the Synapse prod account.