### PR TITLE
GH OIDC for nextflow-infra repo

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -481,10 +481,10 @@ GithubOidcWorkflowsDevNextflowInfra:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks
   Template: github-oidc-provider-access.njk
-  StackName: !Sub ${resourcePrefix}-${appName}-workflows-dev-nextflow-infra
+  StackName: !Sub ${resourcePrefix}-${appName}-nextflow-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-workflows-dev-nextflow-infra
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-nextflow-infra
     MaxSessionDuration: "21600"
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
@@ -503,10 +503,10 @@ GithubOidcWorkflowsProdNextflowInfra:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks
   Template: github-oidc-provider-access.njk
-  StackName: !Sub ${resourcePrefix}-${appName}-workflows-prod-nextflow-infra
+  StackName: !Sub ${resourcePrefix}-${appName}-nextflow-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-workflows-prod-nextflow-infra
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-nextflow-infra
     MaxSessionDuration: "21600"
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -485,6 +485,7 @@ GithubOidcNexflowInfra:
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ProviderRoleName: !Sub ${resourcePrefix}-${appName}-nextflow-infra
+    MaxSessionDuration: "21600"
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
       - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -477,14 +477,14 @@ GithubOidcSageBionetworksSynapseR:
     Account: !Ref SynapseProdAccount
     Region: us-east-1
 
-GithubOidcNexflowInfra:
+GithubOidcWorkflowsDevNextflowInfra:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks
   Template: github-oidc-provider-access.njk
-  StackName: !Sub ${resourcePrefix}-${appName}-nextflow-infra
+  StackName: !Sub ${resourcePrefix}-${appName}-workflows-dev-nextflow-infra
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-nextflow-infra
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-workflows-dev-nextflow-infra
     MaxSessionDuration: "21600"
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
@@ -493,9 +493,30 @@ GithubOidcNexflowInfra:
     GitHubOrg: "Sage-Bionetworks-Workflows"
     Repositories:
       - name: "nextflow-infra"
-        branches: ["dev", "prod"]
+        branches: ["dev"]
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref WorkflowsNextflowDevAccount
+    Region: us-east-1
+
+GithubOidcWorkflowsProdNextflowInfra:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: github-oidc-provider-access.njk
+  StackName: !Sub ${resourcePrefix}-${appName}-workflows-prod-nextflow-infra
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-workflows-prod-nextflow-infra
+    MaxSessionDuration: "21600"
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks-Workflows"
+    Repositories:
+      - name: "nextflow-infra"
+        branches: ["prod"]
   DefaultOrganizationBinding:
     Account:
       - !Ref WorkflowsNextflowProdAccount
-      - !Ref WorkflowsNextflowDevAccount
     Region: us-east-1

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -476,3 +476,25 @@ GithubOidcSageBionetworksSynapseR:
   DefaultOrganizationBinding:
     Account: !Ref SynapseProdAccount
     Region: us-east-1
+
+GithubOidcNexflowInfra:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: github-oidc-provider-access.njk
+  StackName: !Sub ${resourcePrefix}-${appName}-nextflow-infra
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-nextflow-infra
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks-Workflows"
+    Repositories:
+      - name: "nextflow-infra"
+        branches: ["dev", "prod"]
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref WorkflowsNextflowProdAccount
+      - !Ref WorkflowsNextflowDevAccount
+    Region: us-east-1

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -485,7 +485,7 @@ GithubOidcWorkflowsDevNextflowInfra:
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ProviderRoleName: !Sub ${resourcePrefix}-${appName}-nextflow-infra
-    MaxSessionDuration: "21600"
+    MaxSessionDuration: "7200"
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AdministratorAccess"
       - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"

--- a/sceptre/strides-ampad-workflows/config/prod/github-oidc-nextflow-infra.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/github-oidc-nextflow-infra.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.1/templates/IAM/github-oidc-provider.j2
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.4/templates/IAM/github-oidc-provider.j2
 stack_name: github-oidc-nextflow-infra
 parameters:
   ManagedPolicyArns:
@@ -8,6 +8,7 @@ parameters:
   ThumbprintList:
     - "6938fd4d98bab03faadb97b34396831e3780aea1"
   GitHubOrg: "Sage-Bionetworks-Workflows"
+  MaxSessionDuration: "3600"
 sceptre_user_data:
   Repositories:
     - name: "nextflow-infra"

--- a/sceptre/strides-ampad-workflows/config/prod/github-oidc-nextflow-infra.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/github-oidc-nextflow-infra.yaml
@@ -1,0 +1,14 @@
+template:
+  type: http
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.1/templates/IAM/github-oidc-provider.j2
+stack_name: github-oidc-nextflow-infra
+parameters:
+  ManagedPolicyArns:
+    - "arn:aws:iam::aws:policy/AdministratorAccess"
+  ThumbprintList:
+    - "6938fd4d98bab03faadb97b34396831e3780aea1"
+  GitHubOrg: "Sage-Bionetworks-Workflows"
+sceptre_user_data:
+  Repositories:
+    - name: "nextflow-infra"
+      branch: "*"

--- a/sceptre/strides-ampad-workflows/config/prod/github-oidc-nextflow-infra.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/github-oidc-nextflow-infra.yaml
@@ -8,7 +8,7 @@ parameters:
   ThumbprintList:
     - "6938fd4d98bab03faadb97b34396831e3780aea1"
   GitHubOrg: "Sage-Bionetworks-Workflows"
-  MaxSessionDuration: "3600"
+  MaxSessionDuration: "7200"
 sceptre_user_data:
   Repositories:
     - name: "nextflow-infra"


### PR DESCRIPTION
This sets up github OIDC access for the
Sage-Bionetworks-Workflows/nextflow-infra repo.

depends on https://github.com/Sage-Bionetworks/aws-infra/pull/395