### PR TITLE
Create role for snoflake access to synapsedev data with fake extID to get roleArn

### DIFF
--- a/sceptre/synapsedev/config/prod/snowflake-access.yaml
+++ b/sceptre/synapsedev/config/prod/snowflake-access.yaml
@@ -1,0 +1,4 @@
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.8/IAM/snowflake-synapse-access.yaml
+stack_name: snowflake-access.yaml

--- a/sceptre/synapsedev/config/prod/snowflake-access.yaml
+++ b/sceptre/synapsedev/config/prod/snowflake-access.yaml
@@ -1,8 +1,9 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.8/IAM/snowflake-synapse-access.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.8/IAM/snowflake-bucket-access.yaml
 stack_name: snowflake-access.yaml
 parameters:
-  Stack: dev
+  BucketArn: arn:aws:s3:::dev.datawarehouse.sagebase.org
+  BucketPrefix: warehouse
   SnowflakeAccountArn: arn:aws:iam::365909334157:user/m2nb0000-s
   SnowflakeAccountExternalId: 0123456789

--- a/sceptre/synapsedev/config/prod/snowflake-access.yaml
+++ b/sceptre/synapsedev/config/prod/snowflake-access.yaml
@@ -2,3 +2,7 @@ template:
   type: http
   url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.8/IAM/snowflake-synapse-access.yaml
 stack_name: snowflake-access.yaml
+parameters:
+  Stack: dev
+  SnowflakeAccountArn: arn:aws:iam::365909334157:user/m2nb0000-s
+  SnowflakeAccountExternalId: 0123456789


### PR DESCRIPTION
This PR will create a new role for the snowflake access to Synapse dw bucket.
First called with fake externalID to get the role ARN.

Depends on https://github.com/Sage-Bionetworks/aws-infra/pull/398
