### PR TITLE
[IT-3554] Add additional Service Catalog permissions

### DIFF
--- a/sceptre/scipool/templates/sc-enduser-iam.yaml
+++ b/sceptre/scipool/templates/sc-enduser-iam.yaml
@@ -62,8 +62,7 @@ Resources:
             Resource: "*"
           - Effect: Allow
             Action:
-              - "ec2:*Tags"
-              - "s3:*Tags"
+              - "*:*Tags"
               - "*:TagResource"
               - "*:UntagResource"
             Resource: "*"

--- a/sceptre/scipool/templates/sc-enduser-iam.yaml
+++ b/sceptre/scipool/templates/sc-enduser-iam.yaml
@@ -57,7 +57,25 @@ Resources:
               - organizations:DescribeOrganization
               - servicecatalog:DescribeProvisionedProduct
               - cloudwatch:GetMetricData  # access to EC2 monitoring info
+              - ec2:DescribeImages  # service catalog status info
+              - lambda:ListTags  # service catalog tag updates
             Resource: "*"
+          - Effect: Allow
+            Action:
+              - "ec2:*Tags"
+              - "s3:*Tags"
+              - "*:TagResource"
+              - "*:UntagResource"
+            Resource: "*"
+            Condition:
+              StringEquals:
+                # The 'aws:ResourceTag/foo' key lets us compare against the value of the 'foo' tag on
+                # the target resource. Here we are checking the value of the 'provisioningPrincipalArn'
+                # service tag against the 'PrincipalArn' from the request.
+                # https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html#access_tags_control-resources
+                # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-resourcetag
+                # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalarn
+                "aws:ResourceTag/aws:servicecatalog:provisioningPrincipalArn": "${aws.PrincipalArn}"
   BatchReadOnlyPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:


### PR DESCRIPTION
Updating provisioned products with changes to tags is failing with permissions errors. RestrictBucketDownloadRegionFunction updates fail on 'lambda:ListTags', and the associated roles fail on'iam:UntagResource'. Allow SC roles to list tags on any lambda, and to update tags on their own provisioned resources.

The 'aws:ResourceTag/foo' condition key lets us compare against the value of the 'foo' tag on the target resource. Here we are comparing the 'provisioningPrincipalArn' SC service tag value against the 'PrincipalArn' from the request.

https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html#access_tags_control-resources https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-resourcetag https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalarn
