### PR TITLE
IT-3335: Add Agora repo to OIDC

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -735,6 +735,8 @@ GithubOidcAgoraInfraDeploy:
     Repositories:
       - name: "agora2-infra"
         branches: ["main"]
+      - name: "Agora"
+        branches: ["develop", "prod", "staging"]
   DefaultOrganizationBinding:
     Account:
       - !Ref AgoraDevAccount


### PR DESCRIPTION
This PR enables AWS access for GH workflows from the Sage-Bionetworks/Agora repo.
