### PR TITLE
Consolidate GH OIDC defintions for DCC

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -218,10 +218,10 @@ GithubOidcDccValidatorDeploy:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks
   Template: github-oidc-provider-access.njk
-  StackName: !Sub ${resourcePrefix}-${appName}-dcc-validator-deploy
+  StackName: !Sub ${resourcePrefix}-${appName}-dccvalidator-deploy
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-dcc-validator-deploy
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-dccvalidator-deploy
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
       - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -213,14 +213,15 @@ GithubOidcSageBionetworksS3FileHostingInfra:
       - !Ref DnTDevAccount
     Region: us-east-1
 
-GithubOidcSageBionetworksDccValidator1kDInfra:
+# GH OIDC for DCC validator to AWS DccvalidatorDev and DccvalidatorProd accounts
+GithubOidcDccValidatorDeploy:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks
   Template: github-oidc-provider-access.njk
-  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-1kD-infra
+  StackName: !Sub ${resourcePrefix}-${appName}-dcc-validator-deploy
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-1kD-infra
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-dcc-validator-deploy
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
       - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
@@ -228,73 +229,13 @@ GithubOidcSageBionetworksDccValidator1kDInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "dccvalidator_1kD-infra"
-        branches: ["*"]
-  DefaultOrganizationBinding:
-    Account:
-      - !Ref DccvalidatorDevAccount
-      - !Ref DccvalidatorProdAccount
-    Region: us-east-1
-
-GithubOidcSageBionetworksDccValidatorPECInfra:
-  Type: update-stacks
-  DependsOn: GithubOidcSageBionetworks
-  Template: github-oidc-provider-access.njk
-  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-pec-infra
-  Parameters:
-    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-pec-infra
-    ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AdministratorAccess"
-      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
-  TemplatingContext:
-    GitHubOrg: "Sage-Bionetworks"
-    Repositories:
+        branches: ["dev", "prod"]
       - name: "dccvalidator_PEC-infra"
-        branches: ["*"]
-  DefaultOrganizationBinding:
-    Account:
-      - !Ref DccvalidatorDevAccount
-      - !Ref DccvalidatorProdAccount
-    Region: us-east-1
-
-GithubOidcSageBionetworksDccValidatorAMPADInfra:
-  Type: update-stacks
-  DependsOn: GithubOidcSageBionetworks
-  Template: github-oidc-provider-access.njk
-  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-amp-ad-infra
-  Parameters:
-    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccvalidator-amp-ad-infra
-    ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AdministratorAccess"
-      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
-  TemplatingContext:
-    GitHubOrg: "Sage-Bionetworks"
-    Repositories:
+        branches: ["dev", "prod"]
       - name: "dccvalidator_AMP-AD-infra"
-        branches: ["*"]
-  DefaultOrganizationBinding:
-    Account:
-      - !Ref DccvalidatorDevAccount
-      - !Ref DccvalidatorProdAccount
-    Region: us-east-1
-
-GithubOidcSageBionetworksDccMonitorInfra:
-  Type: update-stacks
-  DependsOn: GithubOidcSageBionetworks
-  Template: github-oidc-provider-access.njk
-  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccmonitor-infra
-  Parameters:
-    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-dccmonitor-infra
-    ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AdministratorAccess"
-      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
-  TemplatingContext:
-    GitHubOrg: "Sage-Bionetworks"
-    Repositories:
+        branches: ["dev", "prod"]
       - name: "dccmonitor_ECS-infra"
-        branches: ["*"]
+        branches: ["dev", "prod"]
   DefaultOrganizationBinding:
     Account:
       - !Ref DccvalidatorDevAccount


### PR DESCRIPTION
DCC apps all deploy to the same accounts so we can consolidate the definition to reduce duplication.

depends on #859

