### PR TITLE
[IT-2984] Add rules for inactive codes

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -41,7 +41,7 @@ CostCategoryRulesMicroservice:
   Parameters:
     AcmCertificateArn: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sageit-finops-cert-CertificateArn']
     DnsName: "cost-rules.finops.sageit.org"
-    ChartOfAccountsURL: "https://mips-api.finops.sageit.org/accounts?enable_code_filter"
+    ChartOfAccountsURL: "https://mips-api.finops.sageit.org/accounts?enable_code_filter&disable_inactive_filter"
     ProgramCodeTagList: "CostCenterOther,CostCenter"
 
 CostCategories:


### PR DESCRIPTION
Add cost category rules for inactive program codes so that we can track ongoing costs related inactive programs.

Depends on Sage-Bionetworks-IT/lambda-mips-api#19
