### PR TITLE
IT-2827: Allow dccvalidator_AMP-AD-infra repo' to deploy to AWS

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -216,6 +216,26 @@ GithubOidcSageBionetworksDccValidatorPECInfra:
       - !Ref DccvalidatorProdAccount
     Region: us-east-1
 
+GithubOidcSageBionetworksDccValidatorAMPADInfra:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: github-oidc-provider-access.njk
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-amp-ad-infra
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "dccvalidator_AMP-AD-infra"
+        branch: "*"
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref DccvalidatorDevAccount
+      - !Ref DccvalidatorProdAccount
+    Region: us-east-1
+
 GithubOidcSageBionetworksDccMonitorInfra:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks


### PR DESCRIPTION
Allow dccvalidator_AMP-AD-infra repo' to deploy to AWS using OIDC integration.