### PR TITLE
Update strides ampad role for CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -139,7 +139,7 @@ jobs:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
-      role-to-assume: "arn:aws:iam::751556145034:role/github-oidc-sage-bionetwo-ProviderRoleorganization-9JE3CF75DHRZ"
+      role-to-assume: "arn:aws:iam::751556145034:role/github-oidc-sage-bionetworks-it"
       working-dir: "sceptre/strides-ampad-workflows"
   sceptre-scipooldev:
     if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
PR #907 update the GH action CI role for
Sage-Bionetworks-IT/organizations-infra repo in AWS.  We update to pass that role in to GH action to match.

depends on #907
