### PR TITLE
[IT-2883] Setup AWS Macie

### DIFF
--- a/org-formation/077-macie/README.md
+++ b/org-formation/077-macie/README.md
@@ -1,0 +1,8 @@
+### Purpose of these templates
+The templates in this folder enables
+[AWS Macie](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html)
+across our AWS organization.
+
+Amazon Macie is a data security service that discovers sensitive
+data by using machine learning and pattern matching, provides visibility into
+data security risks, and enables automated protection against those risks.

--- a/org-formation/077-macie/_tasks.yaml
+++ b/org-formation/077-macie/_tasks.yaml
@@ -1,0 +1,20 @@
+Parameters:
+  <<: !Include '../_parameters.yaml'
+
+  appName:
+    Type: String
+    Default: 'macie'
+
+  accountId:
+    Type: String
+    Description: The identifier from the account used to manage this service
+    Default: !Ref MasterAccount
+
+Macie:
+  Type: update-stacks
+  Template: macie.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}'
+  StackDescription: Setup AWS Macie service
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref accountId

--- a/org-formation/077-macie/macie.yaml
+++ b/org-formation/077-macie/macie.yaml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Setup AWS Macie"
+Resources:
+  MacieSession:
+    Type: AWS::Macie::Session
+    Properties:
+      FindingPublishingFrequency: FIFTEEN_MINUTES
+      Status: ENABLED
+Outputs:
+  MacieSessionServiceRole:
+    Description: "The Macie session service role"
+    Value: !GetAtt MacieSession.ServiceRole
+    Export:
+      Name: !Sub '${AWS::StackName}-MacieSessionServiceRole'

--- a/org-formation/_tasks.yaml
+++ b/org-formation/_tasks.yaml
@@ -36,6 +36,11 @@ SecurityHub:
   DependsOn: [ Types ]
   Path: ./075-security-hub/_tasks.yaml
 
+Macie:
+  Type: include
+  DependsOn: [ Types ]
+  Path: ./077-macie/_tasks.yaml
+
 AwsConfigInventory:
   Type: include
   DependsOn: [ Types ]


### PR DESCRIPTION
We setup Macie[1] to scan for security and compliance risks. This setup enables Macie with it's default scanning settings. The configuration may require customizations which can be done with CustomDataIdentifier, AllowLists and Filters.

[1] https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html

