### PR TITLE
IT-3317: In SC dev: Adding product assoc', updating SC Notebook and ALB

### DIFF
--- a/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/0.1.4/cfn-cr-alb-rule.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/0.1.5/cfn-cr-alb-rule.yaml
 stack_name: cfn-cr-alb-rule
 dependencies:
   - "develop/sc-kms-key.yaml"

--- a/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-docker-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-docker-notebook.yaml
@@ -1,0 +1,9 @@
+template:
+  path: "sc-ec2-action-associations.yaml"
+stack_name: "sc-product-assoc-ec2-linux-docker-notebook"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "develop/sc-product-ec2-linux-docker-notebook.yaml"
+parameters:
+  ProductId: !stack_output_external sc-product-ec2-linux-docker-notebook::ProductId

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker-notebook.yaml
@@ -20,7 +20,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.3/ec2/sc-ec2-linux-docker-notebook.yaml'
       Name: 'v1.3.3'
-    - Description: 'Update instance types {{ range(1, 10000) | random }}'
+    - Description: 'Update instance types'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.4/ec2/sc-ec2-linux-docker-notebook.yaml'
       Name: 'v1.3.4'
+    - Description: 'Use Sage maintained Docker image {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.5/ec2/sc-ec2-linux-docker-notebook.yaml'
+      Name: 'v1.3.5'


### PR DESCRIPTION
In SC dev: 
- Adding product assoc', 
-  Updating SC Notebook ALB to '0.1.5';
- Updating Notebook to 'v1.3.5'


Depends on https://github.com/Sage-Bionetworks-IT/cfn-cr-alb-rule/pull/16.  After merging that repo' must be tagged with `0.1.5`.

Depends on https://github.com/Sage-Bionetworks/service-catalog-library/pull/322.  After merging, that repo' must be tagged with 'v1.3.5'.