### PR TITLE
[IT-3471] Setup a cross account cloudwatch dashboard

### DIFF
--- a/org-formation/740-cloudwatch-dashboard/CloudWatch-CrossAccountListAccountsRole-AccountList.yaml
+++ b/org-formation/740-cloudwatch-dashboard/CloudWatch-CrossAccountListAccountsRole-AccountList.yaml
@@ -1,0 +1,42 @@
+# This template is downloaded from the AWS Console (from organizations account)
+# Cloudwatch -> Settings -> Share your Organization account list
+# It should be deployed to the AWS Organizations account
+
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Enables monitoring accounts to list the accounts information in an AWS Organization
+
+Parameters:
+  MonitoringAccountIds:
+    Description: Allows one or more monitoring accounts to view AWS Organization account list. Enter AWS account ids, 12 numeric digits in comma-separated list
+    Type: CommaDelimitedList
+
+Resources:
+  CWCrossAccountListAccountsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: CloudWatch-CrossAccountSharing-ListAccountsRole
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            AWS: !Split
+            - ','
+            - !Sub
+              - 'arn:aws:iam::${inner}:root'
+              - inner: !Join
+                - ':root,arn:aws:iam::'
+                - Ref: MonitoringAccountIds
+          Action:
+          - sts:AssumeRole
+      Path: "/"
+      Policies:
+      - PolicyName: CloudWatch-CrossAccountSharing-ListAccounts-Policy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Action:
+            - organizations:ListAccounts
+            - organizations:ListAccountsForParent
+            Resource: '*'
+            Effect: Allow

--- a/org-formation/740-cloudwatch-dashboard/CloudWatch-CrossAccountSharingRole-AccountList.yaml
+++ b/org-formation/740-cloudwatch-dashboard/CloudWatch-CrossAccountSharingRole-AccountList.yaml
@@ -1,0 +1,75 @@
+# This template is downloaded from the AWS Console (from org-sagebase-monitorcentral account)
+# Cloudwatch -> Settings -> Share your CloudWatch data -> Create CloudFormation stack
+# It should be deployed to all member accounts except for the org-sagebase-monitorcentral account
+
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Enables CloudWatch in central monitoring accounts to assume permissions to view CloudWatch data in the current account
+
+Parameters:
+  MonitoringAccountIds:
+    Description: Allows one or more monitoring accounts to view your data. Enter AWS account ids, 12 numeric digits in comma-separated list
+    Type: CommaDelimitedList
+
+  Policy:
+    Description: The level of access to give to the Monitoring accounts
+    Type: String
+    Default: CloudWatch-and-AutomaticDashboards
+    AllowedValues:
+      - CloudWatch-and-AutomaticDashboards
+      - CloudWatch-and-ServiceLens
+      - CloudWatch-AutomaticDashboards-and-ServiceLens
+      - CloudWatch-core-permissions
+      - View-Access-for-all-services
+
+Conditions:
+  DoFullReadOnly: !Equals [ !Ref Policy, View-Access-for-all-services ]
+  DoAutomaticDashboards: !Equals [ !Ref Policy, CloudWatch-and-AutomaticDashboards ]
+  DoServiceLens: !Equals [ !Ref Policy, CloudWatch-and-ServiceLens ]
+  DoServiceLensAndAutomaticDashboards: !Equals [ !Ref Policy, CloudWatch-AutomaticDashboards-and-ServiceLens ]
+  DoCWReadOnly: !Equals [ !Ref Policy, CloudWatch-core-permissions ]
+
+Resources:
+  CWCrossAccountSharingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: CloudWatch-CrossAccountSharingRole
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Split
+                - ','
+                - !Sub
+                  - 'arn:aws:iam::${inner}:root'
+                  - inner: !Join
+                      - ':root,arn:aws:iam::'
+                      - Ref: MonitoringAccountIds
+            Action:
+              - sts:AssumeRole
+      Path: "/"
+      ManagedPolicyArns: !If
+        - DoFullReadOnly
+        -
+          - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
+          - arn:aws:iam::aws:policy/CloudWatchAutomaticDashboardsAccess
+          - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
+          - arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess
+        - !If
+          - DoAutomaticDashboards
+          -
+            - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
+            - arn:aws:iam::aws:policy/CloudWatchAutomaticDashboardsAccess
+          - !If
+            - DoServiceLens
+            -
+              - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
+              - arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess
+            - !If
+              - DoServiceLensAndAutomaticDashboards
+              -
+                - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
+                - arn:aws:iam::aws:policy/CloudWatchAutomaticDashboardsAccess
+                - arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess
+              -
+                - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess

