### PR TITLE
SC-383: Update service-catalog-library version

### DIFF
--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -98,5 +98,5 @@ sceptre_user_data:
       Name: 'v1.1.45'
     - Description: 'Update distro, python, apache, rstudio versions {{ range(1, 10000) | random }}'
       Info:
-        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.5/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
-      Name: 'v1.2.5'
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.6/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.2.6'


### PR DESCRIPTION
This PR updates the version of service-catalog-library.
Hold until tag v1.2.6 is created.
Depends on https://github.com/Sage-Bionetworks/service-catalog-library/pull/301
