### PR TITLE
[IT-3128] Remove service user

### DIFF
--- a/sceptre/scicomp/config/prod/bootstrap.yaml
+++ b/sceptre/scicomp/config/prod/bootstrap.yaml
@@ -1,4 +1,4 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.6/bootstrap.yaml
 stack_name: bootstrap


### PR DESCRIPTION
We have switch all repos that use this service user from travis to github action (OIDC) therefore we should remove the service user. The only difference in the updated template is the removal of the service user.

