### PR TITLE
setup GH OIDC for imagecentral-dashboard

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -418,6 +418,8 @@ GithubOidcPackerImageDeploy:
         branches: ["master"]
       - name: "packer-amazonlinux-docker"
         branches: ["master"]
+      - name: "imagecentral-dashboard"
+        branches: ["master"]
   DefaultOrganizationBinding:
     Account: !Ref ImageCentralAccount
     Region: us-east-1


### PR DESCRIPTION
Sage-Bionetworks-IT/imagecentral-dashboard was using a service user to access AWS for CI builds.  That service user has been removed by PR #967 so now we setup the GH repo with OIDC access to AWS.

