### PR TITLE
SC-383: Bump version for bugfix

### DIFF
--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -98,5 +98,5 @@ sceptre_user_data:
       Name: 'v1.1.45'
     - Description: 'Update distro, python, apache, rstudio versions {{ range(1, 10000) | random }}'
       Info:
-        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.6/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
-      Name: 'v1.2.6'
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.7/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.2.7'


### PR DESCRIPTION
This PR updates the product to v1.2.7 (includes bugfix from https://github.com/Sage-Bionetworks/service-catalog-utils/pull/23).
