### PR TITLE
[IT-3230] Role for agora-data-manager repo

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -797,3 +797,25 @@ GithubOidcAgoraEBDeploy:
       - !Ref AgoraDevAccount
       - !Ref AgoraProdAccount
     Region: us-east-1
+
+GithubOidcAgoraDataManagerDeploy:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-agora-data-manager-deploy
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-agora-data-manager-deploy
+    MaxSessionDuration: 900
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AmazonDocDBFullAccess"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "Agora"
+        branches: ["develop", "prod", "staging"]
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref AgoraDevAccount
+      - !Ref AgoraProdAccount
+    Region: us-east-1


### PR DESCRIPTION
The first step to moving agora-data-manager CI from travis to GH action is to setup
GH action OIDC access on agora-data-manager to allow access to update the document
database.

