### PR TITLE
IT-2827 Adding CNAME forwarding for AMP-AD dccvalidator/dccmonitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,4 +144,3 @@ org-formation/200-baseline/cdk-bootstrap.json
 org-formation/200-baseline/tmptemplate.json
 
 .project
-

--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ lerna-debug.log
 # auto generated files
 org-formation/200-baseline/cdk-bootstrap.json
 org-formation/200-baseline/tmptemplate.json
+
+.project
+

--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -224,6 +224,24 @@ DccValidatorPECDevAppDnsForward:
     # the value of the CNAME record
     TargetHostName: !CopyValue ['dccvalidator-pec-dev-DockerFargateStack-LoadBalancerDNS', !Ref DccvalidatorDevAccount]
 
+# forward https://dccvalidator-amp-ad-dev.app.sagebionetworks.org to dccvalidator-amp-ad-infra ALB
+# https://github.com/Sage-Bionetworks/dccvalidator_AMP-AD-infra
+DccValidatorAMPADdevAppDnsForward:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/R53/cname.yaml
+  StackName: !Sub '${resourcePrefix}-dccvalidator-amp-ad-dev-cname'
+  StackDescription: Setup a CNAME for dccvalidator_AMP-AD-infra dev ALB
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref SageITAccount
+  Parameters:
+    # the name of the CNAME record
+    SourceHostName: "dccvalidator-amp-ad-dev.app.sagebionetworks.org"
+    # ID of the app.sagebionetworks.org zone (in sageit account)
+    SourceHostedZoneId: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sagebio-app-zone-HostedZoneId']
+    # the value of the CNAME record
+    TargetHostName: !CopyValue ['dccvalidator-amp-ad-dev-DockerFargateStack-LoadBalancerDNS', !Ref DccvalidatorDevAccount]
+
 # forward https://dccmonitor-1kD-dev.app.sagebionetworks.org to dccmonitor_ECS-infra 1kD dev ALB
 # https://github.com/Sage-Bionetworks/dccmonitor_ECS-infra
 DccMonitor1kDDevAppDnsForward:
@@ -259,6 +277,24 @@ DccMonitorPECDevAppDnsForward:
     SourceHostedZoneId: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sagebio-app-zone-HostedZoneId']
     # the value of the CNAME record
     TargetHostName: !CopyValue ['dccmonitor-pec-pec-dev-DockerFargateStack-LoadBalancerDNS', !Ref DccvalidatorDevAccount]
+
+# forward https://dccmonitor-amp-ad-dev.app.sagebionetworks.org to dccmonitor_ECS-infra AMP-AD dev ALB
+# https://github.com/Sage-Bionetworks/dccmonitor_ECS-infra
+DccMonitorAMPADDevAppDnsForward:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/R53/cname.yaml
+  StackName: !Sub '${resourcePrefix}-dccmonitor-amp-ad-dev-cname'
+  StackDescription: Setup a CNAME for dccmonitor_ECS-infra AMP-AD dev ALB
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref SageITAccount
+  Parameters:
+    # the name of the CNAME record
+    SourceHostName: "dccmonitor-amp-ad-dev.app.sagebionetworks.org"
+    # ID of the app.sagebionetworks.org zone (in sageit account)
+    SourceHostedZoneId: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sagebio-app-zone-HostedZoneId']
+    # the value of the CNAME record
+    TargetHostName: !CopyValue ['dccmonitor-amp-ad-amp-ad-dev-DockerFargateStack-LoadBalancerDNS', !Ref DccvalidatorDevAccount]
 
 # forward https://dccvalidator-1kD.app.sagebionetworks.org to dccvalidator-1kD-infra ALB
 # https://github.com/Sage-Bionetworks/dccvalidator_1kD-infra


### PR DESCRIPTION
Adding CNAME forwarding for AMP-AD dccvalidator/dccmonitor:

dccvalidator-amp-ad-dev.app.sagebionetworks.org

dccmonitor-amp-ad-dev.app.sagebionetworks.org