### PR TITLE
[IT-3008] Supress Security hub rule

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -369,6 +369,9 @@ Resources:
               - 'aws-foundational-security-best-practices/v/1.0.0/IAM.6'
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/2.7'
               - 'cis-aws-foundations-benchmark/v/1.4.0/3.7'
+              # SecHub Recommendation: no security group allows unrestricted ingress access to port 22.
+              # Supression Reason: Allow for bastian hosts and testing
+              - 'cis-aws-foundations-benchmark/v/1.2.0/rule/4.1'
             Workflow:
               Status:
               - NEW


### PR DESCRIPTION
It is useful to have a security group that allows unrestricted access to port 22 for testing and setting up bastian hosts.  Not to mention that, by default, the AWS security group wizard will create a security group with this access when provisiong a public EC2 instance.

