### PR TITLE
[IT-3000] Supress public bucket rule

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -404,7 +404,7 @@ Resources:
                 - prefix: 'arn:aws:s3:::essentials-awss3lambdaartifactsbucket-'
                 - prefix: 'arn:aws:s3:::cf-templates-'
                 - prefix: 'arn:aws:s3:::cloudformationmanageduploadinfrast-'
-                - prefix: 'arn:aws:s3:::cost-and-usage-reports.sagebase.orggi'
+                - prefix: 'arn:aws:s3:::cost-and-usage-reports.sagebase.org'
                 # This should only match with 2.1.5.1
                 - 'AWS::::Account:140124849929'
             GeneratorId:

--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -403,7 +403,7 @@ Resources:
                 - prefix: 'arn:aws:s3:::bootstrap-awss3cloudformationbucket-'
                 - prefix: 'arn:aws:s3:::essentials-awss3lambdaartifactsbucket-'
                 - prefix: 'arn:aws:s3:::cf-templates-'
-                - prefix: 'arn:aws:s3:::cloudformationmanageduploadinfrast-'
+                - prefix: 'arn:aws:s3:::cloudformationmanageduploadinfra'
                 - prefix: 'arn:aws:s3:::cost-and-usage-reports.sagebase.org'
                 # This should only match with 2.1.5.1
                 - 'AWS::::Account:140124849929'

--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -403,6 +403,8 @@ Resources:
                 - prefix: 'arn:aws:s3:::bootstrap-awss3cloudformationbucket-'
                 - prefix: 'arn:aws:s3:::essentials-awss3lambdaartifactsbucket-'
                 - prefix: 'arn:aws:s3:::cf-templates-'
+                - prefix: 'arn:aws:s3:::cloudformationmanageduploadinfrast-'
+                - prefix: 'arn:aws:s3:::cost-and-usage-reports.sagebase.orggi'
                 # This should only match with 2.1.5.1
                 - 'AWS::::Account:140124849929'
             GeneratorId:


### PR DESCRIPTION
Buckets used for cost reporting can be public so we are suppressing the security hub notifications for those buckets.
