### PR TITLE
[IT-1532] Send monthly cloud-spend emails

### DIFF
--- a/org-formation/050-costs/README.md
+++ b/org-formation/050-costs/README.md
@@ -1,0 +1,16 @@
+### Purpose of these stacks
+The stacks created in this directory enable and improve cost-tracking capabilities.
+
+#### Anomaly Detection
+Deploy an anomaly detector service in every account in the organization, sending
+email alerts to the account's root email.
+
+#### Microservice Lambdas
+A few microservices are developed and deployed as Lambdas:
+
+* A service to provide read-only access to our MIP Chart of Accounts
+* A service to generate a CloudFormation snippet based on current Chart of Accounts
+* A service to send monthly per-user cloud-spend notifications via SES
+
+#### Cost Category Template
+The template in this directory creates two cost categories in AWS Cost Explorer.

--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -30,6 +30,7 @@ MipsMicroservice:
       - !Sub 'arn:aws:iam::${CurrentAccount.AccountId}:root'
       - 'arn:aws:iam::745159704268:role/github-oidc-sage-bionetwo-ProviderRoleorganization-93H11ERK3F4N'
 
+# Deploy a microservice for generating cost category rules
 CostCategoryRulesMicroservice:
   Type: update-stacks
   Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-finops-cost-rules/master/lambda-finops-cost-rules.yaml'
@@ -51,3 +52,16 @@ CostCategories:
   DefaultOrganizationBinding:
     Account: !Ref MasterAccount
     Region: !Ref primaryRegion
+
+# Deploy a lambda to notify users of their total cloud spend via SES;
+# use the payer account so that cost explorer aggregates member account data
+CostNotificationMicroservice:
+  Type: update-stacks
+  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-finops-email-totals/master/lambda-finops-email-totals.yaml'
+  StackName: !Sub '${resourcePrefix}-cost-notifications'
+  DefaultOrganizationBinding:
+    Account: !Ref MasterAccount
+    Region: !Ref primaryRegion
+  Parameters:
+    RestrictRecipients: True
+    ApprovedRecipients: "it@sagebase.org"


### PR DESCRIPTION
Canary deployment of a lambda to send monthly email notifications summarizing cloud spend and linking to confluence documentation on how to access AWS Cost Explorer.

Restrict the recipient list to Sage IT as a canary test and to review the content and formatting of the email.

Depends on Sage-Bionetworks-IT/lambda-finops-email-totals#5
