### PR TITLE
IT-3606: switch security-hub account to SecurityCentralAccount

### DIFF
--- a/org-formation/075-security-hub/_tasks.yaml
+++ b/org-formation/075-security-hub/_tasks.yaml
@@ -8,7 +8,7 @@ Parameters:
   accountId:
     Type: String
     Description: The identifier from the account used to manage this service
-    Default: !Ref SecurityCentralAccount
+    Default: !Ref MasterAccount
 
 SecurityHub:
   Type: update-stacks

--- a/org-formation/075-security-hub/_tasks.yaml
+++ b/org-formation/075-security-hub/_tasks.yaml
@@ -8,7 +8,7 @@ Parameters:
   accountId:
     Type: String
     Description: The identifier from the account used to manage this service
-    Default: !Ref MasterAccount
+    Default: !Ref SecurityCentralAccount
 
 SecurityHub:
   Type: update-stacks

--- a/org-formation/075-security-hub/security-hub.yaml
+++ b/org-formation/075-security-hub/security-hub.yaml
@@ -3,16 +3,6 @@ Description: "Setup AWS Security Hub"
 Resources:
   SecurityHub:
     Type: "AWS::SecurityHub::Hub"
-  SecurityHubStandardFoundationalBestPractices:
-    Type: "AWS::SecurityHub::Standard"
-    Properties:
-      StandardsArn:
-        Fn::Sub: arn:${AWS::Partition}:securityhub:${AWS::Region}::standards/aws-foundational-security-best-practices/v/1.0.0
-  SecurityHubStandardCISFoundationsBenchmark:
-    Type: "AWS::SecurityHub::Standard"
-    Properties:
-      StandardsArn:
-        Fn::Sub: arn:${AWS::Partition}:securityhub:${AWS::Region}::standards/cis-aws-foundations-benchmark/v/1.4.0
 Outputs:
   SecurityHubArn:
     Description: "The security hub ARN"


### PR DESCRIPTION
We want the security-hub CF stack to be created in the delegated admin' account rather than in the Organizations account.