### PR TITLE
update GH OIDC for packer

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -415,7 +415,7 @@ GithubOidcPackerImageDeploy:
       - name: "packer-base-ubuntu-jammy"
         branches: ["master"]
       - name: "packer-rstudio"
-        branches: ["master", "v2.1.3"]
+        branches: ["master"]
   DefaultOrganizationBinding:
     Account: !Ref ImageCentralAccount
     Region: us-east-1


### PR DESCRIPTION
Remove allowing a specific branch to deploy to imagecentral AWS account.  @xschildw set this up for testing which he has since completed.

