### PR TITLE
Revert "Fix tag option stacks (#871)"

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-tag-options-external.yaml
@@ -9,6 +9,5 @@ dependencies:
   - "bmgfki/sc-portfolio-ec2-external.yaml"
   - "bmgfki/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
-  CostCenters: ["NO PROGRAM / 000000"]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/sceptre/scipool/config/bmgfki/sc-tag-options.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-tag-options.yaml
@@ -9,7 +9,6 @@ dependencies:
   - "bmgfki/sc-portfolio-ec2-external.yaml"
   - "bmgfki/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
-  CostCenters: ["NO PROGRAM / 000000"]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/sceptre/scipool/config/develop/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/develop/sc-tag-options-external.yaml
@@ -9,6 +9,5 @@ dependencies:
   - "develop/sc-portfolio-ec2-external.yaml"
   - "develop/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
-  CostCenters: ["NO PROGRAM / 000000"]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/sceptre/scipool/config/prod/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/prod/sc-tag-options-external.yaml
@@ -9,6 +9,5 @@ dependencies:
   - "prod/sc-portfolio-ec2-external.yaml"
   - "prod/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
-  CostCenters: ["NO PROGRAM / 000000"]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/sceptre/scipool/config/strides/sc-tag-options-external.yaml
+++ b/sceptre/scipool/config/strides/sc-tag-options-external.yaml
@@ -9,6 +9,5 @@ dependencies:
   - "strides/sc-portfolio-ec2-external.yaml"
   - "strides/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
-  CostCenters: ["NO PROGRAM / 000000"]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/sceptre/scipool/config/strides/sc-tag-options.yaml
+++ b/sceptre/scipool/config/strides/sc-tag-options.yaml
@@ -10,7 +10,6 @@ dependencies:
   - "strides/sc-portfolio-s3-basic.yaml"
   - "strides/sc-portfolio-scheduled-jobs.yaml"
 sceptre_user_data:
-  CostCenters: ["NO PROGRAM / 000000"]
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId


### PR DESCRIPTION
This reverts commit f82730158217b558ce1c29cbc81b072add225fca. 

revert because duplicate tags are not allowed.
```
develop/sc-tag-options-external NOPROGRAM000000CostCenterTag
AWS::ServiceCatalog::TagOption CREATE_FAILED CostCenter|NO PROGRAM / 000000 already exists in stack
arn:aws:cloudformation:us-east-1:465877038949:stack/sc-tag-options/f8245460-6dc8-11ec-a4e0-1289ac4902b3
```
