### PR TITLE
Deploy one merge at a time

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,9 @@ on:
   push:
     branches: ['*']
 
+# Ensures that only one deploy task per branch/environment will run at a time.
+concurrency: ci-${{ github.ref }}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We want the CI to only deploy once per merge otherwise the deployments might get into a bad state.

From GH action docs, this change should do the following..

  "When a concurrent job or workflow is queued, if another job or
  workflow using the same concurrency group in the repository is
  in progress, the queued job or workflow will be pending."

[1] https://docs.github.com/en/actions/using-jobs/using-concurrency

