### PR TITLE
[IT-3386] Send a copy of cost reports to a new google group.

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -61,13 +61,14 @@ CostCategories:
 # use the payer account so that cost explorer aggregates member account data
 CostNotificationMicroservice:
   Type: update-stacks
-  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-finops-email-totals/1.0.0/lambda-finops-email-totals.yaml'
+  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-finops-email-totals/1.1.0/lambda-finops-email-totals.yaml'
   StackName: !Sub '${resourcePrefix}-cost-notifications'
   DefaultOrganizationBinding:
     Account: !Ref MasterAccount
     Region: !Ref primaryRegion
   Parameters:
     AdminEmail: "it@sagebase.org"
+    CopyRecipients: "cloud-cost-audit@sagebase.org"
     # Uncomment the following lines to disable user reports
     #RestrictRecipients: "True"
     #ApprovedRecipients: "it@sagebase.org"


### PR DESCRIPTION
Update the email report lambda to a version that supports sending copies to additional recipients, and add a newly-created google group as an additional recipient.

Depends on Sage-Bionetworks-IT/lambda-finops-email-totals#19
