### PR TITLE
temporarily remove SchematicDevAppDnsForward

### DIFF
--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -118,21 +118,23 @@ DcaProdAppDnsForward:
 
 # forward schematic-dev.api.sagebionetworks.org to schematic-infra ALB
 # https://github.com/Sage-Bionetworks/schematic-infra
-SchematicDevAppDnsForward:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/R53/cname.yaml
-  StackName: !Sub '${resourcePrefix}-schematic-dev-cname'
-  StackDescription: Setup a CNAME for schematic-infra dev ALB
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    Account: !Ref SageITAccount
-  Parameters:
-    # the name of the CNAME record
-    SourceHostName: "schematic-dev.api.sagebionetworks.org"
-    # ID of the api.sagebionetworks.org zone (in sageit account)
-    SourceHostedZoneId: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sagebio-api-zone-HostedZoneId']
-    # the value of the CNAME record
-    TargetHostName: !CopyValue ['schematic-dev-DockerFargateStack-LoadBalancerDNS', !Ref DnTDevAccount]
+
+# @linglp temporarily comment out due to a broken schematica-infra deployment
+#SchematicDevAppDnsForward:
+#  Type: update-stacks
+#  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/R53/cname.yaml
+#  StackName: !Sub '${resourcePrefix}-schematic-dev-cname'
+#  StackDescription: Setup a CNAME for schematic-infra dev ALB
+#  DefaultOrganizationBindingRegion: !Ref primaryRegion
+#  DefaultOrganizationBinding:
+#    Account: !Ref SageITAccount
+#  Parameters:
+#    # the name of the CNAME record
+#    SourceHostName: "schematic-dev.api.sagebionetworks.org"
+#    # ID of the api.sagebionetworks.org zone (in sageit account)
+#    SourceHostedZoneId: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sagebio-api-zone-HostedZoneId']
+#    # the value of the CNAME record
+#    TargetHostName: !CopyValue ['schematic-dev-DockerFargateStack-LoadBalancerDNS', !Ref DnTDevAccount]
 
 # forward schematic-staging.api.sagebionetworks.org to schematic-infra ALB
 # https://github.com/Sage-Bionetworks/schematic-infra


### PR DESCRIPTION
The schematica-infra deployment failure is causing the reference in this repo to break which is causing the CI for this repo to fail.  Remove the route53 record set until the schematica-infra deployment is fixed.

