### PR TITLE
Revert "[IT-3128] Remove service user (#1011)"

### DIFF
--- a/sceptre/scicomp/config/prod/bootstrap.yaml
+++ b/sceptre/scicomp/config/prod/bootstrap.yaml
@@ -1,4 +1,4 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.6/bootstrap.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
 stack_name: bootstrap


### PR DESCRIPTION
This reverts commit 43f713e68ecbcfd74af3902d90623bd6d93fdbfb.

need to revert due to failure..

```
prod/bootstrap bootstrap AWS::CloudFormation::Stack UPDATE_ROLLBACK_IN_PROGRESS
Export us-east-1-bootstrap-CfServiceRoleArn cannot be deleted as it is in use by
bsmnmanifests and htan-synapse-sync-kms-key
```
