### PR TITLE
Disable GH action concurrency

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,10 +4,12 @@ on:
   pull_request:
     branches: ['*']
   push:
-    branches: ['*']
+    branches: ['master']
 
 # Ensures that only one deploy task per branch/environment will run at a time.
-concurrency: ci-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   pre-commit:


### PR DESCRIPTION
* We want to only deploy from master branch
* We do not want concurrent cloudformation deployments to AWS accounts.
* We also don't want to interrupt cloudformation deployments otherwise it
  may get into a bad state.  Therefore we are disabling concurrency[1]

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idconcurrency
