### PR TITLE
[IT-3021] Prioritize the RECOVER code

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -42,7 +42,7 @@ CostCategoryRulesMicroservice:
   Parameters:
     AcmCertificateArn: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sageit-finops-cert-CertificateArn']
     DnsName: "cost-rules.finops.sageit.org"
-    ChartOfAccountsURL: "https://mips-api.finops.sageit.org/accounts?enable_code_filter&disable_inactive_filter"
+    ChartOfAccountsURL: "https://mips-api.finops.sageit.org/accounts?show_inactive_codes=on"
     ProgramCodeTagList: "CostCenterOther,CostCenter"
 
 # The underlying template uses AWS::Include, but CloudFormation will not detect changes in the included

--- a/sceptre/scipool/config/develop/sc-tag-options.yaml
+++ b/sceptre/scipool/config/develop/sc-tag-options.yaml
@@ -11,7 +11,7 @@ dependencies:
   - "develop/sc-portfolio-scheduled-jobs.yaml"
 sceptre_user_data:
   CostCenters: !from_json
-    - !request 'https://mips-api.finops.sageit.org/tags?only_codes=101300,101400,101600,112501,119400,121700,120100,122000,122100,122300,122500,312000,314900,401900,506800,613500,990100,990300,990400&enable_other_code=true'
+    - !request 'https://mips-api.finops.sageit.org/tags?limit=25&enable_other_code=true&priority_codes=122500'
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/sceptre/scipool/config/develop/sc-tag-options.yaml
+++ b/sceptre/scipool/config/develop/sc-tag-options.yaml
@@ -10,8 +10,10 @@ dependencies:
   - "develop/sc-portfolio-s3-basic.yaml"
   - "develop/sc-portfolio-scheduled-jobs.yaml"
 sceptre_user_data:
+  # We prioritize the following program codes to ensure they are in the Service Catalog drop-down menu:
+  # 122500: MGH RECOVER
   CostCenters: !from_json
-    - !request 'https://mips-api.finops.sageit.org/tags?limit=25&enable_other_code=true&priority_codes=122500'
+    - !request 'https://mips-api.finops.sageit.org/tags?limit=25&show_other_code=true&priority_codes=122500'
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/sceptre/scipool/config/develop/sc-tag-options.yaml
+++ b/sceptre/scipool/config/develop/sc-tag-options.yaml
@@ -11,7 +11,7 @@ dependencies:
   - "develop/sc-portfolio-scheduled-jobs.yaml"
 sceptre_user_data:
   CostCenters: !from_json
-    - !request 'https://mips-api.finops.sageit.org/tags?limit=25&enable_other_code=true'
+    - !request 'https://mips-api.finops.sageit.org/tags?only_codes=101300,101400,101600,112501,119400,121700,120100,122000,122100,122300,122500,312000,314900,401900,506800,613500,990100,990300,990400&enable_other_code=true'
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/sceptre/scipool/config/prod/sc-tag-options.yaml
+++ b/sceptre/scipool/config/prod/sc-tag-options.yaml
@@ -10,8 +10,10 @@ dependencies:
   - "prod/sc-portfolio-s3-basic.yaml"
   - "prod/sc-portfolio-scheduled-jobs.yaml"
 sceptre_user_data:
+  # We prioritize the following program codes to ensure they are in the Service Catalog drop-down menu:
+  # 122500: MGH RECOVER
   CostCenters: !from_json
-    - !request 'https://mips-api.finops.sageit.org/tags?limit=25&enable_other_code=true'
+    - !request 'https://mips-api.finops.sageit.org/tags?limit=25&show_other_code=true&priority_codes=122500'
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId


### PR DESCRIPTION
Prioritize the RECOVER code so that it is listed near the top of the lambda output, ensuring that it is available in the Service Catalog drop-down menu.

Also update mips-api parameters to match name changes happening in the dependent PR.

Depends on Sage-Bionetworks-IT/lambda-mips-api#21
