### PR TITLE
SC-383: Allow OIDC from branch v1.1.45

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -259,7 +259,7 @@ GithubOidcCfnTemplateDeploy:
       - name: "aws-infra"
         branches: ["master"]
       - name: "service-catalog-library"
-        branches: ["master"]
+        branches: [ "master", "v1.1.45" ]
   DefaultOrganizationBinding:
     Account: !Ref AdminCentralAccount
     Region: us-east-1


### PR DESCRIPTION
This PR is similar to #945, it fixes the failure to deploy in https://github.com/Sage-Bionetworks/service-catalog-library/pull/305 (job cannot assume role).