--- a/org-formation/740-cloudwatch-dashboard/Cloudwatch-Link-Management-Account.yaml
+++ b/org-formation/740-cloudwatch-dashboard/Cloudwatch-Link-Management-Account.yaml
@@ -1,0 +1,22 @@
+# This template is downloaded from the AWS Console (from org-sagebase-monitorcentral account)
+# Cloudwatch -> Settings -> Determine how to link your source accounts
+# It should be deployed to all member accounts except for the org-sagebase-monitorcentral account
+
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  MonitoringAccountId:
+    Description: Allows one or more monitoring accounts to view your data. Enter AWS account ids, 12 numeric digits in comma-separated list
+    Type: String
+
+Resources:
+  Link:
+    Type: AWS::Oam::Link
+    Properties:
+      LabelTemplate: "$AccountName"
+      ResourceTypes:
+        - "AWS::CloudWatch::Metric"
+        - "AWS::Logs::LogGroup"
+        - "AWS::XRay::Trace"
+        - "AWS::ApplicationInsights::Application"
+      SinkIdentifier: !Sub "arn:aws:oam:us-east-1:${MonitoringAccountId}:sink/5ea88d72-76d8-419e-9c6d-07d4de64f972"

--- a/org-formation/740-cloudwatch-dashboard/README.md
+++ b/org-formation/740-cloudwatch-dashboard/README.md
@@ -1,0 +1,11 @@
+### Purpose of these templates
+The templates in this folder sets up a cross account CloudWatch monitoring dashboard.
+It uses a management/member architecture, instead of using the Organizations account
+as the cloudwatch management account we created org-sagebase-monitorcentral account
+for that purpose.  Creating a separate account will allow us to isolate user access
+to the dashboards.
+
+* The Cloudwatch management account is org-sagebase-monitorcentral
+* The monitorcentral account uses the AWS account list from the Organizations account.
+  This will allow monitorcentral to include new AWS accounts as they are added.
+* All other AWS accounts are Cloudwatch member accounts.

--- a/org-formation/740-cloudwatch-dashboard/_tasks.yaml
+++ b/org-formation/740-cloudwatch-dashboard/_tasks.yaml
@@ -8,7 +8,7 @@ Parameters:
 # Give MonitorCentral access to the account list in Organizations
 CrossAccountListAccountRole:
   Type: update-stacks
-  Template: CloudWatch-CrossAccountListAccountsRole-AccountList.yaml
+  Template: ./CloudWatch-CrossAccountListAccountsRole-AccountList.yaml
   StackName: !Sub '${resourcePrefix}-${appName}-CrossAccountListAccountsRole'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
@@ -19,21 +19,21 @@ CrossAccountListAccountRole:
 # Link cloudwatch in member accounts to MonitorCentral
 LinkManagementAccount:
   Type: update-stacks
-  Template: CloudWatch-CrossAccountSharingRole-AccountList.yaml
+  Template: ./Cloudwatch-Link-Management-Account.yaml
   StackName: !Sub '${resourcePrefix}-${appName}-LinkManagementAccount'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     Account: '*'
-    Exclude: !Ref MonitorCentralAccount
+    ExcludeAccount: !Ref MonitorCentralAccount
 
 # Allow member accounts to share cloudwatch data with MonitorCentral
 CrossAccountSharingRole:
   Type: update-stacks
-  Template: CloudWatch-CrossAccountSharingRole-AccountList.yaml
+  Template: ./CloudWatch-CrossAccountSharingRole-AccountList.yaml
   StackName: !Sub '${resourcePrefix}-${appName}-CrossAccountSharingRole'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     Account: '*'
-    Exclude: !Ref MonitorCentralAccount
+    ExcludeAccount: !Ref MonitorCentralAccount
   Parameters:
     MonitoringAccountIds: !Ref MonitorCentralAccount

--- a/org-formation/740-cloudwatch-dashboard/_tasks.yaml
+++ b/org-formation/740-cloudwatch-dashboard/_tasks.yaml
@@ -1,0 +1,39 @@
+Parameters:
+  <<: !Include '../_parameters.yaml'
+
+  appName:
+    Type: String
+    Default: 'CloudWatcDashboard'
+
+# Give MonitorCentral access to the account list in Organizations
+CrossAccountListAccountRole:
+  Type: update-stacks
+  Template: CloudWatch-CrossAccountListAccountsRole-AccountList.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-CrossAccountListAccountsRole'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref MasterAccount
+  Parameters:
+    MonitoringAccountIds: !Ref MonitorCentralAccount
+
+# Link cloudwatch in member accounts to MonitorCentral
+LinkManagementAccount:
+  Type: update-stacks
+  Template: CloudWatch-CrossAccountSharingRole-AccountList.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-LinkManagementAccount'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: '*'
+    Exclude: !Ref MonitorCentralAccount
+
+# Allow member accounts to share cloudwatch data with MonitorCentral
+CrossAccountSharingRole:
+  Type: update-stacks
+  Template: CloudWatch-CrossAccountSharingRole-AccountList.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-CrossAccountSharingRole'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: '*'
+    Exclude: !Ref MonitorCentralAccount
+  Parameters:
+    MonitoringAccountIds: !Ref MonitorCentralAccount


### PR DESCRIPTION
Setup AWS Cloudwatch cross-account observability[1].  This feature will allow us to create a cloudwatch dashboard in one AWS account that monitors apps deployed to multiple AWS accounts.

Note: all of the templates used to setup cloudwatch dashboard is provided by AWS

[1] https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html
