### PR TITLE
[IT-3697] Test the latest docker AMI before tagging a new version

### DIFF
--- a/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
+++ b/sceptre/scipool/config/develop/sc-product-ec2-linux-docker.yaml
@@ -59,5 +59,5 @@ sceptre_user_data:
       Name: 'v1.4.0'
     - Description: 'Update Amazon Linux AMI {{ range(1, 10000) | random }}'
       Info:
-        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.4.2/ec2/sc-ec2-linux-docker.yaml'
-      Name: 'v1.4.2'
+        LoadTemplateFromURL: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/master/ec2/sc-ec2-linux-docker.yaml'
+      Name: 'v1.4.3'


### PR DESCRIPTION
Test the latest AMI created by packer-amazonlinux-docker before tagging a new version by referencing the master AMI in the product template on the master branch of service-catalog-library and referencing that product template in the dev account here.

If the test works then packer-amazonlinux-docker will be tagged with a new version, the tagged AMI will be referenced in the product template and service-catalog-library will be tagged with a new version. Finally, new products will be created here from the newly tagged product template.