### PR TITLE
PLFM-7908: Add access to *firehoselogs schemas

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -285,7 +285,9 @@ SynapseAthenaUserAccessPolicy:
             "Resource": [
                 "arn:aws:glue:us-east-1:${CurrentAccount.AccountId}:catalog",
                 "arn:aws:glue:us-east-1:${CurrentAccount.AccountId}:database/*warehouse",
-                "arn:aws:glue:us-east-1:${CurrentAccount.AccountId}:table/*warehouse/*"
+                "arn:aws:glue:us-east-1:${CurrentAccount.AccountId}:table/*warehouse/*",
+                "arn:aws:glue:us-east-1:${CurrentAccount.AccountId}:database/*firehoselogs",
+                "arn:aws:glue:us-east-1:${CurrentAccount.AccountId}:table/*firehoselogs/*"
             ]
         },
         {

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -338,7 +338,6 @@ SynapseAthenaUserAccessPolicy:
                     "arn:aws:s3:::*.log.sagebase.org/*",
                     "arn:aws:s3:::*.filehandles.sagebase.org",
                     "arn:aws:s3:::*.filehandles.sagebase.org/*"
-
                 ]
             }
         ]

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -333,7 +333,12 @@ SynapseAthenaUserAccessPolicy:
                 ],
                 "Resource": [
                     "arn:aws:s3:::*.datawarehouse.sagebase.org",
-                    "arn:aws:s3:::*.datawarehouse.sagebase.org/*"
+                    "arn:aws:s3:::*.datawarehouse.sagebase.org/*",
+                    "arn:aws:s3:::*.log.sagebase.org",
+                    "arn:aws:s3:::*.log.sagebase.org/*",
+                    "arn:aws:s3:::*.filehandles.sagebase.org",
+                    "arn:aws:s3:::*.filehandles.sagebase.org/*"
+
                 ]
             }
         ]


### PR DESCRIPTION
This PR gives access to the *firehoselogs schemas in Athena. The policy is used by the SSO group in Synapse.
