### PR TITLE
Reduce privileges for application managers

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -574,7 +574,6 @@ SsoApplicationManager:
     managedPolicies:
       - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
       - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
-      - arn:aws:iam::aws:policy/SecretsManagerReadWrite
       - arn:aws:iam::aws:policy/AWSCertificateManagerReadOnly
     inlinePolicy: >-
       {


### PR DESCRIPTION
I think the application manager role is a bit over privileged. They should probably not have unilateral access to the secrets manger in the entire AWS account.

