### PR TITLE
MaxSessionDuration for GH OIDC session

### DIFF
--- a/org-formation/650-identity-providers/github-oidc-provider-access.njk
+++ b/org-formation/650-identity-providers/github-oidc-provider-access.njk
@@ -58,6 +58,13 @@ Parameters:
             }
           ]
         }
+  MaxSessionDuration:
+    Type: Number
+    Description: "The IAM role's maximum session duration"
+    MaxValue: 43200
+    MinValue: 3600
+    Default: 3600
+
 Conditions:
   HasManagedPolicyArns: !Not
     - !Equals
@@ -74,6 +81,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       RoleName: !Ref ProviderRoleName
+      MaxSessionDuration: !Ref MaxSessionDuration
       # Concatinate managed policy and custom policy
       ManagedPolicyArns: !Split
         - ","


### PR DESCRIPTION
The default role session timeout is 1hr however some CI jobs take longer than that to run.  We setup a MaxSessionDuration parameter so users can pass in a custom timeout for their github OIDC sessions.

