### PR TITLE
[IT-3128] Remove service user

### DIFF
--- a/sceptre/scicomp/config/prod/bootstrap.yaml
+++ b/sceptre/scicomp/config/prod/bootstrap.yaml
@@ -1,4 +1,4 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.3.0/bootstrap.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.6/bootstrap.yaml
 stack_name: bootstrap


### PR DESCRIPTION
This is a redo of commit 43f713e  which was reverted in commit c7a487d due to a dependency on bsmmanifests and htan-synapse-sync-kms-key stacks.

We have removed the bsmmanifests stack and have refactored htan-synapse-sync-kms-key to remove the dependency

depends on https://github.com/Sage-Bionetworks/scicomp-provisioner/pull/616

