### PR TITLE
IT-2789: Enable key rotation

### DIFF
--- a/sceptre/synapsedev/templates/SynapseCMK-template.json
+++ b/sceptre/synapsedev/templates/SynapseCMK-template.json
@@ -240,7 +240,7 @@
             "Type": "AWS::KMS::Key",
             "Properties": {
                 "Description": "The master encryption key used to encypt/decrypt all Synapse master secrets",
-                "EnableKeyRotation": false,
+                "EnableKeyRotation": true,
                 "KeyPolicy": {
                     "Version": "2012-10-17",
                     "Id": "key-default-1",


### PR DESCRIPTION
This  PR (re-)enables key rotation for the synapse-dev-cmk key.
