### PR TITLE
[IT-2984] Force deployment of categories stack

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -45,10 +45,14 @@ CostCategoryRulesMicroservice:
     ChartOfAccountsURL: "https://mips-api.finops.sageit.org/accounts?enable_code_filter&disable_inactive_filter"
     ProgramCodeTagList: "CostCenterOther,CostCenter"
 
+# The underlying template uses AWS::Include, but CloudFormation will not detect changes in the included
+# template unless there are also changes to categories.yaml; force deployment of the stack to apply any
+# changes in the included file.
 CostCategories:
   Type: update-stacks
   Template: categories.yaml
   StackName: !Sub '${resourcePrefix}-cost-categories'
+  ForceDeploy: true
   DefaultOrganizationBinding:
     Account: !Ref MasterAccount
     Region: !Ref primaryRegion


### PR DESCRIPTION
We use AWS::Include in categories.yaml, but CloudFormation will only process stack updates if there are changes to the immediate template, it will not detect changes in the included template. Force org-formation to deploy the stack so that CloudFormation will always process the included template.
