### PR TITLE
[IT-3128] Remove service user

### DIFF
--- a/sceptre/scicomp/config/prod/bootstrap.yaml
+++ b/sceptre/scicomp/config/prod/bootstrap.yaml
@@ -1,4 +1,4 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.6/bootstrap.yaml
 stack_name: bootstrap


### PR DESCRIPTION
This is a redo of b4d08b9 which was reverted in 2a60b99 due to a dependency on the Emory pipeline.

We are now removing the Emory pipeline which should allow us to remove this service user.

depends on https://github.com/Sage-Bionetworks/scicomp-provisioner/pull/615

