### PR TITLE
[IT-3425] Update service catalog windows product

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-windows-jumpcloud.yaml
@@ -68,7 +68,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.44/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.44'
-    - Description: 'Update instance types {{ range(1, 10000) | random }}'
+    - Description: 'Update instance types'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.12/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.2.12'
+    - Description: 'fix chocolately and JC agent installs {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.7/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.3.7'

--- a/sceptre/scipool/config/develop/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-windows-jumpcloud.yaml
@@ -67,7 +67,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.44/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.44'
-    - Description: 'Update instance types {{ range(1, 10000) | random }}'
+    - Description: 'Update instance types'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.12/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.2.12'
+    - Description: 'fix chocolately and JC agent installs {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.7/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.3.7'

--- a/sceptre/scipool/config/prod/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-windows-jumpcloud.yaml
@@ -68,7 +68,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.44/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.44'
-    - Description: 'Update instance types {{ range(1, 10000) | random }}'
+    - Description: 'Update instance types'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.12/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.2.12'
+    - Description: 'fix chocolately and JC agent installs {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.7/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.3.7'

--- a/sceptre/scipool/config/strides/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-windows-jumpcloud.yaml
@@ -68,7 +68,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.44/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.1.44'
-    - Description: 'Update instance types {{ range(1, 10000) | random }}'
+    - Description: 'Update instance types'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.12/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.2.12'
+    - Description: 'fix chocolately and JC agent installs {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.7/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.3.7'


### PR DESCRIPTION
Update the service catalog windows product with fixes for the chocolately and jumpcloud agent installs

depends on https://github.com/Sage-Bionetworks/service-catalog-library/pull/325

