### PR TITLE
[IT-3091] Remove CI service account for Agora

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -1,22 +1,6 @@
 Parameters:
   <<: !Include '../_parameters.yaml'
 
-# A service account for https://github.com/Sage-Bionetworks/agora-infra
-AgoraCIServiceAccount:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/IAM/service-account.yaml
-  StackName: ci-service-access
-  Parameters:
-    ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/AdministratorAccess
-      - arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: false
-    Account:
-      - !Ref AgoraDevAccount
-      - !Ref AgoraProdAccount
-    Region: us-east-1
-
 # A service account for https://github.com/Sage-Bionetworks/iatlas-infra
 iAtlasCIServiceAccount:
   Type: update-stacks


### PR DESCRIPTION
Now that Agora has migrated from TravisCI to Github Actions, we can remove the CI service account for Agora.