### PR TITLE
Setup OIDC access to github for SC login app

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -697,3 +697,51 @@ GithubOidcSageBionetworksMTBSageIT:
   DefaultOrganizationBinding:
     Account: !Ref SageITAccount
     Region: us-east-1
+
+# for https://github.com/Sage-Bionetworks/synapse-login-aws-infra
+GithubOidcSageBioNetworksScSynapseLoginInfra:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-sc-synapse-login-infra
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapse-login-infra
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "synapse-login-aws-infra"
+        branches: ["develop","prod"]
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref BmgfkiAccount
+      - !Ref ScipoolDevAccount
+      - !Ref ScipoolProdAccount
+    Region: us-east-1
+
+# for https://github.com/Sage-Bionetworks/synapse-login-scipool
+GithubOidcSageBioNetworksScSynapseLogin:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-sc-synapse-login
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapse-login
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk
+      - arn:aws:iam::aws:policy/AmazonS3FullAccess
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "synapse-login-aws-infra"
+        branches: ["develop","prod"]
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref BmgfkiAccount
+      - !Ref ScipoolDevAccount
+      - !Ref ScipoolProdAccount
+    Region: us-east-1

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -456,6 +456,8 @@ GithubOidcSciPoolProdSageBionetworksSynapseLoginAwsInfra:
     Repositories:
       - name: "synapse-login-aws-infra"
         branches: ["prod"]
+      - name: "synapse-login-scipool"
+        branches: ["prod"]
   DefaultOrganizationBinding:
     Account: !Ref ScipoolProdAccount
     Region: us-east-1
@@ -476,6 +478,8 @@ GithubOidcSciPoolDevSageBionetworksSynapseLoginAwsInfra:
     Repositories:
       - name: "synapse-login-aws-infra"
         branches: ["develop"]
+      - name: "synapse-login-scipool"
+        branches: ["develop"]
   DefaultOrganizationBinding:
     Account: !Ref ScipoolDevAccount
     Region: us-east-1
@@ -495,7 +499,9 @@ GithubOidcBmgfkiSageBionetworksSynapseLoginAwsInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "synapse-login-aws-infra"
-        branches: ["prod"]
+        branches: ["bmgfki"]
+      - name: "synapse-login-scipool"
+        branches: ["bmgfki"]
   DefaultOrganizationBinding:
     Account: !Ref BmgfkiAccount
     Region: us-east-1
@@ -696,52 +702,4 @@ GithubOidcSageBionetworksMTBSageIT:
         branches: ["main", "feature"]
   DefaultOrganizationBinding:
     Account: !Ref SageITAccount
-    Region: us-east-1
-
-# for https://github.com/Sage-Bionetworks/synapse-login-aws-infra
-GithubOidcSageBioNetworksScSynapseLoginInfra:
-  Type: update-stacks
-  DependsOn: GithubOidcSageBionetworks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
-  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-sc-synapse-login-infra
-  Parameters:
-    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapse-login-infra
-    ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AdministratorAccess"
-      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
-  TemplatingContext:
-    GitHubOrg: "Sage-Bionetworks"
-    Repositories:
-      - name: "synapse-login-aws-infra"
-        branches: ["develop","prod"]
-  DefaultOrganizationBinding:
-    Account:
-      - !Ref BmgfkiAccount
-      - !Ref ScipoolDevAccount
-      - !Ref ScipoolProdAccount
-    Region: us-east-1
-
-# for https://github.com/Sage-Bionetworks/synapse-login-scipool
-GithubOidcSageBioNetworksScSynapseLogin:
-  Type: update-stacks
-  DependsOn: GithubOidcSageBionetworks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
-  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-sc-synapse-login
-  Parameters:
-    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapse-login
-    ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk
-      - arn:aws:iam::aws:policy/AmazonS3FullAccess
-  TemplatingContext:
-    GitHubOrg: "Sage-Bionetworks"
-    Repositories:
-      - name: "synapse-login-aws-infra"
-        branches: ["develop","prod"]
-  DefaultOrganizationBinding:
-    Account:
-      - !Ref BmgfkiAccount
-      - !Ref ScipoolDevAccount
-      - !Ref ScipoolProdAccount
     Region: us-east-1

--- a/sceptre/strides/config/prod/github-oidc-sage-bionetworks.yaml
+++ b/sceptre/strides/config/prod/github-oidc-sage-bionetworks.yaml
@@ -13,8 +13,6 @@ sceptre_user_data:
   GitHubOrg: "Sage-Bionetworks"
   Repositories:
     - name: "synapse-login-aws-infra"
-      branches: ["dev", "prod"]
-    - name: "synapse-login-aws-infra"
       branches: ["develop", "prod"]
     - name: "synapse-login-scipool"
       branches: ["develop", "prod"]

--- a/sceptre/strides/config/prod/github-oidc-sage-bionetworks.yaml
+++ b/sceptre/strides/config/prod/github-oidc-sage-bionetworks.yaml
@@ -14,3 +14,7 @@ sceptre_user_data:
   Repositories:
     - name: "synapse-login-aws-infra"
       branches: ["dev", "prod"]
+    - name: "synapse-login-aws-infra"
+      branches: ["develop", "prod"]
+    - name: "synapse-login-scipool"
+      branches: ["develop", "prod"]


### PR DESCRIPTION
In anticipation of moving the service catalog login app to github actions we are setting up GH OIDC access for the repos.

The idea is to be able to allow the login app repos access to the AWS accounts it needs to deploy to (bmgfki, scipooldev, scipoolprod, and strides)

