### PR TITLE
[IT-3471] Bootstrap a cloudwatch monitoring account

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -91,6 +91,7 @@ Organization:
         - !Ref IpamAccount
         - !Ref SysmanCentralAccount
         - !Ref IdentityCentralAccount
+        - !Ref MonitorCentralAccount
 
   PolicyStagingOU:
     Type: OC::ORG::OrganizationalUnit
@@ -504,6 +505,15 @@ Organization:
       AccountName: org-sagebase-ipam
       RootEmail: aws.ipam@sagebase.org
       Alias: org-sagebase-ipam
+      Tags:
+        <<: !Include ./_platform_org_tags.yaml
+
+  MonitorCentralAccount:
+    Type: OC::ORG::Account
+    Properties:
+      AccountName: org-sagebase-monitorcentral
+      RootEmail: aws.monitorcentral@sagebase.org
+      Alias: org-sagebase-monitorcentral
       Tags:
         <<: !Include ./_platform_org_tags.yaml
 


### PR DESCRIPTION
With Amazon CloudWatch cross-account observability[1], we can monitor and troubleshoot applications that span multiple accounts within a Region.

The first step is to set up an AWS monitoring account.

[1] https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html

