### PR TITLE
IT-3333: Create bucket for e2e results in synapseDev

### DIFF
--- a/sceptre/synapsedev/config/prod/e2e-results-bucket.yaml
+++ b/sceptre/synapsedev/config/prod/e2e-results-bucket.yaml
@@ -1,4 +1,4 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.9/temp--data-bucket.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.9/temp-data-bucket.yaml
 stack_name: e2e-reports-bucket


### PR DESCRIPTION
This PR creates a bucket for temporary e2e test reports in SynapseDev.

Depends on https://github.com/Sage-Bionetworks/aws-infra/pull/400
