### PR TITLE
enable object delete and multipart upload permissions

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -236,13 +236,16 @@ GithubOidcCfnTemplateDeploy:
           {
               "Sid": "ListObjectsInBucket",
               "Effect": "Allow",
-              "Action": [ "s3:GetBucketLocation", "s3:ListBucket" ],
+              "Action": [ "s3:GetBucketLocation", "s3:ListBucket", "s3:ListBucketV2", "s3:ListParts" ],
               "Resource": [ "arn:aws:s3:::bootstrap-awss3cloudformationbucket-19qromfd235z9" ]
           },
           {
               "Sid": "AllObjectActions",
               "Effect": "Allow",
-              "Action": [ "s3:PutObject", "s3:GetObject" ],
+              "Action": [ "s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:DeleteObjects",
+                          "s3:UploadPart", "s3:CompleteMultipartUpload", "s3:CompleteMultipartUpload",
+                          "s3:CreateMultipartUpload"
+                        ],
               "Resource": ["arn:aws:s3:::bootstrap-awss3cloudformationbucket-19qromfd235z9/aws-infra/*"]
           }
         ]

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -236,14 +236,16 @@ GithubOidcCfnTemplateDeploy:
           {
               "Sid": "ListObjectsInBucket",
               "Effect": "Allow",
-              "Action": [ "s3:GetBucketLocation", "s3:ListBucket", "s3:ListBucketV2", "s3:ListParts" ],
+              "Action": [ "s3:GetBucketLocation", "s3:ListBucket", "s3:ListBucketV2",
+                          "s3:ListParts", "s3:ListMultipartUploads"
+                        ],
               "Resource": [ "arn:aws:s3:::bootstrap-awss3cloudformationbucket-19qromfd235z9" ]
           },
           {
               "Sid": "AllObjectActions",
               "Effect": "Allow",
               "Action": [ "s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:DeleteObjects",
-                          "s3:UploadPart", "s3:CompleteMultipartUpload", "s3:CompleteMultipartUpload",
+                          "s3:UploadPart", "s3:CompleteMultipartUpload", "s3:AbortMultipartUpload",
                           "s3:CreateMultipartUpload"
                         ],
               "Resource": ["arn:aws:s3:::bootstrap-awss3cloudformationbucket-19qromfd235z9/aws-infra/*"]


### PR DESCRIPTION
The Sage-Bionetworks/service-catalog-library repo's GH action is throwing the following error..
```
delete failed: s3://bootstrap-awss3cloudformationbucket-19qromfd235z9/service-catalog-library/master/ec2/README.md
An error occurred (AccessDenied) when calling the DeleteObject operation: Access Denied
```

The error happens because the GH action attempts to replace files in the template bucket. This change is to address that error by providing object deletion access to the GH OIDC that deploys the files.

