### PR TITLE
Remove hard dependency from essentials stack

### DIFF
--- a/sceptre/admincentral/config/prod/essentials.yaml
+++ b/sceptre/admincentral/config/prod/essentials.yaml
@@ -1,9 +1,12 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.3/templates/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
-  VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
+  KmsInfraKeyPrincipals:
+    - "arn:aws:iam::745159704268:root"
+    - !stack_output_external "bootstrap::AWSIAMSsmParamLambdaExecutionRoleArn"
+    - !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"
   LambdaBucketVersioning: Enabled

--- a/sceptre/organizations/config/prod/essentials.yaml
+++ b/sceptre/organizations/config/prod/essentials.yaml
@@ -1,8 +1,11 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.3/templates/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
-  VpcPeeringRequesterAwsAccountId: !ssm "/infra/AdmincentralAwsAccountId"
+  KmsInfraKeyPrincipals:
+    - "arn:aws:iam::531805629419:root"
+    - !stack_output_external "bootstrap::AWSIAMSsmParamLambdaExecutionRoleArn"
+    - !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"

--- a/sceptre/scicomp/config/prod/essentials.yaml
+++ b/sceptre/scicomp/config/prod/essentials.yaml
@@ -1,8 +1,11 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.3/templates/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
-  VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
+  KmsInfraKeyPrincipals:
+    - "arn:aws:iam::055273631518:root"
+    - !stack_output_external "bootstrap::AWSIAMSsmParamLambdaExecutionRoleArn"
+    - !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"

--- a/sceptre/scipool/config/bmgfki/essentials.yaml
+++ b/sceptre/scipool/config/bmgfki/essentials.yaml
@@ -1,8 +1,11 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.3/templates/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "bmgfki/bootstrap.yaml"
 parameters:
-  VpcPeeringRequesterAwsAccountId: "745159704268"  # org-sagebase-admincentral
+  KmsInfraKeyPrincipals:
+    - "arn:aws:iam::464102568320:root"
+    - !stack_output_external "bootstrap::AWSIAMSsmParamLambdaExecutionRoleArn"
+    - !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"

--- a/sceptre/scipool/config/develop/essentials.yaml
+++ b/sceptre/scipool/config/develop/essentials.yaml
@@ -1,8 +1,11 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.3/templates/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "develop/bootstrap.yaml"
 parameters:
-  VpcPeeringRequesterAwsAccountId: "745159704268"
+  KmsInfraKeyPrincipals:
+    - "arn:aws:iam::465877038949:root"
+    - !stack_output_external "bootstrap::AWSIAMSsmParamLambdaExecutionRoleArn"
+    - !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"

--- a/sceptre/scipool/config/prod/essentials.yaml
+++ b/sceptre/scipool/config/prod/essentials.yaml
@@ -1,8 +1,11 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.3/templates/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
-  VpcPeeringRequesterAwsAccountId: "745159704268"
+  KmsInfraKeyPrincipals:
+    - "arn:aws:iam::237179673806:root"
+    - !stack_output_external "bootstrap::AWSIAMSsmParamLambdaExecutionRoleArn"
+    - !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"

--- a/sceptre/scipool/config/strides/essentials.yaml
+++ b/sceptre/scipool/config/strides/essentials.yaml
@@ -1,8 +1,11 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.3/templates/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "strides/bootstrap.yaml"
 parameters:
-  VpcPeeringRequesterAwsAccountId: "745159704268"  # org-sagebase-admincentral
+  KmsInfraKeyPrincipals:
+    - "arn:aws:iam::423819316185:root"
+    - !stack_output_external "bootstrap::AWSIAMSsmParamLambdaExecutionRoleArn"
+    - !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"

--- a/sceptre/securitycentral/config/prod/essentials.yaml
+++ b/sceptre/securitycentral/config/prod/essentials.yaml
@@ -1,8 +1,11 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.3/templates/essentials.yaml
 stack_name: essentials
 dependencies:
   - prod/bootstrap.yaml
 parameters:
-  VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
+  KmsInfraKeyPrincipals:
+    - "arn:aws:iam::140124849929:root"
+    - !stack_output_external "bootstrap::AWSIAMSsmParamLambdaExecutionRoleArn"
+    - !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"

--- a/sceptre/strides-ampad-workflows/config/prod/essentials.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/essentials.yaml
@@ -1,8 +1,11 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.3/templates/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
-  VpcPeeringRequesterAwsAccountId: "745159704268"  # org-sagebase-admincentral
+  KmsInfraKeyPrincipals:
+    - "arn:aws:iam::751556145034:root"
+    - !stack_output_external "bootstrap::AWSIAMSsmParamLambdaExecutionRoleArn"
+    - !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"

--- a/sceptre/strides/config/prod/essentials.yaml
+++ b/sceptre/strides/config/prod/essentials.yaml
@@ -1,8 +1,11 @@
 template:
   type: http
-  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.0/templates/essentials.yaml
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.3/templates/essentials.yaml
 stack_name: "essentials"
 dependencies:
   - "prod/bootstrap.yaml"
 parameters:
-  VpcPeeringRequesterAwsAccountId: "745159704268"  # org-sagebase-admincentral
+  KmsInfraKeyPrincipals:
+    - "arn:aws:iam::423819316185:root"
+    - !stack_output_external "bootstrap::AWSIAMSsmParamLambdaExecutionRoleArn"
+    - !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"


### PR DESCRIPTION
The older version of the essentials.yaml template contained an `!ImportValue` reference which sets up a hard dependency which makes it difficult to update values.  We update to a newer version which takes in a value to allow users to more easily change values thus making easier to do updates.

This also removes a VPC peering role which we no longer use since we switched from VPC peering to the transit gateway.

