### PR TITLE
Replace service account

### DIFF
--- a/sceptre/scipool/config/bmgfki/cfn-macro-ssm-param.yaml
+++ b/sceptre/scipool/config/bmgfki/cfn-macro-ssm-param.yaml
@@ -6,4 +6,4 @@ dependencies:
   - "bmgfki/bootstrap.yaml"
 parameters:
   LambdaExecutionRoleArn: !stack_output_external "bootstrap::AWSIAMSsmParamLambdaExecutionRoleArn"
-  LambdaServiceRoleArn: !stack_output_external "bootstrap::AWSIAMCfServiceRoleArn"
+  LambdaServiceRoleArn: !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"

--- a/sceptre/scipool/config/bmgfki/sc-kms-key.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-kms-key.yaml
@@ -7,5 +7,5 @@ dependencies:
   - "bmgfki/bootstrap.yaml"
 parameters:
   AdminRoleArns:
-    - !stack_output_external bootstrap::AWSIAMCfServiceRoleArn
+    - !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"
     - "arn:aws:iam::464102568320:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_686ebad4f95d49f9"

--- a/sceptre/scipool/config/develop/cfn-macro-ssm-param.yaml
+++ b/sceptre/scipool/config/develop/cfn-macro-ssm-param.yaml
@@ -6,4 +6,4 @@ dependencies:
   - "develop/bootstrap.yaml"
 parameters:
   LambdaExecutionRoleArn: !stack_output_external "bootstrap::AWSIAMSsmParamLambdaExecutionRoleArn"
-  LambdaServiceRoleArn: !stack_output_external "bootstrap::AWSIAMCfServiceRoleArn"
+  LambdaServiceRoleArn: !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"

--- a/sceptre/scipool/config/develop/sc-kms-key.yaml
+++ b/sceptre/scipool/config/develop/sc-kms-key.yaml
@@ -7,6 +7,6 @@ dependencies:
   - "develop/bootstrap.yaml"
 parameters:
   AdminRoleArns:
-    - !stack_output_external bootstrap::AWSIAMCfServiceRoleArn
+    - !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"
     - "arn:aws:sts::465877038949:assumed-role/AWSReservedSSO_Administrator_a99f9cc4789c4254/khai.do@sagebase.org"
     - "arn:aws:sts::465877038949:assumed-role/AWSReservedSSO_Administrator_a99f9cc4789c4254/x.schildwachter@sagebase.org"

--- a/sceptre/scipool/config/prod/cfn-macro-ssm-param.yaml
+++ b/sceptre/scipool/config/prod/cfn-macro-ssm-param.yaml
@@ -6,4 +6,4 @@ dependencies:
   - "prod/bootstrap.yaml"
 parameters:
   LambdaExecutionRoleArn: !stack_output_external "bootstrap::AWSIAMSsmParamLambdaExecutionRoleArn"
-  LambdaServiceRoleArn: !stack_output_external "bootstrap::AWSIAMCfServiceRoleArn"
+  LambdaServiceRoleArn: !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"

--- a/sceptre/scipool/config/prod/sc-kms-key.yaml
+++ b/sceptre/scipool/config/prod/sc-kms-key.yaml
@@ -7,6 +7,6 @@ dependencies:
   - "prod/bootstrap.yaml"
 parameters:
   AdminRoleArns:
-    - !stack_output_external bootstrap::AWSIAMCfServiceRoleArn
+    - !stack_output_external "sagebase-github-oidc-sage-bionetworks-it::ProviderRoleArn"
     - "arn:aws:sts::237179673806:assumed-role/AWSReservedSSO_Administrator_56cd956ee776e6c0/khai.do@sagebase.org"
     - "arn:aws:sts::237179673806:assumed-role/AWSReservedSSO_Administrator_56cd956ee776e6c0/x.schildwachter@sagebase.org"

--- a/sceptre/scipool/config/strides/cfn-macro-ssm-param.yaml
+++ b/sceptre/scipool/config/strides/cfn-macro-ssm-param.yaml
@@ -6,4 +6,4 @@ dependencies:
   - "strides/bootstrap.yaml"
 parameters:
   LambdaExecutionRoleArn: !stack_output_external "bootstrap::AWSIAMSsmParamLambdaExecutionRoleArn"
-  LambdaServiceRoleArn: !stack_output_external "bootstrap::AWSIAMCfServiceRoleArn"
+  LambdaServiceRoleArn: !stack_output_external "github-oidc-sage-bionetworks-it::ProviderRoleArn"

--- a/sceptre/scipool/config/strides/sc-kms-key.yaml
+++ b/sceptre/scipool/config/strides/sc-kms-key.yaml
@@ -7,6 +7,6 @@ dependencies:
   - "strides/bootstrap.yaml"
 parameters:
   AdminRoleArns:
-    - !stack_output_external bootstrap::AWSIAMCfServiceRoleArn
+    - !stack_output_external "github-oidc-sage-bionetworks-it::ProviderRoleArn"
     - "arn:aws:sts::423819316185:assumed-role/strides-admin/khai.do@sagebase.org"
     - "arn:aws:sts::423819316185:assumed-role/strides-admin/x.schildwachter@sagebase.org"


### PR DESCRIPTION
We are in the process of switch aws service accounts used by travis with github OIDC roles.  There are still things like lambdas that need assistance from service accounts to deploy resources into AWS.  This is to allow lamdas to use the GH OIDC roles.
