### PR TITLE
IT-3317 Add dockerized notebook to SC portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,24 @@ Refer to [Org-Formation Overview](./org-formation/README.md) for a summary of wh
 
 ### sceptre
 
+
+#### Install your machine and then and then run:
+
 * create a python 3.x [virtualenv](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/)
-* run `pip install sceptre sceptre-ssm-resolver sceptre-date-resolver git+git://github.com/Sceptre/sceptre-file-resolver.git`
+* run `pip install sceptre sceptre-ssm-resolver sceptre-date-resolver sceptre-file-resolver`
 * cd sceptre/_folder_  (i.e. sceptre/sandbox)
 * uncomment `# profile: {{ var.profile | default("default") }}` in config/configs.yaml
 * run `sceptre --var "profile=member-profile" --var "region=us-east-1" launch prod/my-template.yaml`
 
 __Note__: member-profile is a profile that can assume the member account's `OrganizationAccountAccessRole` role
+
+#### Run in a docker container:
+
+```
+docker run --rm --name sceptre -v /path/to/src/organizations-infra/sceptre/scipool:/project \
+-v $HOME/.aws:/root/.aws/:ro sceptreorg/sceptre \
+--var "region=us-east-1" launch -y prod/my-template.yaml
+```
 
 ### Automation
 We have setup [Github actions](https://github.com/Sage-Bionetworks-IT/organizations-infra/actions) to automate

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker-notebook.yaml
@@ -16,4 +16,3 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/ec2/sc-ec2-linux-docker-notebook.yaml'
       Name: 'v0.0.1'
-      

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker-notebook.yaml
@@ -15,4 +15,4 @@ sceptre_user_data:
     - Description: 'Update instance types {{ range(1, 10000) | random }}'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/ec2/sc-ec2-linux-docker-notebook.yaml'
-      Name: 'v0.0.1'
+      Name: 'v1.0.0'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker-notebook.yaml
@@ -1,0 +1,19 @@
+template:
+  path: "sc-product-ec2-linux-docker-notebook.j2"
+stack_name: "sc-product-ec2-linux-docker-notebook"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "develop/sc-portfolio-ec2.yaml"
+  - "develop/sc-ec2-actions.yaml"
+  - "develop/sc-product-ec2-linux-notebook-write-to-ssm-policy.yaml"
+parameters:
+  ReplaceProvisioningArtifacts: "true"
+sceptre_user_data:
+  # force cloudformation to update stack by setting a random number to the latest product's description
+  ProvisioningArtifactParameters: |
+    - Description: 'Update instance types {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/ec2/sc-ec2-linux-docker-notebook.yaml'
+      Name: 'v0.0.1'
+      

--- a/sceptre/scipool/templates/sc-product-ec2-linux-docker-notebook.j2
+++ b/sceptre/scipool/templates/sc-product-ec2-linux-docker-notebook.j2
@@ -1,0 +1,106 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Notebook ServiceCatalog product'
+Parameters:
+  ProductName:
+    Type: String
+    Description: Name of the product that will be visible to the end user
+    Default: 'EC2 with Notebook Software'
+  ReplaceProvisioningArtifacts:
+    Type: String
+    Description: "Whether to keep or replace the provisioning artifact identifier on update"
+    Default: 'false'
+  ProvisioningArtifactActive:
+    Description: >-
+      Indicates whether the product version is active. Inactive provisioning artifacts
+      are invisible to end users. End users cannot launch or update a provisioned product
+      from an inactive provisioning artifact
+    Type: String
+    AllowedValues:
+      - "True"
+      - "False"
+    ConstraintDescription: "Valid values are True|False"
+    Default: "True"
+  ProvisioningArtifactGuidance:
+    Description: 'The value to apply to the product version guidance'
+    Type: String
+    AllowedValues:
+      - "DEFAULT"
+      - "DEPRECATED"
+    ConstraintDescription: "Valid values are DEFAULT|DEPRECATED"
+    Default: "DEFAULT"
+  ProvisioningArtifactAction:
+    Description: >-
+      The action type used to apply ProvisioningArtifactActive and ProvisioningArtifactGuidance
+      to provisioning artifacts. ALL to apply to all artifacts, ALL_EXCEPT_LATEST to apply to
+      all except the latest artifact
+    Type: String
+    AllowedValues:
+      - "ALL"
+      - "ALL_EXCEPT_LATEST"
+    ConstraintDescription: "Valid values are ALL|ALL_EXCEPT_LATEST"
+    Default: "ALL"
+Resources:
+  ScEc2LinuxNotebookProduct:
+    Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002  # missing `owner` property error -> it's inside of included products.yaml
+            - E3003  # invalid property `Fn::Transform` error -> cfn-lint bug
+    Properties:
+      Name: !Ref ProductName
+      Description: This product provides an RStudio or Jupyter notebook, running on an EC2 instance.
+      ProvisioningArtifactParameters:
+        {{ sceptre_user_data.ProvisioningArtifactParameters|indent(8) }}
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          # source: https://github.com/Sage-Bionetworks/admincentral-infra/blob/master/templates/cfn-snippets-bucket.yaml
+          Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipool/products.yaml"
+      ReplaceProvisioningArtifacts: !Ref ReplaceProvisioningArtifacts
+  Associateec2linux:
+    Type: AWS::ServiceCatalog::PortfolioProductAssociation
+    Properties:
+      PortfolioId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-ec2-SCEC2portfolioId'
+      ProductId: !Ref 'ScEc2LinuxNotebookProduct'
+  constraintec2linux:
+    Type: AWS::ServiceCatalog::LaunchRoleConstraint
+    DependsOn: Associateec2linux
+    Properties:
+      PortfolioId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-ec2-SCEC2portfolioId'
+      ProductId: !Ref 'ScEc2LinuxNotebookProduct'
+      RoleArn: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-ec2vpc-launchrole-LaunchRoleArn'
+  AssociatesExternalPortfolio:
+    Type: AWS::ServiceCatalog::PortfolioProductAssociation
+    Properties:
+      PortfolioId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-ec2-external-SCEC2portfolioId'
+      ProductId: !Ref 'ScEc2LinuxNotebookProduct'
+  ConstraintExternalPortfolio:
+    Type: AWS::ServiceCatalog::LaunchRoleConstraint
+    DependsOn: AssociatesExternalPortfolio
+    Properties:
+      PortfolioId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-ec2-external-SCEC2portfolioId'
+      ProductId: !Ref 'ScEc2LinuxNotebookProduct'
+      RoleArn: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-ec2vpc-launchrole-LaunchRoleArn'
+  UpdateProductVersions:
+    Type: Custom::ProductProvider
+    Properties:
+      ReDeploy: '{{ range(1, 1000000) | random }}'  # force CFN to redeploy this resource
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-sc-product-provider-UpdateProvisioningArtifactFunctionArn'
+      ProductId: !Ref ScEc2LinuxNotebookProduct
+      ProvisioningArtifactActive: !Ref ProvisioningArtifactActive
+      ProvisioningArtifactGuidance: !Ref ProvisioningArtifactGuidance
+      ProvisioningArtifactAction: !Ref ProvisioningArtifactAction
+Outputs:
+  ProductId:
+    Value: !Ref 'ScEc2LinuxNotebookProduct'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ProductId'


### PR DESCRIPTION
Add Dockerized Notebook defined in  [service-catalog-library](https://github.com/Sage-Bionetworks/service-catalog-library/pull/318) to Service Catalog portfolio.


Depends on: https://github.com/Sage-Bionetworks/service-catalog-library/pull/318