### PR TITLE
Increase session timeout for packer GH OIDC

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -267,6 +267,7 @@ GithubOidcPackerImageDeploy:
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ProviderRoleName: !Sub ${resourcePrefix}-${appName}-packer-image-deploy
+    MaxSessionDuration: 7200
     ManagedPolicyArns:
       - arn:aws:iam::aws:policy/AmazonEC2FullAccess
       - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore


### PR DESCRIPTION
Some packer jobs take over one hour to build so we need to increase the github OIDC session timeout.

depends on #889

