### PR TITLE
[IT-3420] Update service catalog EC2 products

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-docker-notebook.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-docker-notebook.yaml
@@ -17,3 +17,7 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.6/ec2/sc-ec2-linux-docker-notebook.yaml'
       Name: 'v1.3.6'
+    - Description: 'Remove nano instance type {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.0/ec2/sc-ec2-linux-docker-notebook.yaml'
+      Name: 'v1.4.0'

--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-docker.yaml
@@ -50,7 +50,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.12/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.2.12'
-    - Description: 'Update system libraries, including Python version {{ range(1, 10000) | random }}'
+    - Description: 'Update system libraries, including Python version'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.9/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.3.9'
+    - Description: 'Remove nano instance type {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.0/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.4.0'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker-notebook.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker-notebook.yaml
@@ -28,7 +28,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.5/ec2/sc-ec2-linux-docker-notebook.yaml'
       Name: 'v1.3.5'
-    - Description: 'Update Docker image and volume mounting {{ range(1, 10000) | random }}'
+    - Description: 'Update Docker image and volume mounting'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.6/ec2/sc-ec2-linux-docker-notebook.yaml'
       Name: 'v1.3.6'
+    - Description: 'Remove nano instance type {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.0/ec2/sc-ec2-linux-docker-notebook.yaml'
+      Name: 'v1.4.0'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
@@ -49,7 +49,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.12/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.2.12'
-    - Description: 'Update system libraries, including Python version {{ range(1, 10000) | random }}'
+    - Description: 'Update system libraries, including Python version'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.9/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.3.9'
+    - Description: 'Remove nano instance type {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.0/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.4.0'

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-docker-notebook.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-docker-notebook.yaml
@@ -17,3 +17,7 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.6/ec2/sc-ec2-linux-docker-notebook.yaml'
       Name: 'v1.3.6'
+    - Description: 'Remove nano instance type {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.0/ec2/sc-ec2-linux-docker-notebook.yaml'
+      Name: 'v1.4.0'

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-docker.yaml
@@ -50,7 +50,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.12/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.2.12'
-    - Description: 'Update system libraries, including Python version {{ range(1, 10000) | random }}'
+    - Description: 'Update system libraries, including Python version'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.9/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.3.9'
+    - Description: 'Remove nano instance type {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.0/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.4.0'

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-docker-notebook.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-docker-notebook.yaml
@@ -17,3 +17,7 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.6/ec2/sc-ec2-linux-docker-notebook.yaml'
       Name: 'v1.3.6'
+    - Description: 'Remove nano instance type {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.0/ec2/sc-ec2-linux-docker-notebook.yaml'
+      Name: 'v1.4.0'

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-docker.yaml
@@ -54,7 +54,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.2.13/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.2.13'
-    - Description: 'Update system libraries, including Python version {{ range(1, 10000) | random }}'
+    - Description: 'Update system libraries, including Python version'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.9/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.3.9'
+    - Description: 'Remove nano instance type {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.0/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.4.0'


### PR DESCRIPTION
Update products to remove the nano EC2 instance type as an option.

depends on https://github.com/Sage-Bionetworks/service-catalog-library/pull/330

