### PR TITLE
Remove CostCategoryRulesMicroservice parameter

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -51,7 +51,6 @@ CostCategoryRulesMicroservice:
     DnsName: "cost-rules.finops.sageit.org"
     ChartOfAccountsURL: "https://mips-api.finops.sageit.org/accounts?enable_code_filter"
     ProgramCodeTagList: "CostCenterOther,CostCenter"
-    OwnerEmailTagList: "OwnerEmail,synapse:email,AccountOwner"
 
 CostCategories:
   Type: update-stacks


### PR DESCRIPTION
The CostCategoryRulesMicroservice lambda parameter was removed[1] but wasn't removed in deployment of the lambda.  We remove it from the deployment to fix the CI deployment[2]

[1] https://github.com/Sage-Bionetworks-IT/lambda-finops-cost-rules/commit/73a87319e00b9e81cfc99d197b143461e7e8a990
[2] https://github.com/Sage-Bionetworks-IT/organizations-infra/actions/runs/5191378925/jobs/9359135735

