### PR TITLE
[IT-3301] Update SSO access for Bridge Prod

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -121,6 +121,10 @@ Parameters:
     Type: String
     Default: '906769aa66-e7083100-27d4-49bd-8ed2-c588371a1f91'
 
+  bridgeProdViewerPlusGroup:  #JC aws-bridgeprod-viewer-plus
+    Type: String
+    Default: '44085488-70f1-704b-c058-b6dde3aba1ef'
+
   scipoolDevAdminGroup:       #JC aws-scipooldev-admins
     Type: String
     Default: '906769aa66-5215fbe3-2331-4ea6-9cb3-ee25cdad4cc8'
@@ -501,6 +505,7 @@ SsoViewerPlus:
       - arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess
       - arn:aws:iam::aws:policy/AWSNetworkManagerReadOnlyAccess
       - arn:aws:iam::aws:policy/AWSOrganizationsReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonSNSReadOnlyAccess
     inlinePolicy: >-
       {
         "Version": "2012-10-17",
@@ -1088,6 +1093,23 @@ SsoBridgeProdIosDeveloper:
           }
         ]
       }
+
+SsoBridgeProdViewerPlus:
+  Type: update-stacks
+  DependsOn: SsoViewerPlus
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-bridgeprod-viewer-plus'
+  StackDescription: 'SSO: Viewer Plus role used by Bridge viewer-plus group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref BridgeProdAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref bridgeProdViewerPlusGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-viewer-plus-permission-set-arn' ]
 
 SsoScipoolDevAdmin:
   Type: update-stacks


### PR DESCRIPTION
Setup a SSO viewer plus role for Bridge Prod AWS account. Also Update the viewer plus role to include read access to SNS.

Once merged we can provide Sonia with access to this role so she can do her thing.

