### PR TITLE
[IT-3456] Add GH OIDC for packer-winserver-2022

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -420,6 +420,8 @@ GithubOidcPackerImageDeploy:
         branches: ["master"]
       - name: "imagecentral-dashboard"
         branches: ["master"]
+      - name: "packer-winserver-2022"
+        branches: ["master"]
   DefaultOrganizationBinding:
     Account: !Ref ImageCentralAccount
     Region: us-east-1


### PR DESCRIPTION
Add OIDC for packer-winserver-2022 to deploy AMIs to imagecentral.
