### PR TITLE
Release latest version of the finops email lambda

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -61,7 +61,7 @@ CostCategories:
 # use the payer account so that cost explorer aggregates member account data
 CostNotificationMicroservice:
   Type: update-stacks
-  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-finops-email-totals/1.1.0/lambda-finops-email-totals.yaml'
+  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-finops-email-totals/1.1.1/lambda-finops-email-totals.yaml'
   StackName: !Sub '${resourcePrefix}-cost-notifications'
   DefaultOrganizationBinding:
     Account: !Ref MasterAccount


### PR DESCRIPTION
Update lambda-finops-email-totals to a version that includes a section about unexpected CostCenterOther tags (i.e. when CostCenter is not `Other / 000001`).