### PR TITLE
remove simple-shiny deployment, no longer needed

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -171,27 +171,6 @@ GithubOidcSageBionetworksDPEAirflowInfra:
       - !Ref DnTDevAccount
     Region: us-east-1
 
-GithubOidcSageBionetworksS3FileHostingInfra:
-  Type: update-stacks
-  DependsOn: GithubOidcSageBionetworks
-  Template: github-oidc-provider-access.njk
-  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-s3-file-hosting-infra
-  Parameters:
-    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-s3-file-hosting-infra
-    ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AdministratorAccess"
-      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
-  TemplatingContext:
-    GitHubOrg: "Sage-Bionetworks"
-    Repositories:
-      - name: "s3-file-hosting"
-        branches: ["*"]
-  DefaultOrganizationBinding:
-    Account:
-      - !Ref DnTDevAccount
-    Region: us-east-1
-
 # GH OIDC for DCC validator to AWS DccvalidatorDev and DccvalidatorProd accounts
 GithubOidcDccValidatorDeploy:
   Type: update-stacks

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -127,27 +127,6 @@ GithubOidcSageBionetworksGenieBPCInfra:
       - !Ref GenieProdAccount
     Region: us-east-1
 
-GithubOidcSageBionetworksSimpleShinyInfra:
-  Type: update-stacks
-  DependsOn: GithubOidcSageBionetworks
-  Template: github-oidc-provider-access.njk
-  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-simple-shiny-infra
-  Parameters:
-    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-simple-shiny-infra
-    ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AdministratorAccess"
-      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
-  TemplatingContext:
-    GitHubOrg: "Sage-Bionetworks"
-    Repositories:
-      - name: "simple-shiny-infra"
-        branches: ["*"]
-  DefaultOrganizationBinding:
-    Account:
-      - !Ref DnTDevAccount
-    Region: us-east-1
-
 GithubOidcSageBionetworksDNTInfra:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks


### PR DESCRIPTION
We no longer need the `simple_shiny` application deployed to the DnT Dev account. 
We no longer need the `s3-file-hosting` application deployed to the Synapse Dev account. 

This PR removes the ability for GitHub to deploy those repo's.
