### PR TITLE
[IT-3109] remove service user

### DIFF
--- a/sceptre/scipool/config/bmgfki/bootstrap.yaml
+++ b/sceptre/scipool/config/bmgfki/bootstrap.yaml
@@ -1,4 +1,4 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.6/bootstrap.yaml
 stack_name: "bootstrap"

--- a/sceptre/scipool/config/khai/config.yaml
+++ b/sceptre/scipool/config/khai/config.yaml
@@ -1,0 +1,1 @@
+template_bucket_name: "bootstrap-awss3cloudformationbucket-1phkces1gachs"

--- a/sceptre/scipool/config/khai/khai-sc-portfolio-ec2.yaml
+++ b/sceptre/scipool/config/khai/khai-sc-portfolio-ec2.yaml
@@ -1,0 +1,9 @@
+template:
+  path: "sc-portfolio-ec2.yaml"
+stack_name: "khai-sc-portfolio-ec2"
+#dependencies:
+#  - "khai/sc-ec2vpc-launchrole.yaml"
+#  - "khai/sc-enduser-iam.yaml"
+parameters:
+  PorfolioName: "khai: Sage EC2 Porfolio"
+  PorfolioDescription: "EC2 Products for Sage Bionetworks staff"

--- a/sceptre/scipool/config/khai/khai-sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/khai/khai-sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -1,0 +1,19 @@
+template:
+  path: "sc-product-ec2-linux-jumpcloud-notebook.j2"
+stack_name: "khai-sc-product-ec2-linux-jumpcloud-notebook"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+#  - "khai/khai-sc-portfolio-ec2.yaml"
+#  - "khai/khai-sc-ec2-actions.yaml"
+#  - "khai/khai-sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml"
+parameters:
+  ReplaceProvisioningArtifacts: "true"
+  ProductName: "khai: EC2 notebook test"
+sceptre_user_data:
+  # force cloudformation to update stack by setting a random number to the latest product's description
+  ProvisioningArtifactParameters: |
+    - Description: 'Khais custom product {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.8/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+      Name: 'v1.2.8'

--- a/sceptre/scipool/config/khai/sc-portfolio-ec2-external.yaml
+++ b/sceptre/scipool/config/khai/sc-portfolio-ec2-external.yaml
@@ -1,0 +1,9 @@
+template:
+  path: "sc-portfolio-ec2-external.yaml"
+stack_name: "khai-sc-portfolio-ec2-external"
+#dependencies:
+#  - "khai/sc-ec2vpc-launchrole.yaml"
+#  - "khai/sc-enduser-iam.yaml"
+parameters:
+  PorfolioName: "Collaborator EC2 Porfolio"
+  PorfolioDescription: "EC2 Products for Sage Bionetworks collaborators"

--- a/sceptre/scipool/config/khai/sc-portfolio-s3-basic.yaml
+++ b/sceptre/scipool/config/khai/sc-portfolio-s3-basic.yaml
@@ -1,0 +1,8 @@
+template:
+  path: "sc-portfolio-s3-basic.yaml"
+stack_name: "khai-sc-portfolio-s3-basic"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+#dependencies:
+#  - "khai/sc-s3-launchrole.yaml"
+#  - "khai/sc-enduser-iam.yaml"

--- a/sceptre/scipool/config/khai/sc-portfolio-scheduled-jobs.yaml
+++ b/sceptre/scipool/config/khai/sc-portfolio-scheduled-jobs.yaml
@@ -1,0 +1,8 @@
+template_path: "sc-portfolio-scheduled-jobs.yaml"
+stack_name: "khai-sc-portfolio-scheduled-jobs"
+#dependencies:
+#  - "khai/sc-scheduled-jobs-launchrole.yaml"
+#  - "khai/sc-enduser-iam.yaml"
+parameters:
+  PorfolioName: "Sage Scheduled Jobs Porfolio"
+  PorfolioDescription: "Products for Sage Bionetworks staff"

--- a/sceptre/scipool/config/khai/sc-product-assoc-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/khai/sc-product-assoc-ec2-linux-docker.yaml
@@ -1,0 +1,9 @@
+template:
+  path: "sc-ec2-action-associations.yaml"
+stack_name: "khai-sc-product-assoc-ec2-linux-docker"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "khai/khai-sc-product-ec2-linux-docker.yaml"
+parameters:
+  ProductId: !stack_output_external sc-product-ec2-linux-docker::ProductId

--- a/sceptre/scipool/config/khai/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
+++ b/sceptre/scipool/config/khai/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
@@ -1,0 +1,9 @@
+template:
+  path: "sc-ec2-action-associations.yaml"
+stack_name: "khai-sc-product-assoc-ec2-linux-jumpcloud-notebook"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "khai/khai-sc-product-ec2-linux-jumpcloud-notebook.yaml"
+parameters:
+  ProductId: !stack_output_external sc-product-ec2-linux-jumpcloud-notebook::ProductId

