### PR TITLE
SynapesDev-Snowflake-Access: Actual id from SSM

### DIFF
--- a/sceptre/synapsedev/config/prod/snowflake-access.yaml
+++ b/sceptre/synapsedev/config/prod/snowflake-access.yaml
@@ -6,4 +6,4 @@ parameters:
   BucketArn: arn:aws:s3:::dev.datawarehouse.sagebase.org
   BucketPrefix: warehouse
   SnowflakeAccountArn: arn:aws:iam::365909334157:user/m2nb0000-s
-  SnowflakeAccountExternalId: 0123456789
+  SnowflakeAccountExternalId: !ssm /infra/SnowflakeAccountExternalId


### PR DESCRIPTION
This PR updates the trust relationship by specifying the actual externalID (stored in SSM parameter store).
