### PR TITLE
[IT-3090] Use AWS config to enable VPC flow logs

### DIFF
--- a/org-formation/725-vpc-flow-logs/README.md
+++ b/org-formation/725-vpc-flow-logs/README.md
@@ -1,0 +1,9 @@
+### Purpose of these templates
+
+The templates in this folder is used to implement the
+[AWS blog post](https://aws.amazon.com/blogs/mt/how-to-enable-vpc-flow-logs-automatically-using-aws-config-rules/)
+to  automatically enable VPC flow logs in every VPC using
+[AWS Config](https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html) rules.
+
+The idea is to enable VPC flow logs in every VPC in our organization and send the logs to
+a central S3 bucket in our AWS LogCentral account.

--- a/org-formation/725-vpc-flow-logs/_tasks.yaml
+++ b/org-formation/725-vpc-flow-logs/_tasks.yaml
@@ -17,11 +17,12 @@ VpcFlowLogsBucket:
     Account: !Ref LogCentralAccount
   Parameters:
     EnableDataLifeCycle: "Enabled"
-    LifecycleDataStorageClass: "Glacier"
+    LifecycleDataStorageClass: "GLACIER"
     LifecycleDataExpiration: "360"
 
 # Use AWS config to enable VPC flow logs and configure it to send logs to the central S3 bucket
 AutoEnableVpcFlowLogs:
+  DependsOn: VpcFlowLogsBucket
   Type: update-stacks
   Template: aws-config-rule.yaml
   StackName: !Sub '${resourcePrefix}-${appName}-remediate'

--- a/org-formation/725-vpc-flow-logs/_tasks.yaml
+++ b/org-formation/725-vpc-flow-logs/_tasks.yaml
@@ -1,0 +1,34 @@
+Parameters:
+  <<: !Include '../_parameters.yaml'
+
+  appName:
+    Type: String
+    Default: 'vpc-flow-logs'
+
+# Create a central S3 bucket in LogCentral account
+VpcFlowLogsBucket:
+  Type: update-stacks
+  Template: bucket.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-bucket'
+  StackDescription: "VPC flow logs bucket"
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+    Account: !Ref LogCentralAccount
+  Parameters:
+    EnableDataLifeCycle: "Enabled"
+    LifecycleDataStorageClass: "Glacier"
+    LifecycleDataExpiration: "360"
+
+# Use AWS config to enable VPC flow logs and configure it to send logs the central S3 bucket
+AutoEnableVpcFlowLogs:
+  Type: update-stacks
+  Template: aws-config-rule.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-remediate'
+  StackDescription: Use AWS config to automatically enable VPC flow logs
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+    Account: '*'
+  Parameters:
+    CentralizedS3LoggingBucket: !CopyValue [!Sub '${resourcePrefix}-${appName}-bucket-BucketName', !Ref LogCentralAccount]

--- a/org-formation/725-vpc-flow-logs/_tasks.yaml
+++ b/org-formation/725-vpc-flow-logs/_tasks.yaml
@@ -20,7 +20,7 @@ VpcFlowLogsBucket:
     LifecycleDataStorageClass: "Glacier"
     LifecycleDataExpiration: "360"
 
-# Use AWS config to enable VPC flow logs and configure it to send logs the central S3 bucket
+# Use AWS config to enable VPC flow logs and configure it to send logs to the central S3 bucket
 AutoEnableVpcFlowLogs:
   Type: update-stacks
   Template: aws-config-rule.yaml

--- a/org-formation/725-vpc-flow-logs/aws-config-rule.yaml
+++ b/org-formation/725-vpc-flow-logs/aws-config-rule.yaml
@@ -1,0 +1,107 @@
+# this template is from https://aws.amazon.com/blogs/mt/how-to-enable-vpc-flow-logs-automatically-using-aws-config-rules/
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'This template will deploy an AWS Config rule to automatically remediate VPC Flow Logs enablement'
+Parameters:
+  CustomConfigRuleName:
+    Description: Name that you want to give to the AWS Config Rule.
+    Type: String
+    Default: ConfigRuleForEnableVpcFlowLogs
+  TrafficType:
+    Type: String
+    AllowedValues:
+      - ACCEPT
+      - REJECT
+      - ALL
+    Description: The value for the VPC Flow Logs traffic type.
+    Default: ALL
+  MaxExecutionFrequency:
+    Type: String
+    AllowedValues:
+      - One_Hour
+      - Three_Hours
+      - Six_Hours
+      - Twelve_Hours
+      - TwentyFour_Hours
+    Description: The maximum frequency with which AWS Config runs evaluations for a rule.
+    Default: One_Hour
+  CentralizedS3LoggingBucket:
+    Description: Name of the S3 bucket in the logging account to send VPC Flow Logs.
+    Type: String
+Resources:
+  ConfigRemediationRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: 'Allow'
+            Principal:
+              Service:
+                - 'ssm.amazonaws.com'
+            Action:
+              - 'sts:AssumeRole'
+      Path: '/'
+      Policies:
+        - PolicyName: aws-config-remediate-vpc-flow-logs-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: 'Allow'
+                Action:
+                  - ec2:CreateFlowLogs
+                  - logs:CreateLogDelivery
+                  - logs:DeleteLogDelivery
+                Resource: arn:aws:logs:*:*:*
+  ConfigRuleForEnableVpcFlowLogs:
+    Type: AWS::Config::ConfigRule
+    Properties:
+      ConfigRuleName: !Ref CustomConfigRuleName
+      Description: ConfigPermissionToInvokeAnAutomaticRemediation
+      InputParameters:
+        trafficType: !Ref TrafficType
+      MaximumExecutionFrequency: !Ref MaxExecutionFrequency
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::EC2::VPC
+      Source:
+        Owner: AWS
+        SourceIdentifier: VPC_FLOW_LOGS_ENABLED
+  VpcFlowLogsRemediationConfiguration:
+    DependsOn: ConfigRuleForEnableVpcFlowLogs
+    Type: AWS::Config::RemediationConfiguration
+    Properties:
+        ConfigRuleName: !Ref CustomConfigRuleName
+        Automatic: true
+        MaximumAutomaticAttempts: 5 #minutes
+        RetryAttemptSeconds: 50 #seconds
+        ResourceType: AWS::EC2::VPC
+        Parameters:
+          VPCIds:
+            ResourceValue:
+              Value: 'RESOURCE_ID'
+          LogDestinationType:
+            StaticValue:
+              Values:
+                - s3
+          LogDestinationArn:
+            StaticValue:
+              Values:
+                - !Sub 'arn:aws:s3:::${CentralizedS3LoggingBucket}'
+          TrafficType:
+            StaticValue:
+              Values:
+                - !Ref TrafficType
+          AutomationAssumeRole:
+            StaticValue:
+              Values:
+                - !GetAtt ConfigRemediationRole.Arn
+        TargetId: AWS-EnableVPCFlowLogs
+        TargetType: SSM_DOCUMENT
+        TargetVersion: 1
+Outputs:
+  ConfigRuleForEnableVpcFlowLogsArn:
+    Description: Arn of the AWS Config Rule to enable VPC Flow Logs
+    Value: !GetAtt ConfigRuleForEnableVpcFlowLogs.Arn
+  ConfigRemediationRoleArn:
+    Description: Arn of the IAM Role to perform auto-emediation
+    Value: !GetAtt ConfigRemediationRole.Arn

--- a/org-formation/725-vpc-flow-logs/bucket.yaml
+++ b/org-formation/725-vpc-flow-logs/bucket.yaml
@@ -1,0 +1,97 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Bucket for VPC flow logs
+Parameters:
+  BucketVersioning:
+    Type: String
+    Description: Enabled to enable bucket versioning, default is Suspended
+    AllowedValues:
+      - Enabled
+      - Suspended
+    Default: Suspended
+  EnableDataLifeCycle:
+    Type: String
+    Description: Enabled to enable bucket lifecycle rule, default is Disabled
+    AllowedValues:
+      - Enabled
+      - Disabled
+    Default: Disabled
+  LifecycleDataTransition:
+    Type: Number
+    Description: Number of days until S3 objects are moved to LifecycleDataStorageClass
+    Default: 30
+    MaxValue: 360
+    MinValue: 1
+  LifecycleDataStorageClass:
+    Type: String
+    Description: S3 bucket objects will transition into this storage class
+    AllowedValues:
+      - DEEP_ARCHIVE
+      - INTELLIGENT_TIERING
+      - STANDARD_IA
+      - ONEZONE_IA
+      - GLACIER
+    Default: GLACIER
+  LifecycleDataExpiration:
+    Type: Number
+    Description: Number of days (from creation) when objects are deleted from S3 and the LifecycleDataStorageClass
+    Default: 365000
+    MaxValue: 365000
+    MinValue: 360
+  BucketName:
+    Type: String
+    Description: (Optional) Name of the created bucket.
+    Default: ""
+Conditions:
+  HasBucketName: !Not [!Equals [!Ref BucketName, ""]]
+Resources:
+  Bucket:
+    Type: "AWS::S3::Bucket"
+    Properties:
+      BucketName: !If [HasBucketName, !Ref BucketName, !Ref 'AWS::NoValue']
+      VersioningConfiguration:
+        Status: !Ref BucketVersioning
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
+      LifecycleConfiguration:
+        Rules:
+        - Id: DataLifecycleRule
+          Status: !Ref EnableDataLifeCycle
+          ExpirationInDays: !Ref LifecycleDataExpiration
+          Transitions:
+            - TransitionInDays: !Ref LifecycleDataTransition
+              StorageClass: !Ref LifecycleDataStorageClass
+  # this policy is from https://aws.amazon.com/blogs/mt/how-to-enable-vpc-flow-logs-automatically-using-aws-config-rules/
+  BucketPolicy:
+    Type: "AWS::S3::BucketPolicy"
+    Properties:
+      Bucket: !Ref Bucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: delivery.logs.amazonaws.com
+          Action: s3:PutObject
+          Resource: [ !Sub "${Bucket.Arn}/*" ]
+          Condition:
+            StringEquals:
+              s3:x-amz-acl: bucket-owner-full-control
+        - Effect: Allow
+          Principal:
+            Service: delivery.logs.amazonaws.com
+          Action: s3:GetBucketAcl
+          Resource: [ !Sub "${Bucket.Arn}" ]
+Outputs:
+  BucketName:
+    Value: !Ref Bucket
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Bucket'
+  BucketArn:
+    Value: !GetAtt Bucket.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-BucketArn'

--- a/org-formation/725-vpc-flow-logs/bucket.yaml
+++ b/org-formation/725-vpc-flow-logs/bucket.yaml
@@ -90,8 +90,8 @@ Outputs:
   BucketName:
     Value: !Ref Bucket
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-Bucket'
+      Name: !Sub '${AWS::StackName}-BucketName'
   BucketArn:
     Value: !GetAtt Bucket.Arn
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-BucketArn'
+      Name: !Sub '${AWS::StackName}-BucketArn'

--- a/org-formation/README.md
+++ b/org-formation/README.md
@@ -34,6 +34,8 @@ prefixed with numbers to enforce the order they are deployed in.
   Configure AWS Config for all accounts.
 - 090 [Systems Manager](./090-systems-manager) \
   Configure Systems Manager for all accounts.
+- 725 [vpc flow logs](./725-vpc-flow-logs) \
+  Use AWS config to enable VPC flow logs
 
 ### Shared Application Infrastructure
 


### PR DESCRIPTION
Security hub says we should enable VPC flow logs.  The solution we are going to use to do that is outlined in the AWS blog post[1] on how to enable vpc flow logs automatically using aws config rules. Their implementation uses control tower, ours will use org-formation.

[1] https://aws.amazon.com/blogs/mt/how-to-enable-vpc-flow-logs-automatically-using-aws-config-rules/
