### PR TITLE
[IT-2768] make OIDC template support multi repos

### DIFF
--- a/org-formation/650-identity-providers/README.md
+++ b/org-formation/650-identity-providers/README.md
@@ -11,6 +11,25 @@ and have it reviewed and approved. Note the following important parameters:
 * DefaultOrganizationBinding - Set this to the AWS accounts that your repo will deploy to.
 * ManagedPolicyArns - Allows the repo to access the AWS accounts with an AWS managed policy.
 * PolicyDocument - Allows the repo to access the AWS accounts with an AWS custom policy.
+* GitHubOrg - The Github organization to allow OIDC access (i.e. "Sage-Bionetworks")
+* Repositories - A dictionary list of repositories and branches in the GitHubOrg to allow OIDC access
+
+Example to allow GH OIDC in Sage-Bionetworks/repoA and Sage-Bionetworks/repoB in AWS AccountX and AWS AccountY:
+```yaml
+TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "repoA"
+        branches: ["dev","prod"]
+      - name: "repoB"
+        branches: ["*"]
+DefaultOrganizationBinding:
+    Account:
+      - !Ref AccountX
+      - !Ref AccountY
+    Region: us-east-1
+```
+NOTE: `*` indicates all branches.
 
   Please take care to set a [least privileged policy](https://csrc.nist.gov/glossary/term/least_privilege) for your OIDC integration.
 
@@ -30,7 +49,7 @@ in a github action to assume a role.
 Example using [configure-aws-credentials GH action](https://github.com/aws-actions/configure-aws-credentials):
 ```
   - name: Assume AWS Role
-    uses: aws-actions/configure-aws-credentials@v1
+    uses: aws-actions/configure-aws-credentials@v2
     with:
       aws-region: us-east-1
       role-to-assume: arn:aws:iam::XXXXXXXX:role/sagebase-github-oidc-sage-ProviderRoleXXXXXXXX-XXXXXXXX

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -423,7 +423,7 @@ GithubOidcSciPoolDevSageBionetworksSynapseLoginAwsInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-scipool-dev-synapse-login-aws-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-scipool-dev-sage-bionetworks-synapse-login-aws-infra
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-scipool-dev-synapse-login-aws-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -442,7 +442,7 @@ GithubOidcBmgfkiSageBionetworksSynapseLoginAwsInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-bmgfki-synapse-login-aws-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-bmgfki-sage-bionetworks-synapse-login-aws-infra
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-bmgfki-synapse-login-aws-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -404,7 +404,7 @@ GithubOidcSciPoolProdSageBionetworksSynapseLoginAwsInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-scipool-prod-sage-bionetworks-synapse-login-aws-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-scipool-prod-sage-bionetworks-synapse-login-aws-infra
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-scipool-prod-synapse-login-aws-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -420,7 +420,7 @@ GithubOidcSciPoolDevSageBionetworksSynapseLoginAwsInfra:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks
   Template: github-oidc-provider-access.njk
-  StackName: !Sub ${resourcePrefix}-${appName}-scipool-dev-sage-bionetworks-synapse-login-aws-infra
+  StackName: !Sub ${resourcePrefix}-${appName}-scipool-dev-synapse-login-aws-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ProviderRoleName: !Sub ${resourcePrefix}-${appName}-scipool-dev-sage-bionetworks-synapse-login-aws-infra
@@ -439,7 +439,7 @@ GithubOidcBmgfkiSageBionetworksSynapseLoginAwsInfra:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks
   Template: github-oidc-provider-access.njk
-  StackName: !Sub ${resourcePrefix}-${appName}-bmgfki-sage-bionetworks-synapse-login-aws-infra
+  StackName: !Sub ${resourcePrefix}-${appName}-bmgfki-synapse-login-aws-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ProviderRoleName: !Sub ${resourcePrefix}-${appName}-bmgfki-sage-bionetworks-synapse-login-aws-infra
@@ -502,7 +502,7 @@ GithubOidcSageBionetworksSynapseProdWebMonorepoInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapseprod-web-monorepo-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapseprod-web-monorepo-infra
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-synapseprod-web-monorepo-infra
     PolicyDocument: |
       {
         "Version": "2012-10-17",

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -25,6 +25,7 @@ GithubOidcSageBionetworksIt:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-it
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-it
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -44,6 +45,7 @@ GithubOidcSageBionetworksRecover:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-recover
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-recover
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -64,6 +66,7 @@ GithubOidcSageBionetworksDataCuratorInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-data-curator-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-data-curator-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -84,6 +87,7 @@ GithubOidcSageBionetworksSchematicInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-schematic-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-schematic-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -104,6 +108,7 @@ GithubOidcSageBionetworksGenieBPCInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-genie-bpc-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-genie-bpc-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -124,6 +129,7 @@ GithubOidcSageBionetworksSimpleShinyInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-simple-shiny-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-simple-shiny-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -143,6 +149,7 @@ GithubOidcSageBionetworksDNTInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dnt-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dnt-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -163,6 +170,7 @@ GithubOidcSageBionetworksDPEAirflowInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dpe-airflow-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dpe-airflow-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -183,6 +191,7 @@ GithubOidcSageBionetworksS3FileHostingInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-s3-file-hosting-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-s3-file-hosting-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -202,6 +211,7 @@ GithubOidcSageBionetworksDccValidator1kDInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-1kD-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-1kD-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -222,6 +232,7 @@ GithubOidcSageBionetworksDccValidatorPECInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-pec-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-1kD-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -242,6 +253,7 @@ GithubOidcSageBionetworksDccValidatorAMPADInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-amp-ad-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-amp-ad-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -262,6 +274,7 @@ GithubOidcSageBionetworksDccMonitorInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccmonitor-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccmonitor-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -282,6 +295,7 @@ GithubOidcSageBionetworksSecuityHubToJira:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-security-hub-to-jira
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-security-hub-to-jira
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AWSSecurityHubReadOnlyAccess"
   TemplatingContext:
@@ -301,6 +315,7 @@ GithubOidcSageBionetworksAwsInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-awsinfra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-awsinfra
     PolicyDocument: |
       {
         "Version": "2012-10-17",
@@ -335,6 +350,7 @@ GithubOidcSageBionetworksScicompProvisioner:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-scicomp-provisioner
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-scicomp-provisioner
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -353,6 +369,7 @@ GithubOidcSageBionetworksServiceCatalogLibrary:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-service-catalog-library
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-service-catalog-library
     PolicyDocument: |
       {
         "Version": "2012-10-17",
@@ -387,6 +404,7 @@ GithubOidcSciPoolProdSageBionetworksSynapseLoginAwsInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-scipool-prod-sage-bionetworks-synapse-login-aws-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-scipool-prod-sage-bionetworks-synapse-login-aws-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -405,6 +423,7 @@ GithubOidcSciPoolDevSageBionetworksSynapseLoginAwsInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-scipool-dev-sage-bionetworks-synapse-login-aws-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-scipool-dev-sage-bionetworks-synapse-login-aws-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -423,6 +442,7 @@ GithubOidcBmgfkiSageBionetworksSynapseLoginAwsInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-bmgfki-sage-bionetworks-synapse-login-aws-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-bmgfki-sage-bionetworks-synapse-login-aws-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -441,6 +461,7 @@ GithubOidcSageBionetworksWebMonorepoInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-web-monorepo-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-web-monorepo-infra
     PolicyDocument: |
       {
         "Version": "2012-10-17",
@@ -481,6 +502,7 @@ GithubOidcSageBionetworksSynapseProdWebMonorepoInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapseprod-web-monorepo-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapseprod-web-monorepo-infra
     PolicyDocument: |
       {
         "Version": "2012-10-17",

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -232,7 +232,7 @@ GithubOidcSageBionetworksDccValidatorPECInfra:
   StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-pec-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-1kD-infra
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-pec-infra
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
   TemplatingContext:
@@ -401,7 +401,7 @@ GithubOidcSciPoolProdSageBionetworksSynapseLoginAwsInfra:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks
   Template: github-oidc-provider-access.njk
-  StackName: !Sub ${resourcePrefix}-${appName}-scipool-prod-sage-bionetworks-synapse-login-aws-infra
+  StackName: !Sub ${resourcePrefix}-${appName}-scipool-prod-synapse-login-aws-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ProviderRoleName: !Sub ${resourcePrefix}-${appName}-scipool-prod-synapse-login-aws-infra

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -31,7 +31,7 @@ GithubOidcSageBionetworksIt:
     GitHubOrg: "Sage-Bionetworks-IT"
     Repositories:
       - name: "organizations-infra"
-        branch: "master"
+        branches: ["master"]
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'
@@ -50,7 +50,7 @@ GithubOidcSageBionetworksRecover:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "recover"
-        branch: "*"
+        branches: ["*"]
   DefaultOrganizationBinding:
     Account:
       - !Ref RecoverProdAccount
@@ -70,7 +70,7 @@ GithubOidcSageBionetworksDataCuratorInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "data_curator-infra"
-        branch: "*"
+        branches: ["*"]
   DefaultOrganizationBinding:
     Account:
       - !Ref DnTDevAccount
@@ -90,7 +90,7 @@ GithubOidcSageBionetworksSchematicInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "schematic-infra"
-        branch: "*"
+        branches: ["*"]
   DefaultOrganizationBinding:
     Account:
       - !Ref DnTDevAccount
@@ -110,7 +110,7 @@ GithubOidcSageBionetworksGenieBPCInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "genie-bpc-infra"
-        branch: "*"
+        branches: ["*"]
   DefaultOrganizationBinding:
     Account:
       - !Ref DnTDevAccount
@@ -130,7 +130,7 @@ GithubOidcSageBionetworksSimpleShinyInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "simple-shiny-infra"
-        branch: "*"
+        branches: ["*"]
   DefaultOrganizationBinding:
     Account:
       - !Ref DnTDevAccount
@@ -149,7 +149,7 @@ GithubOidcSageBionetworksDNTInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "dnt-infra"
-        branch: "*"
+        branches: ["*"]
   DefaultOrganizationBinding:
     Account:
       - !Ref DpeProdAccount
@@ -169,7 +169,7 @@ GithubOidcSageBionetworksDPEAirflowInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "dpe-mwaa-deployment"
-        branch: "*"
+        branches: ["*"]
   DefaultOrganizationBinding:
     Account:
       - !Ref DpeProdAccount
@@ -189,7 +189,7 @@ GithubOidcSageBionetworksS3FileHostingInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "s3-file-hosting"
-        branch: "*"
+        branches: ["*"]
   DefaultOrganizationBinding:
     Account:
       - !Ref DnTDevAccount
@@ -208,7 +208,7 @@ GithubOidcSageBionetworksDccValidator1kDInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "dccvalidator_1kD-infra"
-        branch: "*"
+        branches: ["*"]
   DefaultOrganizationBinding:
     Account:
       - !Ref DccvalidatorDevAccount
@@ -228,7 +228,7 @@ GithubOidcSageBionetworksDccValidatorPECInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "dccvalidator_PEC-infra"
-        branch: "*"
+        branches: ["*"]
   DefaultOrganizationBinding:
     Account:
       - !Ref DccvalidatorDevAccount
@@ -248,7 +248,7 @@ GithubOidcSageBionetworksDccValidatorAMPADInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "dccvalidator_AMP-AD-infra"
-        branch: "*"
+        branches: ["*"]
   DefaultOrganizationBinding:
     Account:
       - !Ref DccvalidatorDevAccount
@@ -268,7 +268,7 @@ GithubOidcSageBionetworksDccMonitorInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "dccmonitor_ECS-infra"
-        branch: "*"
+        branches: ["*"]
   DefaultOrganizationBinding:
     Account:
       - !Ref DccvalidatorDevAccount
@@ -288,7 +288,7 @@ GithubOidcSageBionetworksSecuityHubToJira:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "security-hub-to-jira"
-        branch: "main"
+        branches: ["main"]
   DefaultOrganizationBinding:
     Account:
       - !Ref SecurityCentralAccount
@@ -323,7 +323,7 @@ GithubOidcSageBionetworksAwsInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "aws-infra"
-        branch: "master"
+        branches: ["master"]
   DefaultOrganizationBinding:
     Account: !Ref AdminCentralAccount
     Region: us-east-1
@@ -341,7 +341,7 @@ GithubOidcSageBionetworksScicompProvisioner:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "scicomp-provisioner"
-        branch: "master"
+        branches: ["master"]
   DefaultOrganizationBinding:
     Account: !Ref ScicompAccount
     Region: us-east-1
@@ -375,7 +375,7 @@ GithubOidcSageBionetworksServiceCatalogLibrary:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "service-catalog-library"
-        branch: "master"
+        branches: ["master"]
   DefaultOrganizationBinding:
     Account: !Ref AdminCentralAccount
     Region: us-east-1
@@ -393,7 +393,7 @@ GithubOidcSciPoolProdSageBionetworksSynapseLoginAwsInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "synapse-login-aws-infra"
-        branch: "prod"
+        branches: ["prod"]
   DefaultOrganizationBinding:
     Account: !Ref ScipoolProdAccount
     Region: us-east-1
@@ -411,7 +411,7 @@ GithubOidcSciPoolDevSageBionetworksSynapseLoginAwsInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "synapse-login-aws-infra"
-        branch: "develop"
+        branches: ["develop"]
   DefaultOrganizationBinding:
     Account: !Ref ScipoolDevAccount
     Region: us-east-1
@@ -429,7 +429,7 @@ GithubOidcBmgfkiSageBionetworksSynapseLoginAwsInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "synapse-login-aws-infra"
-        branch: "prod"
+        branches: ["prod"]
   DefaultOrganizationBinding:
     Account: !Ref BmgfkiAccount
     Region: us-east-1
@@ -469,7 +469,7 @@ GithubOidcSageBionetworksWebMonorepoInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "synapse-web-monorepo"
-        branch: "*"
+        branches: ["*"]
   DefaultOrganizationBinding:
     Account: !Ref SageITAccount
     Region: us-east-1
@@ -509,7 +509,7 @@ GithubOidcSageBionetworksSynapseProdWebMonorepoInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "synapse-web-monorepo"
-        branch: "*"
+        branches: ["*"]
   DefaultOrganizationBinding:
     Account: !Ref SynapseProdAccount
     Region: us-east-1

--- a/org-formation/650-identity-providers/github-oidc-provider-access.njk
+++ b/org-formation/650-identity-providers/github-oidc-provider-access.njk
@@ -66,8 +66,7 @@ Resources:
     Type: 'AWS::IAM::ManagedPolicy'
     Properties:
       PolicyDocument: !Ref PolicyDocument
-{% for Repository in Repositories %}
-  ProviderRole{{ Repository.name | replace('-','') | replace('_','') }}:
+  ProviderRole:
     Type: AWS::IAM::Role
     Properties:
       # Concatinate managed policy and custom policy
@@ -88,18 +87,17 @@ Resources:
                 token.actions.githubusercontent.com:aud: !Ref ClientIdList
               StringLike:
                 token.actions.githubusercontent.com:sub: [
-  {% if Repository.branch == '*' %}
-                  "repo:{{ GitHubOrg }}/{{ Repository.name }}:{{Repository.branch }}"
-  {% else %}
-                  "repo:{{ GitHubOrg}}/{{ Repository.name }}:ref:refs/heads/{{ Repository.branch }}",
-                  "repo:{{ GitHubOrg }}/{{ Repository.name }}:ref:refs/tags/*"
-  {% endif %}
-                ]
-{% endfor %}
-Outputs:
+
 {% for Repository in Repositories %}
-  ProviderRoleArn{{ Repository.name | replace('-','') | replace('_','') }}:
-    Value: !GetAtt ProviderRole{{ Repository.name | replace('-','') | replace('_','') }}.Arn
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ProviderRoleArn-{{ Repository.name | replace('-','') | replace('_','') }}'
+  {% for branch in Repository.branches %}
+                  "repo:{{ GitHubOrg}}/{{ Repository.name }}:ref:refs/heads/{{ branch }}",
+  {% endfor %}
+                  "repo:{{ GitHubOrg }}/{{ Repository.name }}:ref:refs/tags/*",
 {% endfor %}
+
+                ]
+Outputs:
+  ProviderRoleArn:
+    Value: !GetAtt ProviderRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ProviderRoleArn'

--- a/org-formation/650-identity-providers/github-oidc-provider-access.njk
+++ b/org-formation/650-identity-providers/github-oidc-provider-access.njk
@@ -69,6 +69,7 @@ Resources:
   ProviderRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub '${AWS::StackName}-ProviderRole'
       # Concatinate managed policy and custom policy
       ManagedPolicyArns: !Split
         - ","
@@ -98,4 +99,4 @@ Outputs:
   ProviderRoleArn:
     Value: !GetAtt ProviderRole.Arn
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ProviderRoleArn'
+      Name: !Sub '${AWS::StackName}-ProviderRoleArn'

--- a/org-formation/650-identity-providers/github-oidc-provider-access.njk
+++ b/org-formation/650-identity-providers/github-oidc-provider-access.njk
@@ -27,6 +27,10 @@ Parameters:
   ProviderArn:
     Type: String
     Description: "The OIDC provider ARN"
+  ProviderRoleName:
+    Type: String
+    Description: "The OIDC provider role name"
+    MaxLength: 64
   # Must provide either a list of ManagePolicyArns or a custom PolicyDocument.
   # Can also provide both a list of ManagePolicyArns and a custom PolicyDocument.
   ManagedPolicyArns:
@@ -69,7 +73,7 @@ Resources:
   ProviderRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub '${AWS::StackName}-ProviderRole'
+      RoleName: !Ref ProviderRoleName
       # Concatinate managed policy and custom policy
       ManagedPolicyArns: !Split
         - ","
@@ -99,4 +103,4 @@ Outputs:
   ProviderRoleArn:
     Value: !GetAtt ProviderRole.Arn
     Export:
-      Name: !Sub '${AWS::StackName}-ProviderRoleArn'
+      Name: !Sub '${ProviderRole}-ProviderRoleArn'

--- a/org-formation/650-identity-providers/github-oidc-provider-access.njk
+++ b/org-formation/650-identity-providers/github-oidc-provider-access.njk
@@ -87,14 +87,12 @@ Resources:
                 token.actions.githubusercontent.com:aud: !Ref ClientIdList
               StringLike:
                 token.actions.githubusercontent.com:sub: [
-
 {% for Repository in Repositories %}
   {% for branch in Repository.branches %}
                   "repo:{{ GitHubOrg}}/{{ Repository.name }}:ref:refs/heads/{{ branch }}",
   {% endfor %}
                   "repo:{{ GitHubOrg }}/{{ Repository.name }}:ref:refs/tags/*",
 {% endfor %}
-
                 ]
 Outputs:
   ProviderRoleArn:


### PR DESCRIPTION
Our current GH OIDC template only sets up GH OIDC for a single repository in an GH org.  This causes lots of duplication in the orgf _task.yaml file.  This update will allow setting up OIDC for multiple repos and branches which will allow us to reduce the number of entries in the _task.yaml file.

