### PR TITLE
IT-3335: Delete svc account

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -1,22 +1,6 @@
 Parameters:
   <<: !Include '../_parameters.yaml'
 
-# A service account for https://github.com/Sage-Bionetworks/agora-infra
-AgoraCIServiceAccount:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/IAM/service-account.yaml
-  StackName: ci-service-access
-  Parameters:
-    ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/AdministratorAccess
-      - arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: false
-    Account:
-      - !Ref AgoraDevAccount
-      - !Ref AgoraProdAccount
-    Region: us-east-1
-
 # A service account for https://github.com/Sage-Bionetworks/iatlas-infra
 iAtlasCIServiceAccount:
   Type: update-stacks


### PR DESCRIPTION
This PR removes the IAM service account used by Agora for deployments

Depends in #1045 , do not merge before the deployment process is migrated from Travis.
