### PR TITLE
AG-1469: Add OIDC role for AgoraDevAccount ECR repo

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -816,3 +816,56 @@ GithubOidcAgoraEBDeploy:
       - !Ref AgoraDevAccount
       - !Ref AgoraProdAccount
     Region: us-east-1
+
+GithubOidcSageBionetworksAgoraDevECR:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-agoradev-ecr
+  Parameters:
+    ProviderArn: !CopyValue [!Sub "${resourcePrefix}-${appName}-ProviderArn"]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-agoradev-ecr
+    PolicyDocument: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "GetAuthorizationToken",
+            "Effect": "Allow",
+            "Action": [
+              "ecr:GetAuthorizationToken"
+            ],
+            "Resource": "*"
+          },
+          {
+            "Sid": "ListImagesInRepository",
+            "Effect": "Allow",
+            "Action": [
+              "ecr:ListImages"
+            ],
+            "Resource": "arn:aws:ecr:us-east-1:607346494281:repository/agora/data"
+          },
+          {
+            "Sid": "AllowPushPull",
+            "Effect": "Allow",
+            "Action": [
+              "ecr:BatchGetImage",
+              "ecr:BatchCheckLayerAvailability",
+              "ecr:CompleteLayerUpload",
+              "ecr:GetDownloadUrlForLayer",
+              "ecr:InitiateLayerUpload",
+              "ecr:PutImage",
+              "ecr:UploadLayerPart"
+            ],
+            "Resource": "arn:aws:ecr:us-east-1:607346494281:repository/agora/data"
+          }
+        ]
+      }
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "Agora"
+        branches: ["*"]
+  DefaultOrganizationBinding:
+    Account: !Ref AgoraDevAccount
+    Region: us-east-1


### PR DESCRIPTION
PR Checklist:
- [x] Describe and explain your intentions for this change
- [x] Setup pre-commit and run the validators (info in README.md)

We're adding a GitHub action in [Agora](https://github.com/Sage-Bionetworks/Agora/) that will 1) authenticate Docker to the Agora dev ECR using [aws ecr get-login-password](https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login-password.html), 2) check whether an image already exists using [aws ecr list-images](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ecr/list-images.html), 3) if the image does not exist, build and push the image to the Agora dev ECR repo, and 4) pull the image for use in e2e tests. Based on this, I included a policy document with permissions based on [this doc](https://github.com/aws-actions/amazon-ecr-login?tab=readme-ov-file#ecr-private) and [this doc](https://docs.aws.amazon.com/AmazonECR/latest/userguide/security_iam_id-based-policy-examples.html).