### PR TITLE
PLFM-7740: de-duplicate permission set name

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -538,7 +538,7 @@ SsoSynapseDevAthenaUser:
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref synapseDevAthenaGroup
-    permissionSetName: 'athena-user'
+    permissionSetName: 'athena-user-dev'
     sessionDuration: 'PT12H'
     masterAccountId: !Ref MasterAccount
 
@@ -561,7 +561,7 @@ SsoSynapseProdAthenaUser:
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref synapseProdAthenaGroup
-    permissionSetName: 'athena-user'
+    permissionSetName: 'athena-user-prod'
     sessionDuration: 'PT12H'
     masterAccountId: !Ref MasterAccount
 


### PR DESCRIPTION
de-duplicate permission set name
The previous build seems to have failed because a second permission set overwrote the first using the same name and rendering the ID of the first one invalid.