--- a/sceptre/scipool/config/khai/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/khai/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
@@ -1,0 +1,9 @@
+template:
+  path: "sc-ec2-action-associations.yaml"
+stack_name: "khai-sc-product-assoc-ec2-windows-jumpcloud"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "khai/khai-sc-product-ec2-windows-jumpcloud.yaml"
+parameters:
+  ProductId: !stack_output_external sc-product-ec2-windows-jumpcloud::ProductId

--- a/sceptre/scipool/config/khai/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/khai/sc-product-ec2-linux-docker.yaml
@@ -1,0 +1,47 @@
+template:
+  path: "sc-product-ec2-linux-docker.j2"
+stack_name: "khai-sc-product-ec2-linux-docker"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "khai/khai-sc-portfolio-ec2.yaml"
+  - "khai/khai-sc-portfolio-ec2-external.yaml"
+#  - "khai/khai-sc-ec2-actions.yaml"
+parameters:
+  ProductName: "EC2: Linux Docker"
+  ReplaceProvisioningArtifacts: "true"
+sceptre_user_data:
+  # force cloudformation to update stack by setting a random number to the latest product's description
+  ProvisioningArtifactParameters: |
+    - Description: 'Baseline release.'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.18/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.18'
+    - Description: 'Increase EBS volume size limit to 5 TB.'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.19/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.19'
+    - Description: 'Reduce instance types'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.21/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.21'
+    - Description: 'Add instance types x2gd, g4dn, and i3en.'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.22/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.22'
+    - Description: 'Update for AWS VPN.'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.36/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.36'
+    - Description: 'Update base AMI.'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.37/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.37'
+    - Description: 'Propagate instance tags to attached volumes'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.40/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.1.40'
+    - Description: 'Change to less costly volume type {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.9/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.2.9'

--- a/sceptre/scipool/config/khai/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/khai/sc-product-ec2-windows-jumpcloud.yaml
@@ -1,0 +1,69 @@
+template:
+  path: "sc-product-ec2-windows-jumpcloud.j2"
+stack_name: "sc-product-ec2-windows-jumpcloud"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "khai/khai-sc-portfolio-ec2.yaml"
+  - "khai/khai-sc-ec2-actions.yaml"
+parameters:
+  ReplaceProvisioningArtifacts: "true"
+sceptre_user_data:
+  # force cloudformation to update stack by setting a random number to the latest product's description
+  ProvisioningArtifactParameters: |
+    - Description: 'Baseline version.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml'
+      Name: 'v1.0.0'
+    - Description: 'Update base AMI and Cloudformation hooks'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.3/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.3'
+    - Description: 'Use SynapseTagger'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.7/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.7'
+    - Description: 'Remove VpcName input'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.8/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.8'
+    - Description: 'Update for strides'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.9/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.9'
+    - Description: 'Include params in mapping'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.10/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.10'
+    - Description: 'Fix policies.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.13/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.13'
+    - Description:  'Restore set_env_var.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.14/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.14'
+    - Description:  'Update for AWS VPN.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.36/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.36'
+    - Description: 'Propagate instance tags to attached volumes'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.40/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.40'
+    - Description: 'Pin Jumpcloud powershell module version 2.0.2'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.41/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.41'
+    - Description: 'Pin Jumpcloud powershell module version 2.1.1'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.42/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.42'
+    - Description: 'Remove JC user to instance association'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.43/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.43'
+    - Description: 'Remove instance assocation {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.44/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.1.44'

--- a/sceptre/scipool/config/khai/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/khai/sc-product-s3-private-enc.yaml
@@ -1,0 +1,58 @@
+template:
+  path: "sc-product-s3-private-enc.j2"
+stack_name: "khai-sc-product-s3-private-enc"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "khai/khai-sc-portfolio-s3-basic.yaml"
+sceptre_user_data:
+  # force cloudformation to update stack by setting a random number to the latest product's description
+  ProvisioningArtifactParameters: |
+    - Description: 'Baseline version.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/s3/sc-s3-encrypted-ra-v1.0.0.yaml'
+      Name: 'v1.0.0'
+    - Description: 'Fix resource contention bug with S3 custom resources'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.1/s3/sc-s3-encrypted-ra-v1.0.1.yaml'
+      Name: 'v1.0.1'
+    - Description: 'Use SynapseTagger'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.7/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.7'
+    - Description: 'Remove VpcName input'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.8/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.8'
+    - Description: 'Update for strides'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.9/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.9'
+    - Description: 'Include params in mapping.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.10/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.10'
+    - Description:  'Include option to restrict bucket downloads to same region.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.15/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.15'
+    - Description:  'Retain bucket on SC product termination.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.23'
+    - Description:  'Enable intelligent tiering.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.24/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.24'
+    - Description:  'Remove option to add arbitrary IAM ARN.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.25/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.25'
+    - Description:  'Pin cfn-cr-same-region-bucket-download lambda.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.33/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.33'
+    - Description:  'Disable bucket ACLs. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.38/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.1.38'

