### PR TITLE
expand GH oidc permision for cfn deployment

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -248,7 +248,7 @@ GithubOidcCfnTemplateDeploy:
                           "s3:UploadPart", "s3:CompleteMultipartUpload", "s3:AbortMultipartUpload",
                           "s3:CreateMultipartUpload"
                         ],
-              "Resource": ["arn:aws:s3:::bootstrap-awss3cloudformationbucket-19qromfd235z9/aws-infra/*"]
+              "Resource": ["arn:aws:s3:::bootstrap-awss3cloudformationbucket-19qromfd235z9/*"]
           }
         ]
       }


### PR DESCRIPTION
The Github OIDC for deployment to cloudformation template is shared by multiple repos (example: aws-infra and service-catalog-library). All repos should have access to the entire repository (bucket).
