### PR TITLE
PLFM-8054: Use my account as temp

### DIFF
--- a/sceptre/synapseprod/config/prod/snowflake-access.yaml
+++ b/sceptre/synapseprod/config/prod/snowflake-access.yaml
@@ -2,5 +2,5 @@ template:
   path: snowflake-access.yaml
 stack_name: snowflake-accesss
 parameters:
-  SnowflakeAccountArn: "arn:aws:iam::449435941126:user/someUser"
+  SnowflakeAccountArn: "arn:aws:iam::449435941126:user/x.schildwachter@sagebase.org"
   SnowflakeAccountExternalId: !ssm /infra/SnowflakeAccountExternalId


### PR DESCRIPTION
#990 failed because the account arn was invalid so I replaced it by mine. It is temporary to create the role, then the role arn is sent to Tom who in turns sends back an actual role and externalID.
