### PR TITLE
Fix tag option stacks

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-tag-options-external.yaml
@@ -9,5 +9,6 @@ dependencies:
   - "bmgfki/sc-portfolio-ec2-external.yaml"
   - "bmgfki/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
+  CostCenters: ["NO PROGRAM / 000000"]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/sceptre/scipool/config/bmgfki/sc-tag-options.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-tag-options.yaml
@@ -9,6 +9,7 @@ dependencies:
   - "bmgfki/sc-portfolio-ec2-external.yaml"
   - "bmgfki/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
+  CostCenters: ["NO PROGRAM / 000000"]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/sceptre/scipool/config/develop/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/develop/sc-tag-options-external.yaml
@@ -9,5 +9,6 @@ dependencies:
   - "develop/sc-portfolio-ec2-external.yaml"
   - "develop/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
+  CostCenters: ["NO PROGRAM / 000000"]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/sceptre/scipool/config/prod/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/prod/sc-tag-options-external.yaml
@@ -9,5 +9,6 @@ dependencies:
   - "prod/sc-portfolio-ec2-external.yaml"
   - "prod/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
+  CostCenters: ["NO PROGRAM / 000000"]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/sceptre/scipool/config/strides/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/strides/sc-tag-options-external.yaml
@@ -9,5 +9,6 @@ dependencies:
   - "strides/sc-portfolio-ec2-external.yaml"
   - "strides/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
+  CostCenters: ["NO PROGRAM / 000000"]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/sceptre/scipool/config/strides/sc-tag-options.yaml
+++ b/sceptre/scipool/config/strides/sc-tag-options.yaml
@@ -10,6 +10,7 @@ dependencies:
   - "strides/sc-portfolio-s3-basic.yaml"
   - "strides/sc-portfolio-scheduled-jobs.yaml"
 sceptre_user_data:
+  CostCenters: ["NO PROGRAM / 000000"]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId


### PR DESCRIPTION
The deployment is failing with message..
```
"An error occurred (ValidationError) when calling the UpdateStack operation:
[/Resources] 'null' values are not allowed in templates"
```

Passing in a value for CostCenters fixes this problem.

