### PR TITLE
SC-383: Update notebook product 1.1.45 

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -89,7 +89,7 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.40/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.40'
-    - Description: 'Enable KMS key rotation {{ range(1, 10000) | random }}'
+    - Description: 'Update in place with rebuilt image from tag 2.1.3 {{ range(1, 10000) | random }}'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.45/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.45'

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -89,7 +89,7 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.40/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.40'
-    - Description: 'Enable KMS key rotation {{ range(1, 10000) | random }}'
+    - Description: 'Update in place with rebuilt image from tag 2.1.3 {{ range(1, 10000) | random }}'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.45/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.45'

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -89,7 +89,7 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.40/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.40'
-    - Description: 'Enable KMS key rotation {{ range(1, 10000) | random }}'
+    - Description: 'Update in place with rebuilt image from tag 2.1.3 {{ range(1, 10000) | random }}'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.45/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.45'


### PR DESCRIPTION
This PR just updates the description to cause a deploy to pick up the updated template with the RStudio Notebook AMI re-built from tag 2.1.3.

Depends on: https://github.com/Sage-Bionetworks/service-catalog-library/pull/307
