### PR TITLE
SWC-6769: Add parameter store permissions for stack builder

### DIFF
--- a/sceptre/synapsedev/templates/SynapseCMK-template.json
+++ b/sceptre/synapsedev/templates/SynapseCMK-template.json
@@ -225,6 +225,13 @@
                                         "appconfig:*"
                                     ],
                                     "Resource": "*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "ssm:*"
+                                    ],
+                                    "Resource": "*"
                                 }
                             ]
                         }

--- a/sceptre/synapseprod/templates/SynapseCMK-template.json
+++ b/sceptre/synapseprod/templates/SynapseCMK-template.json
@@ -210,6 +210,13 @@
                                         "appconfig:*"
                                     ],
                                     "Resource": "*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "ssm:*"
+                                    ],
+                                    "Resource": "*"
                                 }
                             ]
                         }


### PR DESCRIPTION
PR Checklist:
Add parameter store permissions for stack builder to use to pull in AppConfig identifiers inside SWC
- [x] Describe and explain your intentions for this change
- [x] Setup pre-commit and run the validators (info in README.md)
