### PR TITLE
[IT-2607] Remove all references to 'aws-portal'

### DIFF
--- a/org-formation/_scp.yaml
+++ b/org-formation/_scp.yaml
@@ -14,7 +14,6 @@
             - acm:*
             - aws-marketplace-management:*
             - aws-marketplace:*
-            - aws-portal:*
             - budgets:*
             - ce:*
             - chime:*


### PR DESCRIPTION
Remove all references to the deprecated 'aws-portal' actions.
