### PR TITLE
IT-3681: Add targets for deployment

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -508,19 +508,31 @@ GithubOidcSageBionetworksWebMonorepoInfra:
               "Sid": "ListObjectsInBucket",
               "Effect": "Allow",
               "Action": [ "s3:GetBucketLocation", "s3:ListBucket", "s3:ListBucketMultipartUploads" ],
-              "Resource": [ "arn:aws:s3:::prod.accounts.sagebionetworks.org", "arn:aws:s3:::staging.accounts.sagebionetworks.org" ]
+              "Resource": [ "arn:aws:s3:::prod.accounts.sagebionetworks.org",
+                            "arn:aws:s3:::staging.accounts.sagebionetworks.org",
+                            "arn:aws:s3:::prod.accounts.synapse.org",
+                            "arn:aws:s3:::staging.accounts.synapse.org"
+                          ]
           },
           {
               "Sid": "AllObjectActions",
               "Effect": "Allow",
               "Action": [ "s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:*Multipart*" ],
-              "Resource": ["arn:aws:s3:::prod.accounts.sagebionetworks.org/*", "arn:aws:s3:::staging.accounts.sagebionetworks.org/*" ]
+              "Resource": [ "arn:aws:s3:::prod.accounts.sagebionetworks.org/*",
+                            "arn:aws:s3:::staging.accounts.sagebionetworks.org/*",
+                            "arn:aws:s3:::prod.accounts.synapse.org/*",
+                            "arn:aws:s3:::staging.accounts.synapse.org/*"
+                          ]
           },
           {
               "Sid": "CloudfrontActions",
               "Effect": "Allow",
               "Action": [ "cloudfront:CreateInvalidation" ],
-              "Resource": ["arn:aws:cloudfront::797640923903:distribution/E2656IE63W1MXI", "arn:aws:cloudfront::797640923903:distribution/EY52HOUGKDP1F" ]
+              "Resource": [ "arn:aws:cloudfront::797640923903:distribution/E2656IE63W1MXI",
+                            "arn:aws:cloudfront::797640923903:distribution/EY52HOUGKDP1F",
+                            "arn:aws:cloudfront::797640923903:distribution/E7COI4Z95FFZQ",
+                            "arn:aws:cloudfront::797640923903:distribution/E1QXK5X5JV0YKJ"
+                          ]
           }
         ]
       }


### PR DESCRIPTION
This PR adds new buckets and distributionIDs for deployment from synapse-monrepo.

