### PR TITLE
Update sceptre deployment commands

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -53,5 +53,4 @@ jobs:
       - name: Deploy with sceptre
         run: |
           cd ${{ inputs.working-dir }}
-          mkdir -p templates/remote
           ${{ inputs.sceptre-command }}

--- a/.github/workflows/aws-scipool.yaml
+++ b/.github/workflows/aws-scipool.yaml
@@ -55,7 +55,6 @@ jobs:
         # SC-26 & SC-219 workaround: dis-associate and re-associate SC actions on every deploy
         run: |
           cd ${{ inputs.working-dir }}
-          mkdir -p templates/remote
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-docker.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-jumpcloud-notebook.yaml
           sceptre delete --yes prod/sc-product-assoc-ec2-linux-windows-jumpcloud.yaml


### PR DESCRIPTION
We used to use the Sceptre file handler[1] which required a step to create the `template/remote` folder as a temporary location to save downloaded cfn templates.  We no longer need that because we now use the Sceptre http handler[1] which handles downloading of templates for us.  It basically downloads templates to the `/tmp` folder.

[1] https://docs.sceptre-project.org/latest/docs/template_handlers.html#file
[2] https://docs.sceptre-project.org/latest/docs/template_handlers.html#http
