### PR TITLE
SC-383: Allow OIDC from v2.1.3 branch

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -285,7 +285,7 @@ GithubOidcPackerImageDeploy:
       - name: "packer-base-ubuntu-jammy"
         branches: ["master"]
       - name: "packer-rstudio"
-        branches: ["master"]
+        branches: ["master", "v2.1.3"]
   DefaultOrganizationBinding:
     Account: !Ref ImageCentralAccount
     Region: us-east-1


### PR DESCRIPTION
https://github.com/Sage-Bionetworks-IT/packer-rstudio/pull/78 failed with 'Not authorized to perform sts:AssumeRoleWithWebIdentity' when trying to assume the role. The role can only be assumed from
the master branch, this PR add branch 'v2.1.3' to the list.
