### PR TITLE
[SC-409] Test updated docker AMI before tagging

### DIFF
--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
@@ -51,5 +51,5 @@ sceptre_user_data:
       Name: 'v1.2.12'
     - Description: 'Update base AMI {{ range(1, 10000) | random }}'
       Info:
-        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.1/ec2/sc-ec2-linux-docker.yaml'
-      Name: 'v1.3.1'
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/master/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.3.2'


### PR DESCRIPTION
Test the latest docker AMI in scipool-dev before tagging a release.