### PR TITLE
IT-3606 Reverting change to 075-security-hub/_tasks.yaml

### DIFF
--- a/org-formation/075-security-hub/_tasks.yaml
+++ b/org-formation/075-security-hub/_tasks.yaml
@@ -8,7 +8,7 @@ Parameters:
   accountId:
     Type: String
     Description: The identifier from the account used to manage this service
-    Default: !Ref SecurityCentralAccount
+    Default: !Ref MasterAccount
 
 SecurityHub:
   Type: update-stacks

--- a/org-formation/075-security-hub/_tasks.yaml
+++ b/org-formation/075-security-hub/_tasks.yaml
@@ -8,7 +8,7 @@ Parameters:
   accountId:
     Type: String
     Description: The identifier from the account used to manage this service
-    Default: !Ref MasterAccount
+    Default: !Ref SecurityCentralAccount
 
 SecurityHub:
   Type: update-stacks

--- a/org-formation/075-security-hub/security-hub.yaml
+++ b/org-formation/075-security-hub/security-hub.yaml
@@ -3,16 +3,6 @@ Description: "Setup AWS Security Hub"
 Resources:
   SecurityHub:
     Type: "AWS::SecurityHub::Hub"
-  SecurityHubStandardFoundationalBestPractices:
-    Type: "AWS::SecurityHub::Standard"
-    Properties:
-      StandardsArn:
-        Fn::Sub: arn:${AWS::Partition}:securityhub:${AWS::Region}::standards/aws-foundational-security-best-practices/v/1.0.0
-  SecurityHubStandardCISFoundationsBenchmark:
-    Type: "AWS::SecurityHub::Standard"
-    Properties:
-      StandardsArn:
-        Fn::Sub: arn:${AWS::Partition}:securityhub:${AWS::Region}::standards/cis-aws-foundations-benchmark/v/1.4.0
 Outputs:
   SecurityHubArn:
     Description: "The security hub ARN"


### PR DESCRIPTION
The current stack fails to build with:

> Account is already subscribed to Security Hub

I wonder if this is because we changed `MasterAccount` to `SecurityCentralAccount` in  075-security-hub/_tasks.yaml, i.e., if the error is due to trying to run the stack in the designated Security Hub administrator account.

This PR reverts the change to try to fix the build.