### PR TITLE
Bump cfn-cr-alb-rule to 0.1.7 (develop only)

### DIFF
--- a/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/0.1.4/cfn-cr-alb-rule.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/0.1.5/cfn-cr-alb-rule.yaml
 stack_name: cfn-cr-alb-rule
 dependencies:
   - "develop/sc-kms-key.yaml"

--- a/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/0.1.5/cfn-cr-alb-rule.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/0.1.6/cfn-cr-alb-rule.yaml
 stack_name: cfn-cr-alb-rule
 dependencies:
   - "develop/sc-kms-key.yaml"

--- a/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-alb-rule.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/0.1.6/cfn-cr-alb-rule.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-alb-rule/0.1.7/cfn-cr-alb-rule.yaml
 stack_name: cfn-cr-alb-rule
 dependencies:
   - "develop/sc-kms-key.yaml"

--- a/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-docker-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-assoc-ec2-linux-docker-notebook.yaml
@@ -1,0 +1,9 @@
+template:
+  path: "sc-ec2-action-associations.yaml"
+stack_name: "sc-product-assoc-ec2-linux-docker-notebook"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "develop/sc-product-ec2-linux-docker-notebook.yaml"
+parameters:
+  ProductId: !stack_output_external sc-product-ec2-linux-docker-notebook::ProductId

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker-notebook.yaml
@@ -20,7 +20,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.3/ec2/sc-ec2-linux-docker-notebook.yaml'
       Name: 'v1.3.3'
-    - Description: 'Update instance types {{ range(1, 10000) | random }}'
+    - Description: 'Update instance types'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.4/ec2/sc-ec2-linux-docker-notebook.yaml'
       Name: 'v1.3.4'
+    - Description: 'Use Sage maintained Docker image {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.5/ec2/sc-ec2-linux-docker-notebook.yaml'
+      Name: 'v1.3.5'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker-notebook.yaml
@@ -24,7 +24,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.4/ec2/sc-ec2-linux-docker-notebook.yaml'
       Name: 'v1.3.4'
-    - Description: 'Use Sage maintained Docker image {{ range(1, 10000) | random }}'
+    - Description: 'Use Sage maintained Docker image'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.5/ec2/sc-ec2-linux-docker-notebook.yaml'
       Name: 'v1.3.5'
+    - Description: 'Update Docker image and volume mounting {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.6/ec2/sc-ec2-linux-docker-notebook.yaml'
+      Name: 'v1.3.6'


### PR DESCRIPTION
Depends on https://github.com/Sage-Bionetworks-IT/cfn-cr-alb-rule/pull/18 which will also have to be tagged `0.1.7`