### PR TITLE
[IT-3369] Update sc-ec2-windows-jumpcloud to use IMDSv2

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-windows-jumpcloud.yaml
@@ -72,7 +72,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.12/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.2.12'
-    - Description: 'fix chocolately and JC agent installs {{ range(1, 10000) | random }}'
+    - Description: 'fix chocolately and JC agent installs'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.7/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.3.7'
+    - Description: 'Update set_env_vars to use IMDSv2 {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.9/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.3.9'

--- a/sceptre/scipool/config/develop/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-windows-jumpcloud.yaml
@@ -71,7 +71,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.12/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.2.12'
-    - Description: 'fix chocolately and JC agent installs {{ range(1, 10000) | random }}'
+    - Description: 'fix chocolately and JC agent installs'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.7/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.3.7'
+    - Description: 'Update set_env_vars to use IMDSv2 {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.9/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.3.9'

--- a/sceptre/scipool/config/prod/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-windows-jumpcloud.yaml
@@ -72,7 +72,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.12/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.2.12'
-    - Description: 'fix chocolately and JC agent installs {{ range(1, 10000) | random }}'
+    - Description: 'fix chocolately and JC agent installs'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.7/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.3.7'
+    - Description: 'Update set_env_vars to use IMDSv2 {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.9/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.3.9'

--- a/sceptre/scipool/config/strides/sc-product-ec2-windows-jumpcloud.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-windows-jumpcloud.yaml
@@ -72,7 +72,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.12/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.2.12'
-    - Description: 'fix chocolately and JC agent installs {{ range(1, 10000) | random }}'
+    - Description: 'fix chocolately and JC agent installs'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.7/ec2/sc-ec2-windows-jumpcloud.yaml'
       Name: 'v1.3.7'
+    - Description: 'Update set_env_vars to use IMDSv2 {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.9/ec2/sc-ec2-windows-jumpcloud.yaml'
+      Name: 'v1.3.9'


### PR DESCRIPTION
Since it's possible for an AMI to disable IMDSv1, we are updating all of our setup scripts to use IMDSv2.