### PR TITLE
[IT-2922] Update application manager SSO role

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -514,6 +514,21 @@ SsoApplicationManager:
       - arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess
       - arn:aws:iam::aws:policy/SecretsManagerReadWrite
       - arn:aws:iam::aws:policy/AWSCertificateManagerReadOnly
+    inlinePolicy: >-
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "ExecuteEcsTasks",
+            "Effect": "Allow",
+            "Action": [
+              "ecs:RunTask",
+              "ecs:StartTask"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
 
 # Role for a user that can only access AWS Athena in the Synapse Dev account
 SsoSynapseDWDevAthenaUser:


### PR DESCRIPTION
Following the info from AWS docs[1] to set permissions to allow the application manager role to start and run ECS tasks

[1] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security_iam_id-based-policy-examples.html#IAM_run_policies

