### PR TITLE
[IT-3414] update SSO S3 viewer role

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -499,6 +499,7 @@ SsoS3Viewer:
     permissionSetName: 'S3Viewer'
     managedPolicies:
       - 'arn:aws:iam::aws:policy/job-function/ViewOnlyAccess'
+      - 'arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess'
       - 'arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess'
     sessionDuration: 'PT12H'
     masterAccountId: !Ref MasterAccount


### PR DESCRIPTION
Give S3 viewer role read only access to cloudwatch logs.

