### PR TITLE
IT-2111 Allow sage-bionetworks/synapser repo' to write documentation to [staging-]ran.sagebase.org buckets as part of build

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -442,3 +442,32 @@ GithubOidcSageBionetworksSynapseProdWebMonorepoInfra:
   DefaultOrganizationBinding:
     Account: !Ref SynapseProdAccount
     Region: us-east-1
+
+GithubOidcSageBionetworksSynapseR:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: github-oidc-provider-access.njk
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapser
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-synapseprod-synapser
+    PolicyDocument: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+              "Sid": "AccessRanBucket",
+              "Effect": "Allow",
+              "Action": [ "s3:*" ],
+              "Resource": [ "arn:aws:s3:::ran.synapse.org", "arn:aws:s3:::staging-ran.synapse.org", "arn:aws:s3:::ran.synapse.org/*", "arn:aws:s3:::staging-ran.synapse.org/*" ]
+          }
+        ]
+      }
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "synapser"
+        branches: ["*"]
+  DefaultOrganizationBinding:
+    Account: !Ref SynapseProdAccount
+    Region: us-east-1


### PR DESCRIPTION
The `sage-bionetworks/synapser` repo' has a GitHub workflow which generates documentation and writes to a bucket.  Currently access is granted via an IAM user secret.  This PR will allow us to authorize the workflow using OIDC integration and remove the IAM user.