### PR TITLE
[SC-380] GH OIDC to deploy AMIs to imagecentral account

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -315,6 +315,8 @@ GithubOidcPackerImageDeploy:
   TemplatingContext:
     GitHubOrg: "Sage-Bionetworks-IT"
     Repositories:
+      - name: "packer-ami-template"
+        branches: ["master"]
       - name: "packer-base-ubuntu-jammy"
         branches: ["master"]
   DefaultOrganizationBinding:

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -300,6 +300,27 @@ GithubOidcCfnTemplateDeploy:
     Account: !Ref AdminCentralAccount
     Region: us-east-1
 
+# GH OIDC for packer to deploy AMI images to AWS imagecentral account
+GithubOidcPackerImageDeploy:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: github-oidc-provider-access.njk
+  StackName: !Sub ${resourcePrefix}-${appName}-packer-image-deploy
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-packer-image-deploy
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonEC2FullAccess
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks-IT"
+    Repositories:
+      - name: "packer-base-ubuntu-jammy"
+        branches: ["master"]
+  DefaultOrganizationBinding:
+    Account: !Ref ImageCentralAccount
+    Region: us-east-1
+
 GithubOidcSageBionetworksScicompProvisioner:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks


### PR DESCRIPTION
We are going to switch from using Travis to  GH actions to build and deploy packer images.

This configures a GH OIDC to allow packer to deploy AMI images from github repos to the org-sagebase-imagecentral account.

