### PR TITLE
[IT-3471] Configure dashboards for Agora

### DIFF
--- a/org-formation/740-cloudwatch-dashboard/_tasks.yaml
+++ b/org-formation/740-cloudwatch-dashboard/_tasks.yaml
@@ -40,3 +40,23 @@ CrossAccountSharingRole:
     ExcludeAccount: !Ref MonitorCentralAccount
   Parameters:
     MonitoringAccountIds: !Ref MonitorCentralAccount
+
+
+CrossAccountDashboards:
+  Type: update-stacks
+  Template: ./cw-dashboards.njk
+  StackName: !Sub '${resourcePrefix}-${appName}-CrossAccountDashboards'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref MonitorCentralAccount
+  TemplatingContext:
+    Dashboards:
+      - Name: "agora-develop"
+        ElasticBeanstalkEnvName: "agora-develop"
+        AccountId: "607346494281"
+      - Name: "agora-staging"
+        ElasticBeanstalkEnvName: "agora-staging"
+        AccountId: "681175625864"
+      - Name: "agora-prod"
+        ElasticBeanstalkEnvName: "agora-prod"
+        AccountId: "681175625864"

--- a/org-formation/740-cloudwatch-dashboard/cw-dashboards.njk
+++ b/org-formation/740-cloudwatch-dashboard/cw-dashboards.njk
@@ -1,0 +1,136 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Cross Account Cloudwatch Dashboards
+Resources:
+{% for Dashboard in Dashboards %}
+  Dashboard{{ Dashboard.Name | replace('-','') | replace('_','') }}:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: {{ Dashboard.Name }}
+      DashboardBody: >
+        {
+          "widgets": [
+            {
+              "type": "metric",
+              "width": 20,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [
+                    "AWS/ElasticBeanstalk",
+                    "ApplicationRequests2xx",
+                    "EnvironmentName",
+                    "{{ Dashboard.ElasticBeanstalkEnvName }}",
+                    {
+                      "accountId": "{{ Dashboard.AccountId }}"
+                    }
+                  ]
+                ],
+                "legend": {
+                  "position": "bottom"
+                },
+                "region": "us-east-1",
+                "liveData": false,
+                "title": "EnvironmentHealth: Average",
+                "view": "timeSeries",
+                "stacked": false
+              }
+            },
+            {
+              "type": "metric",
+              "properties": {
+                "metrics": [
+                  [
+                    "AWS/ElasticBeanstalk",
+                    "ApplicationRequests2xx",
+                    "EnvironmentName",
+                    "{{ Dashboard.ElasticBeanstalkEnvName }}",
+                    {
+                      "accountId": "{{ Dashboard.AccountId }}"
+                    }
+                  ]
+                ],
+                "legend": {
+                  "position": "bottom"
+                },
+                "region": "us-east-1",
+                "liveData": false,
+                "title": "ApplicationRequests2xx: Average",
+                "view": "timeSeries",
+                "stacked": false
+              }
+            },
+            {
+              "type": "metric",
+              "properties": {
+                "metrics": [
+                  [
+                    "AWS/ElasticBeanstalk",
+                    "ApplicationRequests3xx",
+                    "EnvironmentName",
+                    "{{ Dashboard.ElasticBeanstalkEnvName }}",
+                    {
+                      "accountId": "{{ Dashboard.AccountId }}"
+                    }
+                  ]
+                ],
+                "legend": {
+                  "position": "bottom"
+                },
+                "region": "us-east-1",
+                "liveData": false,
+                "title": "ApplicationRequests3xx: Average",
+                "view": "timeSeries",
+                "stacked": false
+              }
+            },
+            {
+              "type": "metric",
+              "properties": {
+                "metrics": [
+                  [
+                    "AWS/ElasticBeanstalk",
+                    "ApplicationRequests4xx",
+                    "EnvironmentName",
+                    "{{ Dashboard.ElasticBeanstalkEnvName }}",
+                    {
+                      "accountId": "{{ Dashboard.AccountId }}"
+                    }
+                  ]
+                ],
+                "legend": {
+                  "position": "bottom"
+                },
+                "region": "us-east-1",
+                "liveData": false,
+                "title": "ApplicationRequests4xx: Average",
+                "view": "timeSeries",
+                "stacked": false
+              }
+            },
+            {
+              "type": "metric",
+              "properties": {
+                "metrics": [
+                  [
+                    "AWS/ElasticBeanstalk",
+                    "ApplicationRequests5xx",
+                    "EnvironmentName",
+                    "{{ Dashboard.ElasticBeanstalkEnvName }}",
+                    {
+                      "accountId": "{{ Dashboard.AccountId }}"
+                    }
+                  ]
+                ],
+                "legend": {
+                  "position": "bottom"
+                },
+                "region": "us-east-1",
+                "liveData": false,
+                "title": "ApplicationRequests5xx: Average",
+                "view": "timeSeries",
+                "stacked": false
+              }
+            }
+          ]
+        }
+{% endfor %}


### PR DESCRIPTION
Create cloudwatch dashboards for agora develop, staging and prod in the monitoring account. This requires setting up beanstalk to send metrics to cloudwatch in the agora accounts.

depends on https://github.com/Sage-Bionetworks/agora2-infra/pull/25

