### PR TITLE
[IT-3308] fix read only access for strides ampad

### DIFF
--- a/sceptre/strides-ampad-workflows/templates/jumpcloud-idp.yaml
+++ b/sceptre/strides-ampad-workflows/templates/jumpcloud-idp.yaml
@@ -42,6 +42,7 @@ Resources:
       MaxSessionDuration: 28800
       RoleName: !GetAtt AdminSamlProvider.Name
       ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/ReadOnlyAccess
         - arn:aws:iam::aws:policy/AdministratorAccess
         - arn:aws:iam::aws:policy/job-function/Billing
       AssumeRolePolicyDocument:
@@ -68,6 +69,7 @@ Resources:
       MaxSessionDuration: 28800
       RoleName: !GetAtt AuditorSamlProvider.Name
       ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/ReadOnlyAccess
         - arn:aws:iam::aws:policy/SecurityAudit
         - arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess
         - !Ref AWSIAMCostExplorerAccessPolicy
@@ -95,6 +97,7 @@ Resources:
       MaxSessionDuration: 28800
       RoleName: !GetAtt TowerViewerSamlProvider.Name
       ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/ReadOnlyAccess
         - arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess
         - !Ref AWSIAMCostExplorerAccessPolicy
       AssumeRolePolicyDocument:


### PR DESCRIPTION
Give tower viewer role read only access to the strides-ampad account.

