### PR TITLE
[IT-2920] Update application manager role policy

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -511,7 +511,7 @@ SsoApplicationManager:
     masterAccountId: !Ref MasterAccount
     managedPolicies:
       - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
-      - arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess
+      - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
       - arn:aws:iam::aws:policy/SecretsManagerReadWrite
       - arn:aws:iam::aws:policy/AWSCertificateManagerReadOnly
     inlinePolicy: >-


### PR DESCRIPTION
The built in `CloudWatchLogsReadOnlyAccess` does not provide enough permissions to view cloudwatch alarms however the `CloudWatchReadOnlyAccess` does provide appropriate permissions to view alarms.

