### PR TITLE
Fix github OIDC configuration

### DIFF
--- a/org-formation/650-identity-providers/github-oidc-provider-access.njk
+++ b/org-formation/650-identity-providers/github-oidc-provider-access.njk
@@ -94,7 +94,11 @@ Resources:
                 token.actions.githubusercontent.com:sub: [
 {% for Repository in Repositories %}
   {% for branch in Repository.branches %}
+      {% if branch == '*' %}
+                  "repo:{{ GitHubOrg}}/{{ Repository.name }}:{{ branch }}",
+      {% else %}
                   "repo:{{ GitHubOrg}}/{{ Repository.name }}:ref:refs/heads/{{ branch }}",
+      {% endif %}
   {% endfor %}
                   "repo:{{ GitHubOrg }}/{{ Repository.name }}:ref:refs/tags/*",
 {% endfor %}


### PR DESCRIPTION
There was a bug in PR #859 where we were setting '*' condition for branches incorrectly.  According to the AWS docs[1], granting access to all branches does not include the refs.

"The following example condition limits access to the defined GitHub organization and repository, but grants access to any branch within the repository"
```
"Condition": {
  "StringLike": {
    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
    "token.actions.githubusercontent.com:sub": "repo:GitHubOrg/GitHubRepo:*"
  }
}
```

[1] https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html

