### PR TITLE
Add AccountOwner tag to scipool-dev account

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -281,7 +281,7 @@ Organization:
       RootEmail: aws.scipooldev@sagebase.org
       Alias: org-sagebase-scipooldev
       Tags:
-        <<: !Include ./_default_org_tags.yaml
+        <<: !Include ./_platform_org_tags.yaml
 
   ScipoolProdAccount:
     Type: OC::ORG::Account


### PR DESCRIPTION
Inherit platform tags on the scipool-dev account so that Sage IT is tagged as the account owner.
