### PR TITLE
[IT-3547] Update S3 products

### DIFF
--- a/sceptre/scipool/config/develop/sc-product-s3-private-enc.yaml
+++ b/sceptre/scipool/config/develop/sc-product-s3-private-enc.yaml
@@ -56,7 +56,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.38/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.1.38'
-    - Description:  'Update cfn-cr-same-region-bucket-download python version. {{ range(1, 10000) | random }}'
+    - Description:  'Update cfn-cr-same-region-bucket-download python version.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.8/s3/sc-s3-encrypted-ra.yaml'
       Name: 'v1.3.8'
+    - Description:  'Update cfn-cr-same-region-bucket-download dependencies. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.4/s3/sc-s3-encrypted-ra.yaml'
+      Name: 'v1.4.4'

--- a/sceptre/scipool/config/develop/sc-product-s3-synapse.yaml
+++ b/sceptre/scipool/config/develop/sc-product-s3-synapse.yaml
@@ -72,7 +72,11 @@ sceptre_user_data:
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.1.39/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.1.39'
-    - Description:  'Update cfn-cr-same-region-bucket-download python version. {{ range(1, 10000) | random }}'
+    - Description:  'Update cfn-cr-same-region-bucket-download python version.'
       Info:
         LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.3.8/s3/sc-s3-synapse-ra.yaml'
       Name: 'v1.3.8'
+    - Description:  'Update cfn-cr-same-region-bucket-download dependencies. {{ range(1, 10000) | random }}'
+      Info:
+        LoadTemplateFromURL:  'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.4/s3/sc-s3-synapse-ra.yaml'
+      Name: 'v1.4.4'


### PR DESCRIPTION
Use the latest S3 templates, pulling in updated dependencies for the same region download lambda.

Depends on Sage-Bionetworks/service-catalog-library#333
