### PR TITLE
GH OIDC for deployment to strides-ampad-workflows account

### DIFF
--- a/sceptre/strides-ampad-workflows/config/prod/github-oidc-nextflow-infra.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/github-oidc-nextflow-infra.yaml
@@ -1,14 +1,14 @@
 template:
   type: http
   url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.5/templates/IAM/github-oidc-provider.j2
-stack_name: github-oidc-organizations-infra
+stack_name: github-oidc-nextflow-infra
 parameters:
-  ProviderRoleName: sagebase-github-oidc-organizations-infra
+  ProviderRoleName: sagebase-github-oidc-nextflow-infra
   ProviderArn: !stack_output prod/github-oidc-provider.yaml::ProviderRoleArn
   ManagedPolicyArns:
     - "arn:aws:iam::aws:policy/AdministratorAccess"
 sceptre_user_data:
-  GitHubOrg: "Sage-Bionetworks-IT"
+  GitHubOrg: "Sage-Bionetworks-Workflows"
   Repositories:
-    - name: "organizations-infra"
-      branches: ["master"]
+    - name: "nextflow-infra"
+      branches: ["dev", "prod"]

--- a/sceptre/strides-ampad-workflows/config/prod/github-oidc-nextflow-infra.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/github-oidc-nextflow-infra.yaml
@@ -2,9 +2,12 @@ template:
   type: http
   url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.5/templates/IAM/github-oidc-provider.j2
 stack_name: github-oidc-nextflow-infra
+Dependencies:
+  - prod/github-oidc-provider.yaml
 parameters:
-  ProviderRoleName: sagebase-github-oidc-nextflow-infra
-  ProviderArn: !stack_output prod/github-oidc-provider.yaml::ProviderRoleArn
+  ProviderRoleName: github-oidc-nextflow-infra
+  ProviderArn: !stack_output_external github-oidc-provider::ProviderArn
+  MaxSessionDuration: 14400
   ManagedPolicyArns:
     - "arn:aws:iam::aws:policy/AdministratorAccess"
 sceptre_user_data:

--- a/sceptre/strides-ampad-workflows/config/prod/github-oidc-provider.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/github-oidc-provider.yaml
@@ -1,0 +1,10 @@
+template:
+  type: http
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.5/templates/IAM/oidc-provider.j2
+stack_name: github-oidc-provider
+parameters:
+  ManagedPolicyArns:
+    - "arn:aws:iam::aws:policy/AdministratorAccess"
+  ThumbprintList:
+    - "6938fd4d98bab03faadb97b34396831e3780aea1"
+  Url: "https://token.actions.githubusercontent.com"

--- a/sceptre/strides-ampad-workflows/config/prod/github-oidc-provider.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/github-oidc-provider.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.5/templates/IAM/oidc-provider.j2
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.5/templates/IAM/oidc-provider.yaml
 stack_name: github-oidc-provider
 parameters:
   ManagedPolicyArns:

--- a/sceptre/strides-ampad-workflows/config/prod/github-oidc-provider.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/github-oidc-provider.yaml
@@ -3,8 +3,6 @@ template:
   url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.5/templates/IAM/oidc-provider.yaml
 stack_name: github-oidc-provider
 parameters:
-  ManagedPolicyArns:
-    - "arn:aws:iam::aws:policy/AdministratorAccess"
   ThumbprintList:
     - "6938fd4d98bab03faadb97b34396831e3780aea1"
   Url: "https://token.actions.githubusercontent.com"

--- a/sceptre/strides-ampad-workflows/config/prod/github-oidc-sage-bionetworks-it.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/github-oidc-sage-bionetworks-it.yaml
@@ -1,10 +1,12 @@
 template:
   type: http
   url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.5/templates/IAM/github-oidc-provider.j2
-stack_name: github-oidc-organizations-infra
+stack_name: github-oidc-sage-bionetworks-it
+Dependencies:
+  - prod/github-oidc-provider.yaml
 parameters:
-  ProviderRoleName: sagebase-github-oidc-organizations-infra
-  ProviderArn: !stack_output prod/github-oidc-provider.yaml::ProviderRoleArn
+  ProviderRoleName: github-oidc-sage-bionetworks-it
+  ProviderArn: !stack_output_external github-oidc-provider::ProviderArn
   ManagedPolicyArns:
     - "arn:aws:iam::aws:policy/AdministratorAccess"
 sceptre_user_data:


### PR DESCRIPTION
Commit bdfc556 had setup github OIDC access for the Sage-Bionetworks-Workflows/nextflow-infra repo.  However that setup didn't work because the template used was not adequate and needed to be reverted in commit f6de736

Now we need to redo the setup for strides-ampad-workflows with the help of PR https://github.com/Sage-Bionetworks/aws-infra/pull/394

depends on https://github.com/Sage-Bionetworks/aws-infra/pull/394

