### PR TITLE
[IT-3356] Setup guardduty initiated malware protection

### DIFF
--- a/org-formation/070-guard-duty/GuardDuty.yaml
+++ b/org-formation/070-guard-duty/GuardDuty.yaml
@@ -1,0 +1,107 @@
+# From https://github.com/org-formation/org-formation-reference/tree/master/src/templates/070-guard-duty
+AWSTemplateFormatVersion: '2010-09-09-OC'
+
+Parameters:
+  resourcePrefix:
+    Type: String
+
+  accountId:
+    Type: String
+    Description: The identifier from the account used to manage GuardDuty
+
+Resources:
+
+  GuardDutyBucket:
+    Type: AWS::S3::Bucket
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E1012
+    OrganizationBinding: !Ref LogArchiveBinding
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub '${resourcePrefix}-guardduty-finding'
+      AccessControl: Private
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  GuardDutyBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E1012
+    OrganizationBinding: !Ref LogArchiveBinding
+    Properties:
+      Bucket: !Ref GuardDutyBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: GuardDutyWrite
+            Effect: Allow
+            Principal:
+              Service: guardduty.amazonaws.com
+            Action:
+              - s3:PutObject
+              - s3:GetBucketLocation
+            Resource:
+              - !Sub 'arn:aws:s3:::${GuardDutyBucket}/*'
+              - !GetAtt GuardDutyBucket.Arn
+
+  Detector:
+    OrganizationBinding: !Ref AllBinding
+    Type: AWS::GuardDuty::Detector
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E1012
+    Properties:
+      Enable: true
+      FindingPublishingFrequency: FIFTEEN_MINUTES
+      Features:
+        - Name: EBS_MALWARE_PROTECTION
+          Status: ENABLED
+
+  Master:
+    OrganizationBinding: !Ref MemberBinding
+    Type: AWS::GuardDuty::Master
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E1012
+    Properties:
+      DetectorId: !Ref Detector
+      MasterId: !Ref accountId
+
+  Member:
+    Type: AWS::GuardDuty::Member
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [E1012, E1010]
+    ForeachAccount:
+      !Ref MemberBinding
+    Properties:
+      DetectorId: !Ref Detector
+      Email: !GetAtt CurrentAccount.RootEmail
+      MemberId: !Ref CurrentAccount
+      Status: Invited
+      DisableEmailNotification: true
+
+Outputs:
+  DetectorId:
+    Value: !Ref Detector
+    Export:
+      Name: !Sub '${AWS::StackName}-detector-id'

--- a/org-formation/070-guard-duty/_tasks.yaml
+++ b/org-formation/070-guard-duty/_tasks.yaml
@@ -12,7 +12,7 @@ Parameters:
 
 GuardDuty:
   Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/GuardDuty/guard-duty.yaml
+  Template: ./GuardDuty.yaml
   StackName: !Sub '${resourcePrefix}-${appName}'
   StackDescription: GuardDuty - Base
   DefaultOrganizationBindingRegion: !Ref primaryRegion


### PR DESCRIPTION
Guardduty has detected suspicious activity in our EC2 instances in the past.  This change is to improve our security posture

Enable GuardDuty-initiated malware scan[1] to initiate an agentless scan of the Amazon EBS volumes attached to the Amazon EC2 instances and container workloads, automatically whenever GuardDuty generates any of the Findings that invoke GuardDuty-initiated malware scan[2]

[1] https://docs.aws.amazon.com/guardduty/latest/ug/gdu-initiated-malware-scan.html?icmpid=docs_gd_help_panel
[2] https://docs.aws.amazon.com/guardduty/latest/ug/gd-findings-initiate-malware-protection-scan?icmpid=docs_console_unmapped

