### PR TITLE
Fix GH OIDC for synapse login app

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -459,7 +459,9 @@ GithubOidcSciPoolProdSageBionetworksSynapseLoginAwsInfra:
       - name: "synapse-login-scipool"
         branches: ["prod"]
   DefaultOrganizationBinding:
-    Account: !Ref ScipoolProdAccount
+    Account:
+      - !Ref ScipoolProdAccount
+      - !Ref BmgfkiAccount
     Region: us-east-1
 
 GithubOidcSciPoolDevSageBionetworksSynapseLoginAwsInfra:
@@ -482,28 +484,6 @@ GithubOidcSciPoolDevSageBionetworksSynapseLoginAwsInfra:
         branches: ["develop"]
   DefaultOrganizationBinding:
     Account: !Ref ScipoolDevAccount
-    Region: us-east-1
-
-GithubOidcBmgfkiSageBionetworksSynapseLoginAwsInfra:
-  Type: update-stacks
-  DependsOn: GithubOidcSageBionetworks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
-  StackName: !Sub ${resourcePrefix}-${appName}-bmgfki-synapse-login-aws-infra
-  Parameters:
-    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-bmgfki-synapse-login-aws-infra
-    ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AdministratorAccess"
-      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
-  TemplatingContext:
-    GitHubOrg: "Sage-Bionetworks"
-    Repositories:
-      - name: "synapse-login-aws-infra"
-        branches: ["bmgfki"]
-      - name: "synapse-login-scipool"
-        branches: ["bmgfki"]
-  DefaultOrganizationBinding:
-    Account: !Ref BmgfkiAccount
     Region: us-east-1
 
 GithubOidcSageBionetworksWebMonorepoInfra:

--- a/sceptre/strides/config/prod/github-oidc-sage-bionetworks.yaml
+++ b/sceptre/strides/config/prod/github-oidc-sage-bionetworks.yaml
@@ -13,6 +13,6 @@ sceptre_user_data:
   GitHubOrg: "Sage-Bionetworks"
   Repositories:
     - name: "synapse-login-aws-infra"
-      branches: ["develop", "prod"]
+      branches: ["prod"]
     - name: "synapse-login-scipool"
-      branches: ["develop", "prod"]
+      branches: ["prod"]


### PR DESCRIPTION
We deploy the login app to AWS from only two branches develop or prod, one development account and three prod accounts.  Update the OIDC branches accordingly.

