### PR TITLE
[IT-1532] Send AWS cost summary to all tagged owners 

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -68,5 +68,6 @@ CostNotificationMicroservice:
     Region: !Ref primaryRegion
   Parameters:
     AdminEmail: "it@sagebase.org"
-    RestrictRecipients: "True"
-    ApprovedRecipients: "it@sagebase.org"
+    # Uncomment the following lines to disable user reports
+    #RestrictRecipients: "True"
+    #ApprovedRecipients: "it@sagebase.org"


### PR DESCRIPTION
Stop restricting the cost summary report to only Sage IT, send monthly summary reports to all tagged owners.