### PR TITLE
SWC-6768: Add appconfig permissions for stack builder

### DIFF
--- a/sceptre/synapsedev/templates/SynapseCMK-template.json
+++ b/sceptre/synapsedev/templates/SynapseCMK-template.json
@@ -218,6 +218,13 @@
                                         "wafv2:*"
                                     ],
                                     "Resource": "*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "appconfig:*"
+                                    ],
+                                    "Resource": "*"
                                 }
                             ]
                         }


### PR DESCRIPTION
Add AWS AppConfig permissions for stack builder

PR Checklist:
- [x]  Describe and explain your intentions for this change
- [x] Setup pre-commit and run the validators (info in README.md)