### PR TITLE
[IT-3041] Skip sending reports to ex-employees

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -68,5 +68,6 @@ CostNotificationMicroservice:
     Region: !Ref primaryRegion
   Parameters:
     AdminEmail: "it@sagebase.org"
+    SkipRecipients: "bgrande@synapse.org,bruno.grande@sagebase.org,kelsey.montgomery@sagebase.org,larsson.omberg@sagebase.org,larssono@synapse.org,tess.thyer@sagebase.org"
     RestrictRecipients: "True"
     ApprovedRecipients: "it@sagebase.org"


### PR DESCRIPTION
A few former employees are still tagged as resources owners, don't send cost reports to these addresses.