--- a/sceptre/scipool/config/khai/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/khai/sc-product-s3-synapse.yaml
@@ -1,0 +1,74 @@
+template:
+  path: "sc-product-s3-synapse.j2"
+stack_name: "khai-sc-product-s3-synapse"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "khai/khai-sc-portfolio-s3-basic.yaml"
+sceptre_user_data:
+  # force cloudformation to update stack by setting a random number to the latest product's description
+  ProvisioningArtifactParameters: |
+    - Description: 'Baseline version.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/s3/sc-s3-synapse-ra-v1.0.0.yaml'
+      Name: 'v1.0.0'
+    - Description: 'Remove SynapseProdARN parameter.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.1/s3/sc-s3-synapse-ra-v1.0.1.yaml'
+      Name: 'v1.0.1'
+    - Description: 'Fix resource contention bug with S3 custom resources'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.2/s3/sc-s3-synapse-ra-v1.0.2.yaml'
+      Name: 'v1.0.2'
+    - Description: 'Allow multiple synapse bucket owners'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.6/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.6'
+    - Description: 'Use SynapseTagger'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.7/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.7'
+    - Description: 'Remove VpcName input'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.8/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.8'
+    - Description: 'Update for strides'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.9/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.9'
+    - Description: 'Include params in mapping.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.10/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.10'
+    - Description:  'Include option to restrict bucket downloads to same region.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.15/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.15'
+    - Description:  'Fix cross account access.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.20/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.20'
+    - Description:  'Retain bucket on SC product termination.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.23/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.23'
+    - Description:  'Enable intelligent tiering.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.24/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.24'
+    - Description:  'Remove option to add arbitrary IAM ARN.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.25/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.25'
+    - Description:  'Pin cfn-cr-same-region-bucket-download lambda.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.33/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.33'
+    - Description:  'Disable bucket ACLs.'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.38/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.38'
+    - Description:  'Remove bucket ACL setting. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.39/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.1.39'

--- a/sceptre/scipool/config/khai/sc-product-scheduled-jobs.yaml
+++ b/sceptre/scipool/config/khai/sc-product-scheduled-jobs.yaml
@@ -1,0 +1,38 @@
+template:
+  path: "sc-product-scheduled-jobs.j2"
+stack_name: "khai-sc-product-scheduled-jobs"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "khai/sc-portfolio-scheduled-jobs.yaml"
+sceptre_user_data:
+  # force cloudformation to update stack by setting a random number to the latest product's description
+  ProvisioningArtifactParameters: |
+    - Description: 'Baseline version.'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.30/batch/sc-batch-fargate.yaml'
+      Name: 'v1.1.30'
+    - Description: 'Optional Command paramter'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.31/batch/sc-batch-fargate.yaml'
+      Name: 'v1.1.31'
+    - Description: 'Fix Command paramter.'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.32/batch/sc-batch-fargate.yaml'
+      Name: 'v1.1.32'
+    - Description: 'Refactor batch tagger.'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.33/batch/sc-batch-fargate.yaml'
+      Name: 'v1.1.33'
+    - Description: 'Custom job timeout and retries.'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.46/batch/sc-batch-fargate.yaml'
+      Name: 'v1.1.46'
+    - Description: 'Update memory options.'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.2/batch/sc-batch-fargate.yaml'
+      Name: 'v1.2.2'
+    - Description: 'Fix scheduled jobs. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.3/batch/sc-batch-fargate.yaml'
+      Name: 'v1.2.3'

--- a/sceptre/scipool/config/khai/sc-tag-options.yaml
+++ b/sceptre/scipool/config/khai/sc-tag-options.yaml
@@ -1,0 +1,18 @@
+# Tag options for internal Sage teams
+template:
+  path: "sc-tag-options.j2"
+stack_name: "khai-sc-tag-options"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "khai/khai-sc-portfolio-ec2.yaml"
+  - "khai/khai-sc-portfolio-ec2-external.yaml"
+  - "khai/khai-sc-portfolio-s3-basic.yaml"
+  - "khai/khai-sc-portfolio-scheduled-jobs.yaml"
+sceptre_user_data:
+  CostCenters: !from_json
+    - !request 'https://mips-api.finops.sageit.org/tags?limit=25&enable_other_code=true'
+  ProductIDs:
+    - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
+    - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId
+    - !stack_output_external sc-portfolio-scheduled-jobs::SCScheduledJobsPortfolioId


### PR DESCRIPTION
We have switch all repos that use this service user from travis to github action (OIDC) therefore we should remove the service user. The only difference in the updated template is the removal of the service user.
