### PR TITLE
IT-3606: Activate cis-aws-foundations-benchmark SecurityHub standard

### DIFF
--- a/org-formation/075-security-hub/security-hub.yaml
+++ b/org-formation/075-security-hub/security-hub.yaml
@@ -3,6 +3,10 @@ Description: "Setup AWS Security Hub"
 Resources:
   SecurityHub:
     Type: "AWS::SecurityHub::Hub"
+  SecurityHubStandard:
+    Type: "AWS::SecurityHub::Standard"
+    Properties:
+      StandardsArn: arn:aws:securityhub:us-east-1::standards/cis-aws-foundations-benchmark/v/1.4.0
 Outputs:
   SecurityHubArn:
     Description: "The security hub ARN"


### PR DESCRIPTION
SecurityHub has a list of six 'standards' which are sets of controls that it will collect findings for.  We have selected `CIS AWS Foundations Benchmark v1.4.0` for our security program.  The standard seems to have been de-activated in Security Hub.  This PR enables the standard programmatically which should ensure it remains enabled going forward.