### PR TITLE
Setup GH OIDC for packer repo

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -416,6 +416,8 @@ GithubOidcPackerImageDeploy:
         branches: ["master"]
       - name: "packer-rstudio"
         branches: ["master", "v2.1.3"]
+      - name: "packer-amazonlinux-docker"
+        branches: ["master"]
   DefaultOrganizationBinding:
     Account: !Ref ImageCentralAccount
     Region: us-east-1


### PR DESCRIPTION
Allow packer-amazonlinux-docker[1] repo to deploy to imagecentral AWS account.

[1] https://github.com/Sage-Bionetworks-IT/packer-amazonlinux-docker
