### PR TITLE
[IT-2581] Refactor cloudtrail setup

### DIFF
--- a/org-formation/060-cloudtrail/_tasks.yaml
+++ b/org-formation/060-cloudtrail/_tasks.yaml
@@ -1,35 +1,15 @@
 Parameters:
   <<: !Include '../_parameters.yaml'
 
-CloudwatchTrailLog:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.6/templates/Cloudwatch/cloudwatch-log.yaml
-  StackName: !Sub '${resourcePrefix}-cloudwatch-log'
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    Account: '*'
-    IncludeMasterAccount: true
-  Parameters:
-    LogGroupName: !Sub '/aws/cloudtrail/${resourcePrefix}-cloudwatch-log.log'
-    RetentionInDays: !GetAtt CurrentAccount.Tags.CloudwatchCloudTrailLogRetentionPeriod
-
 CloudTrail:
   Type: update-stacks
-  DependsOn: [ "CloudwatchTrailLog" ]
   Template: cloudtrail-trail.yaml
   StackName: !Sub '${resourcePrefix}-cloudtrail'
   StackDescription: CloudTrail
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
-    Account: '*'
-    IncludeMasterAccount: true
-  OrganizationBindings:
-    MasterBinding:
-      Account: !Ref LogCentralAccount
-    MemberBinding:
-      Account: '*'
-      IncludeMasterAccount: true
-      ExcludeAccount: !Ref LogCentralAccount
+    Account: !Ref LogCentralAccount
+    IncludeMasterAccount: false
   Parameters:
     bucketName: !Sub '${resourcePrefix}-cloudtrail-${LogCentralAccount}'
     CloudWatchLogsLogGroupArn: !CopyValue [ !Sub '${primaryRegion}-${resourcePrefix}-cloudwatch-log-LogGroupArn' ]
@@ -38,3 +18,6 @@ CloudTrail:
       - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
       - !Sub 'arn:aws:iam::${AWS::AccountId}:role/OrganizationAccountAccessRole'
       - 'arn:aws:iam::531805629419:role/github-oidc-sage-bionetwo-ProviderRoleorganization-1EY1CRUF48VP5'
+    # Must enable LogCentralAccount as the delegated Cloudtrail admin account
+    # https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-add-delegated-administrator.html
+    IsOrganizationTrail: true

--- a/org-formation/060-cloudtrail/cloudtrail-trail.yaml
+++ b/org-formation/060-cloudtrail/cloudtrail-trail.yaml
@@ -1,14 +1,21 @@
 # From https://github.com/org-formation/org-formation-reference/tree/master/src/templates/060-cloud-trail
 AWSTemplateFormatVersion: '2010-09-09-OC'
+
 Parameters:
+  LogGroupName:
+    Type: String
+    Description: >-
+      The cloudwatch log group name (i.e. /aws/myapp/tomcat/server.log)
+  RetentionInDays:
+    Type: Number
+    Description: >-
+      The number of days to retain the log events in the specified log group. Possible values are:
+      1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653.
+    Default: 90
+    MinValue: 1
+    MaxValue: 3653
   bucketName:
     Type: String
-  CloudWatchLogsLogGroupArn:
-    Type: String
-    Default: ""
-  CloudWatchLogsRoleArn:
-    Type: String
-    Default: ""
   KmsKeyAdminPrincipalArns:
     Type: CommaDelimitedList
     Description: List of user/role/account ARNs that can administer the key
@@ -16,6 +23,7 @@ Parameters:
     Type: String
     Description: Specifies whether the trail is applied to all accounts in an organization in AWS Organizations
     Default: false
+
 Resources:
   KmsKey:
     Type: "AWS::KMS::Key"
@@ -87,7 +95,45 @@ Resources:
               kms:CallerAccount: !Ref AWS::AccountId
             StringLike:
               kms:EncryptionContext:aws:cloudtrail:arn: !Sub 'arn:aws:cloudtrail:*:${AWS::AccountId}:trail/*'
-
+  LogGroup:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      LogGroupName: !Ref LogGroupName
+      RetentionInDays: !Ref RetentionInDays
+  LogPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AWSCloudTrailCreateLogStream
+            Effect: Allow
+            Action:
+              - 'logs:CreateLogStream'
+            Resource:
+              - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LogGroup}:log-stream:${AWS::AccountId}_CloudTrail_${AWS::Region}*'
+          - Sid: AWSCloudTrailPutLogEvents
+            Effect: Allow
+            Action:
+              - 'logs:PutLogEvents'
+            Resource:
+              - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LogGroup}:log-stream:${AWS::AccountId}_CloudTrail_${AWS::Region}*'
+  LogRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              Service:
+                - "cloudtrail.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+      ManagedPolicyArns:
+        - !Ref LogPolicy
   CloudTrailBucket:
     Type: AWS::S3::Bucket
     Metadata:
