### PR TITLE
IT-2651: Infra takes over deployment of synapse-dev-cmk stack

### DIFF
--- a/sceptre/synapsedev/templates/SynapseCMK-template.json
+++ b/sceptre/synapsedev/templates/SynapseCMK-template.json
@@ -258,21 +258,9 @@
                             "Condition": {
                                 "StringNotLike": {
                                     "aws:PrincipalArn": [
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    "arn:aws:iam::",
-                                                    {
-                                                        "Ref": "AWS::AccountId"
-                                                    },
-                                                    ":root"
-                                                ]
-                                            ]
-                                        },
-                                        "arn:aws:iam::449435941126:role*",
-                                        "arn:aws:sts::449435941126:assumed-role*"
-
+                                        { "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:root" },
+                                        { "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role*" },
+                                        { "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:assumed-role*" }
                                     ]
                                 }
                             }
@@ -291,24 +279,9 @@
                                     {
                                         "Fn::ImportValue": "us-east-1-accounts-AWSIAMAdminRoleArn"
                                     },
-                                    {
-                                        "Fn::Join": [
-                                            "",
-                                            [
-                                                "arn:aws:iam::",
-                                                {
-                                                    "Ref": "AWS::AccountId"
-                                                },
-                                                ":root"
-                                            ]
-                                        ]
-                                    },
-                                    "arn:aws:sts::449435941126:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/x.schildwachter@sagebase.org",
-                                    "arn:aws:sts::449435941126:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/john.hill@sagebase.org",
-                                    "arn:aws:sts::449435941126:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/marco.marasca@sagebase.org",
-                                    "arn:aws:sts::449435941126:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/bruce.hoff@sagebase.org",
-                                    "arn:aws:sts::449435941126:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/sandhra.sokhal@sagebase.org",
-                                    "arn:aws:iam::449435941126:role/sagebase-github-oidc-sage-ProviderRoleorganization-1K1MGUYPL5JUO"
+                                    { "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:root" },
+                                    { "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043" },
+                                    { "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role/sagebase-github-oidc-sage-ProviderRoleorganization-1K1MGUYPL5JUO" }
                                 ]
                             },
                             "Action": [

--- a/sceptre/synapsedev/templates/SynapseCMK-template.json
+++ b/sceptre/synapsedev/templates/SynapseCMK-template.json
@@ -28,6 +28,9 @@
                     ]
                 },
                 "Path": "/",
+                "ManagedPolicyArns": [
+                    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+                ],
                 "Policies": [
                     {
                         "PolicyName": "SynapseDeploymentPolicy",
@@ -243,7 +246,7 @@
                     "Id": "key-default-1",
                     "Statement": [
                         {
-                            "Sid": "Allow administration of the key",
+                            "Sid": "Deny administration of the key",
                             "Effect": "Deny",
                             "Principal": {
                                 "AWS": "*"
@@ -254,57 +257,22 @@
                             "Resource": "*",
                             "Condition": {
                                 "StringNotLike": {
-                                    "aws:userid": [
+                                    "aws:PrincipalArn": [
                                         {
                                             "Fn::Join": [
                                                 "",
                                                 [
+                                                    "arn:aws:iam::",
                                                     {
-                                                        "Fn::GetAtt": [
-                                                            "SynapseDeploymentRole",
-                                                            "RoleId"
-                                                        ]
+                                                        "Ref": "AWS::AccountId"
                                                     },
-                                                    ":*"
+                                                    ":root"
                                                 ]
                                             ]
                                         },
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    {
-                                                        "Fn::ImportValue": "us-east-1-accounts-AWSIAMAdminRoleId"
-                                                    },
-                                                    ":*"
-                                                ]
-                                            ]
-                                        },
-                                        {
-                                            "Ref": "AWS::AccountId"
-                                        },
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    {
-                                                        "Fn::ImportValue": "us-east-1-jumpcloud-idp-SynapseDevDeveloperSamlProviderRoleId"
-                                                    },
-                                                    ":*"
-                                                ]
-                                            ]
-                                        },
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    {
-                                                        "Fn::ImportValue": "us-east-1-jumpcloud-idp-SynapseDevAdminSamlProviderRoleId"
-                                                    },
-                                                    ":*"
-                                                ]
-                                            ]
-                                        }
+                                        "arn:aws:iam::449435941126:role*",
+                                        "arn:aws:sts::449435941126:assumed-role*"
+
                                     ]
                                 }
                             }
@@ -335,12 +303,12 @@
                                             ]
                                         ]
                                     },
-                                    {
-                                        "Fn::ImportValue": "us-east-1-jumpcloud-idp-SynapseDevDeveloperSamlProviderRoleArn"
-                                    },
-                                    {
-                                        "Fn::ImportValue": "us-east-1-jumpcloud-idp-SynapseDevAdminSamlProviderRoleArn"
-                                    }
+                                    "arn:aws:sts::449435941126:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/x.schildwachter@sagebase.org",
+                                    "arn:aws:sts::449435941126:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/john.hill@sagebase.org",
+                                    "arn:aws:sts::449435941126:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/marco.marasca@sagebase.org",
+                                    "arn:aws:sts::449435941126:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/bruce.hoff@sagebase.org",
+                                    "arn:aws:sts::449435941126:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/sandhra.sokhal@sagebase.org",
+                                    "arn:aws:iam::449435941126:role/sagebase-github-oidc-sage-ProviderRoleorganization-1K1MGUYPL5JUO"
                                 ]
                             },
                             "Action": [

--- a/sceptre/synapsedev/templates/SynapseCMK-template.json
+++ b/sceptre/synapsedev/templates/SynapseCMK-template.json
@@ -280,8 +280,13 @@
                                         "Fn::ImportValue": "us-east-1-accounts-AWSIAMAdminRoleArn"
                                     },
                                     { "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:root" },
-                                    { "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043" },
-                                    { "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role/sagebase-github-oidc-sage-ProviderRoleorganization-1K1MGUYPL5JUO" }
+                                    { "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role/sagebase-github-oidc-sage-ProviderRoleorganization-1K1MGUYPL5JUO" },
+                                    { "Fn::Sub": "arn:aws:sts::${AWS::AccountId}:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/x.schildwachter@sagebase.org" },
+                                    { "Fn::Sub": "arn:aws:sts::${AWS::AccountId}:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/john.hill@sagebase.org" },
+                                    { "Fn::Sub": "arn:aws:sts::${AWS::AccountId}:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/marco.marasca@sagebase.org" },
+                                    { "Fn::Sub": "arn:aws:sts::${AWS::AccountId}:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/bruce.hoff@sagebase.org" },
+                                    { "Fn::Sub": "arn:aws:sts::${AWS::AccountId}:assumed-role/AWSReservedSSO_Administrator_693a85eb20cd5043/sandhra.sokhal@sagebase.org" }
+
                                 ]
                             },
                             "Action": [


### PR DESCRIPTION
The synapse-dev-cmk stack sets up the deployer role assumed by the Jenkins system in the dev account, it also sets up the root encryption key used to encrypt the secrets (in SecretMgr) used by the Synapse Stack builder. The key was managed by an IAM role (to be deleted), the policy has been modified to give access to users with admin SSO access, to root (as before), to the deployment role (as before) and to the OIDC role (so we can deploy using infra).
This template was run already from the IAM role to give permissions to SSO/OIDC.

This PR is just to setup the deployment in the infra (Cloudformation should not detect any change).

