### PR TITLE
[IT-3547] Update base Amazon Linux AMI

### DIFF
--- a/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/bmgfki/sc-product-ec2-linux-docker.yaml
@@ -54,7 +54,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.9/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.3.9'
-    - Description: 'Remove nano instance type {{ range(1, 10000) | random }}'
+    - Description: 'Remove nano instance type'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.0/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.4.0'
+    - Description: 'Update Amazon Linux AMI {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.2/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.4.2'

--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
@@ -53,7 +53,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.9/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.3.9'
-    - Description: 'Remove nano instance type {{ range(1, 10000) | random }}'
+    - Description: 'Remove nano instance type'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.0/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.4.0'
+    - Description: 'Update Amazon Linux AMI {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.2/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.4.2'

--- a/sceptre/scipool/config/prod/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/prod/sc-product-ec2-linux-docker.yaml
@@ -54,7 +54,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.9/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.3.9'
-    - Description: 'Remove nano instance type {{ range(1, 10000) | random }}'
+    - Description: 'Remove nano instance type'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.0/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.4.0'
+    - Description: 'Update Amazon Linux AMI {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.2/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.4.2'

--- a/sceptre/scipool/config/strides/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/strides/sc-product-ec2-linux-docker.yaml
@@ -58,7 +58,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.9/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.3.9'
-    - Description: 'Remove nano instance type {{ range(1, 10000) | random }}'
+    - Description: 'Remove nano instance type'
       Info:
         LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.0/ec2/sc-ec2-linux-docker.yaml'
       Name: 'v1.4.0'
+    - Description: 'Update Amazon Linux AMI {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.2/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.4.2'


### PR DESCRIPTION
Use our latest custom amazon linux AMI built from the latest AWS-provided AMI to ensure Service Catalog products have the latest package updates.
