### PR TITLE
GH OIDC access to environments

### DIFF
--- a/org-formation/650-identity-providers/github-oidc-provider-access.njk
+++ b/org-formation/650-identity-providers/github-oidc-provider-access.njk
@@ -109,6 +109,7 @@ Resources:
       {% endif %}
   {% endfor %}
                   "repo:{{ GitHubOrg }}/{{ Repository.name }}:ref:refs/tags/*",
+                  "repo:{{ GitHubOrg }}/{{ Repository.name }}:environment:*",
 {% endfor %}
                 ]
 Outputs:


### PR DESCRIPTION
Github requires the AWS OIDC role to have explicit access to github environments as noted in
[GH issue 452](https://github.com/aws-actions/configure-aws-credentials/issues/452). Otherwise the following error will occur when attempting to assume the OIDC role in GH actions..

```
Error: Credentials could not be loaded, please check your action inputs: Could
not load credentials from any providers
```

This change enables GH OIDC access to GH environment.

