### PR TITLE
[IT-3319] ukbiobank bucket for aws opendata

### DIFF
--- a/sceptre/aws-opendata/config/prod/ukbiobank-bucket.yaml
+++ b/sceptre/aws-opendata/config/prod/ukbiobank-bucket.yaml
@@ -1,0 +1,7 @@
+template:
+  path: "opendata-bucket.yaml"
+stack_name: "ukbiobank-bucket"
+dependencies:
+  - "prod/bootstrap.yaml"
+parameters:
+  DataSetName: "ukbiobank.opendata.sagebase.org"


### PR DESCRIPTION
The `ukbiobank.opendata.sagebase.org` bucket was manually deployed to the AWS opendata account previously.  This will put it under Sceptre/cloudformation IaC control.

depends on #1054
