### PR TITLE
PLFM-7886: add bucket permissions required by AWS Quicksight

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -304,6 +304,8 @@ SynapseAthenaUserAccessPolicy:
                 "Resource": [
                     "arn:aws:s3:::aws-athena-query-results-${CurrentAccount.AccountId}-us-east-1",
                     "arn:aws:s3:::aws-athena-query-results-${CurrentAccount.AccountId}-us-east-1/*",
+                    "arn:aws:s3:::aws-athena-query-results-us-east-1-${CurrentAccount.AccountId}",
+                    "arn:aws:s3:::aws-athena-query-results-us-east-1-${CurrentAccount.AccountId}/*",
                     "arn:aws:s3:::*.athena-queries.sagebase.org",
                     "arn:aws:s3:::*.athena-queries.sagebase.org/*"
                 ]


### PR DESCRIPTION
In PLFM-7886 we are evaluation AWS Quicksight as a data visualization tool for Athena tables, in the Synapse Dev account.  Quicksight uses a particular bucket naming pattern for the queries it saves. This PR adds the requested bucket names to the AWS policy used with Quicksight.
