### PR TITLE
[IT-3229] Setup github OIDC for agora infra deployment

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -717,3 +717,26 @@ GithubOidcBridgeDigitalHealthOpenBridgeWeb:
   DefaultOrganizationBinding:
     Account: !Ref SageITAccount
     Region: us-east-1
+
+GithubOidcAgoraInfraDeploy:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-agora-infra-deploy
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-agora-infra-deploy
+    MaxSessionDuration: 7200
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "agora2-infra"
+        branches: ["main"]
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref AgoraDevAccount
+      - !Ref AgoraProdAccount
+    Region: us-east-1


### PR DESCRIPTION
Setup OIDC access to AWS agora accounts from GH action to allow infrastructure deployments for the Agora app.  This is the first step to migrating the Sage-Bionetworks/agora2-infra repo to github actions.

