### PR TITLE
update role for GH deployment to strides account

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -161,7 +161,7 @@ jobs:
     needs: [org-formation, sceptre-strides]
     uses: "./.github/workflows/aws-scipool.yaml"
     with:
-      role-to-assume: "arn:aws:iam::423819316185:role/github-oidc-sage-bionetwo-ProviderRoleorganization-3R0K18XHN449"
+      role-to-assume: "arn:aws:iam::423819316185:role/github-oidc-sage-bionetworks-it"
       working-dir: "sceptre/scipool"
       sceptre-command: "sceptre launch strides --prune --yes"
   sceptre-bmgfki:


### PR DESCRIPTION
The PR #923 forgot to update the role to deploy to strides account which caused
the GH action to fail.  This is the fix

