### PR TITLE
[IT-2871] Update service catalog EC2 docker

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-docker.yaml
@@ -38,7 +38,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.37/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.37'
-    - Description: 'Propagate instance tags to attached volumes {{ range(1, 10000) | random }}'
+    - Description: 'Propagate instance tags to attached volumes'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.40/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.40'
+    - Description: 'Change to less costly volume type {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.9/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.2.9'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
@@ -37,7 +37,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.37/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.37'
-    - Description: 'Propagate instance tags to attached volumes {{ range(1, 10000) | random }}'
+    - Description: 'Propagate instance tags to attached volumes'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.40/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.40'
+    - Description: 'Change to less costly volume type {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.9/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.2.9'

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-docker.yaml
@@ -38,7 +38,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.37/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.37'
-    - Description: 'Propagate instance tags to attached volumes {{ range(1, 10000) | random }}'
+    - Description: 'Propagate instance tags to attached volumes'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.40/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.40'
+    - Description: 'Change to less costly volume type {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.9/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.2.9'

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-docker.yaml
@@ -38,7 +38,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.37/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.37'
-    - Description: 'Propagate instance tags to attached volumes {{ range(1, 10000) | random }}'
+    - Description: 'Propagate instance tags to attached volumes'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.40/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.1.40'
+    - Description: 'Change to less costly volume type {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.9/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.2.9'


### PR DESCRIPTION
Update the service catalog EC2 docker version to pick up the update from PR https://github.com/Sage-Bionetworks/service-catalog-library/pull/304

