### PR TITLE
SC-383: release v1.2.11

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -89,7 +89,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.40/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.40'
-    - Description: 'Update in place with rebuilt image from tag 2.1.3 {{ range(1, 10000) | random }}'
+    - Description: 'Update in place with rebuilt image from tag 2.1.3
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.45/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.45'
+    - Description: 'Update to R/4.3 from tag 3.0.7 {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.11/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.2.11'

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -89,7 +89,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.40/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.40'
-    - Description: 'Update in place with rebuilt image from tag 2.1.3 {{ range(1, 10000) | random }}'
+    - Description: 'Update in place with rebuilt image from tag 2.1.3 '
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.45/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.45'
+    - Description: 'Update to R/4.3 from tag 3.0.7 {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.11/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.2.11'

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -89,7 +89,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.40/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.40'
-    - Description: 'Update in place with rebuilt image from tag 2.1.3 {{ range(1, 10000) | random }}'
+    - Description: 'Update in place with rebuilt image from tag 2.1.3 '
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.45/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
       Name: 'v1.1.45'
+    - Description: 'Update to R/4.3 from tag 3.0.7 {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.11/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.2.11'


### PR DESCRIPTION
This PR releases the RStudio Notebook product v1.2.11 (R/4.3,Py3.10) to production envs.

Depends on: https://github.com/Sage-Bionetworks/service-catalog-library/pull/309 with AMI off https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v3.0.7
