### PR TITLE
GH OIDC for packer-rstudio repo

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -277,6 +277,8 @@ GithubOidcPackerImageDeploy:
         branches: ["master"]
       - name: "packer-base-ubuntu-jammy"
         branches: ["master"]
+      - name: "packer-rstudio"
+        branches: ["master"]
   DefaultOrganizationBinding:
     Account: !Ref ImageCentralAccount
     Region: us-east-1


### PR DESCRIPTION
This sets up github OIDC to allow Sage-Bionetworks-IT/packer-rstudio repo to deploy to AWS org-sagebase-imagecentral account.