@@ -122,7 +168,6 @@ Resources:
               StorageClass: GLACIER
             - TransitionInDays: 180
               StorageClass: DEEP_ARCHIVE
-
   CloudTrailBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Metadata:
@@ -151,7 +196,6 @@ Resources:
           Condition:
             StringEquals:
               s3:x-amz-acl: bucket-owner-full-control
-
   CloudTrail:
     Type: AWS::CloudTrail::Trail
     Properties:
@@ -160,8 +204,8 @@ Resources:
       IncludeGlobalServiceEvents: true
       IsMultiRegionTrail: true
       EnableLogFileValidation: true
-      CloudWatchLogsLogGroupArn: !Ref CloudWatchLogsLogGroupArn
-      CloudWatchLogsRoleArn: !Ref CloudWatchLogsRoleArn
+      CloudWatchLogsLogGroupArn: !GetAtt LogGroup.Arn
+      CloudWatchLogsRoleArn: !GetAtt LogRole.Arn
       KMSKeyId: !Ref KmsKey
       IsOrganizationTrail: !Ref IsOrganizationTrail
 

--- a/org-formation/060-cloudtrail/cloudtrail-trail.yaml
+++ b/org-formation/060-cloudtrail/cloudtrail-trail.yaml
@@ -12,9 +12,12 @@ Parameters:
   KmsKeyAdminPrincipalArns:
     Type: CommaDelimitedList
     Description: List of user/role/account ARNs that can administer the key
+  IsOrganizationTrail:
+    Type: String
+    Description: Specifies whether the trail is applied to all accounts in an organization in AWS Organizations
+    Default: false
 Resources:
   KmsKey:
-    OrganizationBinding: !Ref MasterBinding
     Type: "AWS::KMS::Key"
     Properties:
       Description: !Sub '${AWS::StackName} created key'
@@ -86,7 +89,6 @@ Resources:
               kms:EncryptionContext:aws:cloudtrail:arn: !Sub 'arn:aws:cloudtrail:*:${AWS::AccountId}:trail/*'
 
   CloudTrailBucket:
-    OrganizationBinding: !Ref MasterBinding
     Type: AWS::S3::Bucket
     Metadata:
       cfn-lint:
@@ -122,7 +124,6 @@ Resources:
               StorageClass: DEEP_ARCHIVE
 
   CloudTrailBucketPolicy:
-    OrganizationBinding: !Ref MasterBinding
     Type: AWS::S3::BucketPolicy
     Metadata:
       cfn-lint:
@@ -152,7 +153,6 @@ Resources:
               s3:x-amz-acl: bucket-owner-full-control
 
   CloudTrail:
-    OrganizationBinding: !Ref MasterBinding
     Type: AWS::CloudTrail::Trail
     Properties:
       S3BucketName: !Ref CloudTrailBucket
@@ -163,19 +163,7 @@ Resources:
       CloudWatchLogsLogGroupArn: !Ref CloudWatchLogsLogGroupArn
       CloudWatchLogsRoleArn: !Ref CloudWatchLogsRoleArn
       KMSKeyId: !Ref KmsKey
-
-  MemberCloudTrail:
-    OrganizationBinding: !Ref MemberBinding
-    Type: AWS::CloudTrail::Trail
-    DependsOn: CloudTrailBucketPolicy
-    Properties:
-      S3BucketName: !Ref CloudTrailBucket
-      IsLogging: true
-      IncludeGlobalServiceEvents: true
-      IsMultiRegionTrail: true
-      EnableLogFileValidation: true
-      CloudWatchLogsLogGroupArn: !Ref CloudWatchLogsLogGroupArn
-      CloudWatchLogsRoleArn: !Ref CloudWatchLogsRoleArn
+      IsOrganizationTrail: !Ref IsOrganizationTrail
 
 Outputs:
   CloudTrailBucketName:
@@ -188,9 +176,5 @@ Outputs:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-CloudTrailBucketArn'
   CloudTrailArn:
     Value: !GetAtt CloudTrail.Arn
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-CloudTrailArn'
-  MemberCloudTrailArn:
-    Value: !GetAtt MemberCloudTrail.Arn
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-CloudTrailArn'


### PR DESCRIPTION
Previously to enable cloudtrail to send data to a central AWS account (logcentral) we need to setup cloudtrail in every member account to enable this configuration.

AWS has now introduced a new feature that allows enabling `organizations cloudtrail` without having to setup cloudtrail in every member account. Instead it just need to be enabled from an organizations account or from a deleaged admin account.

We are changing the cloudtrail setup to the latter option because it's much simpler.  The only caveat is that we need to first manually setup logcentral as an cloudtrail delegated admin account[1]

[1] https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-add-delegated-administrator.html

