### PR TITLE
[IT-2978] Send admin cost report to Sage IT

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -67,5 +67,6 @@ CostNotificationMicroservice:
     Account: !Ref MasterAccount
     Region: !Ref primaryRegion
   Parameters:
+    AdminEmail: "it@sagebase.org"
     RestrictRecipients: "True"
     ApprovedRecipients: "it@sagebase.org"


### PR DESCRIPTION
Add parameter setting the email recipient for the admin cost report to Sage IT.
