### PR TITLE
[IT-3471] link non-org accounts to cloudwatch dashboard

### DIFF
--- a/sceptre/aws-opendata/config/prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml
+++ b/sceptre/aws-opendata/config/prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml
@@ -5,6 +5,6 @@ stack_name: "sagebase-CloudWatcDashboard-CrossAccountSharingRole"
 stack_tags:
   OwnerEmail: "it@sagebase.org"
 dependencies:
-  - "prod/bootstrap.yaml"
+  - "prod/Cloudwatch-Link-Management-Account.yaml"
 parameters:
   MonitoringAccountIds: "767397888168"

--- a/sceptre/aws-opendata/config/prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml
+++ b/sceptre/aws-opendata/config/prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml
@@ -1,0 +1,10 @@
+template:
+  type: "http"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.8.6/templates/Cloudwatch/CrossAccountSharingRole-AccountList.yaml"
+stack_name: "sagebase-CloudWatcDashboard-CrossAccountSharingRole"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/bootstrap.yaml"
+parameters:
+  MonitoringAccountIds: "767397888168"

--- a/sceptre/aws-opendata/config/prod/Cloudwatch-Link-Management-Account.yaml
+++ b/sceptre/aws-opendata/config/prod/Cloudwatch-Link-Management-Account.yaml
@@ -1,0 +1,11 @@
+template:
+  type: "http"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.8.6/templates/Cloudwatch/Link-Management-Account.yaml"
+stack_name: "sagebase-CloudWatcDashboard-LinkManagementAccount"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml"
+parameters:
+  MonitoringAccountId: "767397888168"
+  SinkIdentifier: "6046cc13-135d-4e41-ae56-63327a7a7b8c"

--- a/sceptre/aws-opendata/config/prod/Cloudwatch-Link-Management-Account.yaml
+++ b/sceptre/aws-opendata/config/prod/Cloudwatch-Link-Management-Account.yaml
@@ -5,7 +5,7 @@ stack_name: "sagebase-CloudWatcDashboard-LinkManagementAccount"
 stack_tags:
   OwnerEmail: "it@sagebase.org"
 dependencies:
-  - "prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml"
+  - "prod/bootstrap.yaml"
 parameters:
   MonitoringAccountId: "767397888168"
   SinkIdentifier: "6046cc13-135d-4e41-ae56-63327a7a7b8c"

--- a/sceptre/strides-ampad-workflows/config/prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml
@@ -5,6 +5,6 @@ stack_name: "sagebase-CloudWatcDashboard-CrossAccountSharingRole"
 stack_tags:
   OwnerEmail: "it@sagebase.org"
 dependencies:
-  - "prod/bootstrap.yaml"
+  - "prod/Cloudwatch-Link-Management-Account.yaml"
 parameters:
   MonitoringAccountIds: "767397888168"

--- a/sceptre/strides-ampad-workflows/config/prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml
@@ -1,0 +1,10 @@
+template:
+  type: "http"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.8.6/templates/Cloudwatch/CrossAccountSharingRole-AccountList.yaml"
+stack_name: "sagebase-CloudWatcDashboard-CrossAccountSharingRole"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/bootstrap.yaml"
+parameters:
+  MonitoringAccountIds: "767397888168"

--- a/sceptre/strides-ampad-workflows/config/prod/Cloudwatch-Link-Management-Account.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/Cloudwatch-Link-Management-Account.yaml
@@ -1,0 +1,11 @@
+template:
+  type: "http"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.8.6/templates/Cloudwatch/Link-Management-Account.yaml"
+stack_name: "sagebase-CloudWatcDashboard-LinkManagementAccount"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml"
+parameters:
+  MonitoringAccountId: "767397888168"
+  SinkIdentifier: "6046cc13-135d-4e41-ae56-63327a7a7b8c"

--- a/sceptre/strides-ampad-workflows/config/prod/Cloudwatch-Link-Management-Account.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/Cloudwatch-Link-Management-Account.yaml
@@ -5,7 +5,7 @@ stack_name: "sagebase-CloudWatcDashboard-LinkManagementAccount"
 stack_tags:
   OwnerEmail: "it@sagebase.org"
 dependencies:
-  - "prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml"
+  - "prod/bootstrap.yaml"
 parameters:
   MonitoringAccountId: "767397888168"
   SinkIdentifier: "6046cc13-135d-4e41-ae56-63327a7a7b8c"

--- a/sceptre/strides/config/prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml
+++ b/sceptre/strides/config/prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml
@@ -5,6 +5,6 @@ stack_name: "sagebase-CloudWatcDashboard-CrossAccountSharingRole"
 stack_tags:
   OwnerEmail: "it@sagebase.org"
 dependencies:
-  - "prod/bootstrap.yaml"
+  - "prod/Cloudwatch-Link-Management-Account.yaml"
 parameters:
   MonitoringAccountIds: "767397888168"

--- a/sceptre/strides/config/prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml
+++ b/sceptre/strides/config/prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml
@@ -1,0 +1,10 @@
+template:
+  type: "http"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.8.6/templates/Cloudwatch/CrossAccountSharingRole-AccountList.yaml"
+stack_name: "sagebase-CloudWatcDashboard-CrossAccountSharingRole"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/bootstrap.yaml"
+parameters:
+  MonitoringAccountIds: "767397888168"

--- a/sceptre/strides/config/prod/Cloudwatch-Link-Management-Account.yaml
+++ b/sceptre/strides/config/prod/Cloudwatch-Link-Management-Account.yaml
@@ -1,0 +1,11 @@
+template:
+  type: "http"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.8.6/templates/Cloudwatch/Link-Management-Account.yaml"
+stack_name: "sagebase-CloudWatcDashboard-LinkManagementAccount"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml"
+parameters:
+  MonitoringAccountId: "767397888168"
+  SinkIdentifier: "6046cc13-135d-4e41-ae56-63327a7a7b8c"

--- a/sceptre/strides/config/prod/Cloudwatch-Link-Management-Account.yaml
+++ b/sceptre/strides/config/prod/Cloudwatch-Link-Management-Account.yaml
@@ -5,7 +5,7 @@ stack_name: "sagebase-CloudWatcDashboard-LinkManagementAccount"
 stack_tags:
   OwnerEmail: "it@sagebase.org"
 dependencies:
-  - "prod/CloudWatch-CrossAccountSharingRole-AccountList.yaml"
+  - "prod/bootstrap.yaml"
 parameters:
   MonitoringAccountId: "767397888168"
   SinkIdentifier: "6046cc13-135d-4e41-ae56-63327a7a7b8c"


### PR DESCRIPTION
Link AWS accounts that are not in our organizations to the cloudwatch dashboard.

This is a 2nd attempt at PR #1106 which was reverted in commit 3bce57d.
This one contains some fixes to stack names and stack dependencies.

depends on Sage-Bionetworks/aws-infra#407

