### PR TITLE
Remove Omberg as a notification recipient

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -620,7 +620,7 @@ Organization:
       Alias: org-sagebase-dccvalidator-dev
       Tags:
         <<: !Include ./_default_org_tags.yaml
-        AccountOwner: larsson.omberg@sagebase.org
+        AccountOwner: anna.greenwood@sagebase.org
         CostCenter: NO PROGRAM / 000000
         budget-alarm-threshold: 1000
         budget-alarm-threshold-email-recipient: aws-dccvalidator-dev@sagebase.org
@@ -633,7 +633,7 @@ Organization:
       Alias: org-sagebase-dccvalidator-prod
       Tags:
         <<: !Include ./_default_org_tags.yaml
-        AccountOwner: larsson.omberg@sagebase.org
+        AccountOwner: anna.greenwood@sagebase.org
         CostCenter: NO PROGRAM / 000000
         budget-alarm-threshold: 1000
         budget-alarm-threshold-email-recipient: aws-dccvalidator-prod@sagebase.org

--- a/sceptre/scipool/templates/prod/lambda-budgets/budget-rules.yaml
+++ b/sceptre/scipool/templates/prod/lambda-budgets/budget-rules.yaml
@@ -12,4 +12,4 @@ teams:
     period: YEAR
     unit: USD
     community_manager_emails:
-      - 'larsson.omberg@sagebase.org'
+      - 'solly.sieberts@sagebase.org'


### PR DESCRIPTION
Removing Larsson Omberg as a notification recipient.
Dccvalidator ownership has been moved into Anna Greenwood's team.
RECOVER SC access is overseen by Solly Sieberts.
