### PR TITLE
[SC-219] Enable SC action association work around

### DIFF
--- a/.github/workflows/aws-scipool.yaml
+++ b/.github/workflows/aws-scipool.yaml
@@ -59,4 +59,12 @@ jobs:
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-docker.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
+
+          sceptre delete --yes bmgfki/sc-product-assoc-ec2-linux-docker.yaml
+          sceptre delete --yes bmgfki/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
+          sceptre delete --yes bmgfki/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
+
+          sceptre delete --yes strides/sc-product-assoc-ec2-linux-docker.yaml
+          sceptre delete --yes strides/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
+          sceptre delete --yes strides/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
           ${{ inputs.sceptre-command }}

--- a/.github/workflows/aws-scipool.yaml
+++ b/.github/workflows/aws-scipool.yaml
@@ -59,11 +59,9 @@ jobs:
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-docker.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
-
           sceptre delete --yes bmgfki/sc-product-assoc-ec2-linux-docker.yaml
           sceptre delete --yes bmgfki/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
           sceptre delete --yes bmgfki/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml
-
           sceptre delete --yes strides/sc-product-assoc-ec2-linux-docker.yaml
           sceptre delete --yes strides/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
           sceptre delete --yes strides/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml


### PR DESCRIPTION
We setup service catalog action associations workarounds for scipool prod but forgot to setup the work around for bmfgki and strides accounts.  This enables the workaround for those accounts as well.

