### PR TITLE
PLFM-8399: Add AppConfig permissions to deployer role

### DIFF
--- a/sceptre/synapseprod/templates/SynapseCMK-template.json
+++ b/sceptre/synapseprod/templates/SynapseCMK-template.json
@@ -203,6 +203,13 @@
                                         "athena:*"
                                     ],
                                     "Resource": "*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "appconfig:*"
+                                    ],
+                                    "Resource": "*"
                                 }
                             ]
                         }


### PR DESCRIPTION
This PR adds AppConfig permissions to the Synapse Prod deployer role.
Same as #1124 for dev.