### PR TITLE
IT-3162: Add hosted zone in sageit

### DIFF
--- a/org-formation/100-shared-dns/_tasks.yaml
+++ b/org-formation/100-shared-dns/_tasks.yaml
@@ -104,3 +104,15 @@ SagebioApiZoneAcmCertificate:
       - !Ref GenieProdAccount
   Parameters:
     DnsDomainName: "api.sagebionetworks.org"
+
+# Hosted zone for 'bridgedigital.health'
+BridgeDigitalHealhHostedZone:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/R53-hostedzone.yaml
+  StackName: !Sub '${resourcePrefix}-bridgedigitalhealth-zone'
+  StackDescription: Create a hosted zone for bridgedigital.health
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref SageITAccount
+  Parameters:
+    DnsDomainName: "bridgedigital.health"

--- a/sceptre/sageit/config/prod/bridgedigital_health_r53_zone.yaml
+++ b/sceptre/sageit/config/prod/bridgedigital_health_r53_zone.yaml
@@ -1,6 +1,0 @@
-template:
-  type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.6/R53-hostedzone.yaml
-stack_name: bridgedigital_health_hosted_zone
-parameters:
-  DnsDomainName: bridgedigital.health

--- a/sceptre/sageit/config/prod/bridgedigital_health_r53_zone.yaml
+++ b/sceptre/sageit/config/prod/bridgedigital_health_r53_zone.yaml
@@ -1,0 +1,6 @@
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.6/R53-hostedzone.yaml
+stack_name: bridgedigital_health_hosted_zone
+parameters:
+  DnsDomainName: bridgedigital.health


### PR DESCRIPTION
This PR adds a hosted zone for 'bridgedigital.health' in the sageit account.
Once in, we can manually change the name servers at the registrar to use the zone.
