### PR TITLE
SC-383: Force update

### DIFF
--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -92,7 +92,7 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.40/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.40'
-    - Description: 'Enable KMS key rotation'
+    - Description: 'Update in place due to image deleted {{ range(1, 10000) | random }}'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.45/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.45'


### PR DESCRIPTION
Service catalog did not pick up the change from https://github.com/Sage-Bionetworks/service-catalog-library/pull/306 (verified by launching a product on 1.1.45). Verified that the template has been updated in S3.
Usually we'd tag a new version but since 1.1.45 is now broken anyway so adding a random string in the description should force the update.
