### PR TITLE
[IT-3729] Setup Guardduty s3 malware protection

### DIFF
--- a/org-formation/070-guard-duty/_tasks.yaml
+++ b/org-formation/070-guard-duty/_tasks.yaml
@@ -88,7 +88,7 @@ GuarddutyS3MalwareProtection:
   DefaultOrganizationBinding:
     IncludeMasterAccount: false
     Account:
-      - !Ref SynapseProdAccount
+      - !Ref SynapseDevAccount
   Parameters:
     BucketName: "TBD"
 

--- a/org-formation/070-guard-duty/_tasks.yaml
+++ b/org-formation/070-guard-duty/_tasks.yaml
@@ -73,3 +73,23 @@ GuardDutyConnectOpenData:
     MemberRootEmail: "aws.opendata@sagebase.org"
     MasterDectector: !CopyValue [ !Sub '${resourcePrefix}-${appName}-detector-id' ]
 # ==================================================================================================
+
+
+
+# ==================================================================================================
+# S3 Malware protection
+
+GuarddutyS3MalwareProtection:
+  Type: update-stacks
+  Template: ./guardduty-s3-malware-protection.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-s3-malware-protection'
+  StackDescription: Setup AWS Guardduty S3 Malware Protection
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+    Account:
+      - !Ref SynapseProdAccount
+  Parameters:
+    BucketName: "TBD"
+
+# ==================================================================================================

--- a/org-formation/070-guard-duty/guardduty-s3-malware-protection.yaml
+++ b/org-formation/070-guard-duty/guardduty-s3-malware-protection.yaml
@@ -124,8 +124,3 @@ Resources:
         - Id: NotificationTopic
           Arn: !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SnsTopicName}'
       State: ENABLED
-Outputs:
-  SnsTopic:
-    Value: !Ref SnsTopic
-    Export:
-      Name: !Sub '${AWS::StackName}-SnsTopic'

--- a/org-formation/070-guard-duty/guardduty-s3-malware-protection.yaml
+++ b/org-formation/070-guard-duty/guardduty-s3-malware-protection.yaml
@@ -19,7 +19,7 @@ Resources:
     Properties:
       Actions:
         Tagging:
-          Status: Active
+          Status: ENABLED
       ProtectedResource:
         S3Bucket:
           BucketName: !Ref BucketName
@@ -85,8 +85,7 @@ Resources:
             Action:
               - 's3:PutObject'
             Resource:
-              - >-
-                arn:aws:s3:::${BucketName}/malware-protection-resource-validation-object
+              - !Sub 'arn:aws:s3:::${BucketName}/malware-protection-resource-validation-object'
           - Sid: AllowCheckBucketOwnership
             Effect: Allow
             Action:

--- a/org-formation/070-guard-duty/guardduty-s3-malware-protection.yaml
+++ b/org-formation/070-guard-duty/guardduty-s3-malware-protection.yaml
@@ -22,7 +22,7 @@ Resources:
           Status: Active
       ProtectedResource:
         S3Bucket:
-          BucketName: !BucketName
+          BucketName: !Ref BucketName
       Role: !Ref Role
 
   # role & policy from https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection-s3-iam-policy-prerequisite.html

--- a/org-formation/070-guard-duty/guardduty-s3-malware-protection.yaml
+++ b/org-formation/070-guard-duty/guardduty-s3-malware-protection.yaml
@@ -1,0 +1,110 @@
+# Setup AWS Guardduty Malware Protection for S3 to scan and apply a predefined "GuardDutyMalwareScanStatus" tag all
+# S3 objects with possible tag values ["NO_THREATS_FOUND","THREATS_FOUND","UNSUPPORTED","FAILED"]
+# https://docs.aws.amazon.com/guardduty/latest/ug/tag-based-access-s3-malware-protection.html
+#
+# Note: The bucket being scanned should contain a bucket policy to restrict access to Malicious objects.
+# https://docs.aws.amazon.com/guardduty/latest/ug/tag-based-access-s3-malware-protection.html#apply-tbac-s3-malware-protection
+
+AWSTemplateFormatVersion: 2010-09-09
+Description: Guardduty Malware protection plan for S3 bucket
+Parameters:
+  BucketName:
+    Type: String
+    Description: The bucket name
+    ConstraintDescription: Name string (i.e. MyBucket)
+Resources:
+  MalwareProtectionPlan:
+    Type: AWS::GuardDuty::MalwareProtectionPlan
+    Properties:
+      Actions:
+        Tagging:
+          Status: Active
+      ProtectedResource:
+        S3Bucket:
+          BucketName: !BucketName
+      Role: !Ref Role
+
+  # role & policy from https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection-s3-iam-policy-prerequisite.html
+  Role:
+    Type: AWS::IAM::Role
+    Properties:
+      ManagedPolicyArns:
+        - !Ref ManagedPolicy
+      AssumeRolePolicyDocument:
+       Version: 2012-10-17
+       Statement:
+          - Sid: AllowTrustToGuardDutyProtectionPlan
+            Effect: Allow
+            Principal:
+              Service: malware-protection-plan.guardduty.amazonaws.com
+            Action: 'sts:AssumeRole'
+  ManagedPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowManagedRuleToSendS3EventsToGuardDuty
+            Effect: Allow
+            Action:
+              - 'events:PutRule'
+              - 'events:DeleteRule'
+              - 'events:PutTargets'
+              - 'events:RemoveTargets'
+            Resource:
+              - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*'
+            Condition:
+              StringLike:
+                'events:ManagedBy': malware-protection-plan.guardduty.amazonaws.com
+          - Sid: AllowGuardDutyToMonitorEventBridgeManagedRule
+            Effect: Allow
+            Action:
+              - 'events:DescribeRule'
+              - 'events:ListTargetsByRule'
+            Resource:
+              - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*'
+          - Sid: AllowPostScanTag
+            Effect: Allow
+            Action:
+              - 's3:PutObjectTagging'
+              - 's3:GetObjectTagging'
+              - 's3:PutObjectVersionTagging'
+              - 's3:GetObjectVersionTagging'
+            Resource:
+              - !Sub 'arn:aws:s3:::${BucketName}/*'
+          - Sid: AllowEnableS3EventBridgeEvents
+            Effect: Allow
+            Action:
+              - 's3:PutBucketNotification'
+              - 's3:GetBucketNotification'
+            Resource:
+              - !Sub 'arn:aws:s3:::${BucketName}'
+          - Sid: AllowPutValidationObject
+            Effect: Allow
+            Action:
+              - 's3:PutObject'
+            Resource:
+              - >-
+                arn:aws:s3:::${BucketName}/malware-protection-resource-validation-object
+          - Sid: AllowCheckBucketOwnership
+            Effect: Allow
+            Action:
+              - 's3:ListBucket'
+            Resource:
+              - !Sub 'arn:aws:s3:::${BucketName}'
+          - Sid: AllowMalwareScan
+            Effect: Allow
+            Action:
+              - 's3:GetObject'
+              - 's3:GetObjectVersion'
+            Resource:
+              - !Sub 'arn:aws:s3:::${BucketName}/*'
+          - Sid: AllowDecryptForMalwareScan
+            Effect: Allow
+            Action:
+              - 'kms:GenerateDataKey'
+              - 'kms:Decrypt'
+            Resource: !Sub 'arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*'   # bucket is encrypted using an AWS KMS key
+            Condition:
+              StringLike:
+                'kms:ViaService': s3.us-east-1.amazonaws.com

--- a/org-formation/070-guard-duty/guardduty-s3-malware-protection.yaml
+++ b/org-formation/070-guard-duty/guardduty-s3-malware-protection.yaml
@@ -13,6 +13,10 @@ Parameters:
     Type: String
     Description: The bucket for Guardduty to scan
     ConstraintDescription: Name string (i.e. MyBucket)
+  SnsTopicName:
+    Type: String
+    Description: The SNS topic name to send Guardduty findings to
+    ConstraintDescription: SNS topic Arn (i.e. MySnsTopic)
 Resources:
   MalwareProtectionPlan:
     Type: AWS::GuardDuty::MalwareProtectionPlan
@@ -108,29 +112,9 @@ Resources:
             Condition:
               StringLike:
                 'kms:ViaService': s3.us-east-1.amazonaws.com
-  SnsTopic:
-    Type: AWS::SNS::Topic
-    Properties:
-      DisplayName: !Sub 'MalwareProtectionPlan Id: ${MalwareProtectionPlan.MalwareProtectionPlanId}'
-  SnsTopicPolicy:
-    Type: AWS::SNS::TopicPolicy
-    Properties:
-      Topics:
-        - !Ref SnsTopic
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: AllowEventsPublish
-            Effect: Allow
-            Principal:
-              Service: events.amazonaws.com
-            Action: sns:Publish
-            Resource: !Ref SnsTopic
   GuarddutyFindingsRule:
     Type: AWS::Events::Rule
-    DependsOn: SnsTopicPolicy
     Properties:
-      Name: !GetAtt SnsTopic.TopicName
       EventPattern:
         source:
           - aws.guardduty
@@ -138,7 +122,7 @@ Resources:
           - GuardDuty Finding
       Targets:
         - Id: NotificationTopic
-          Arn: !Ref SnsTopic
+          Arn: !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SnsTopicName}'
       State: ENABLED
 Outputs:
   SnsTopic:

--- a/org-formation/070-guard-duty/guardduty-s3-malware-protection.yaml
+++ b/org-formation/070-guard-duty/guardduty-s3-malware-protection.yaml
@@ -23,7 +23,7 @@ Resources:
       ProtectedResource:
         S3Bucket:
           BucketName: !Ref BucketName
-      Role: !Ref Role
+      Role: !GetAtt Role.Arn
 
   # role & policy from https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection-s3-iam-policy-prerequisite.html
   Role:

--- a/org-formation/070-guard-duty/guardduty-s3-malware-protection.yaml
+++ b/org-formation/070-guard-duty/guardduty-s3-malware-protection.yaml
@@ -1,5 +1,6 @@
-# Setup AWS Guardduty Malware Protection for S3 to scan and apply a predefined "GuardDutyMalwareScanStatus" tag all
-# S3 objects with possible tag values ["NO_THREATS_FOUND","THREATS_FOUND","UNSUPPORTED","FAILED"]
+# Setup AWS Guardduty Malware Protection for S3 to scan and apply a pre-defined "GuardDutyMalwareScanStatus" tag
+# to S3 objects with possible tag values ["NO_THREATS_FOUND","THREATS_FOUND","UNSUPPORTED","FAILED"] then send
+# a Guardduty notification to an SNS topic.
 # https://docs.aws.amazon.com/guardduty/latest/ug/tag-based-access-s3-malware-protection.html
 #
 # Note: The bucket being scanned should contain a bucket policy to restrict access to Malicious objects.
@@ -10,7 +11,7 @@ Description: Guardduty Malware protection plan for S3 bucket
 Parameters:
   BucketName:
     Type: String
-    Description: The bucket name
+    Description: The bucket for Guardduty to scan
     ConstraintDescription: Name string (i.e. MyBucket)
 Resources:
   MalwareProtectionPlan:
@@ -108,3 +109,40 @@ Resources:
             Condition:
               StringLike:
                 'kms:ViaService': s3.us-east-1.amazonaws.com
+  SnsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: !Sub 'MalwareProtectionPlan Id: ${MalwareProtectionPlan.MalwareProtectionPlanId}'
+  SnsTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref SnsTopic
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowEventsPublish
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref SnsTopic
+  GuarddutyFindingsRule:
+    Type: AWS::Events::Rule
+    DependsOn: SnsTopicPolicy
+    Properties:
+      Name: !GetAtt SnsTopic.TopicName
+      EventPattern:
+        source:
+          - aws.guardduty
+        detail-type:
+          - GuardDuty Finding
+      Targets:
+        - Id: NotificationTopic
+          Arn: !Ref SnsTopic
+      State: ENABLED
+Outputs:
+  SnsTopic:
+    Value: !Ref SnsTopic
+    Export:
+      Name: !Sub '${AWS::StackName}-SnsTopic'


### PR DESCRIPTION
Enable Guardduty S3 malware protection on a Synapse bucket. Allow Guardduty to automatically tag scanned objects in the bucket with a GuardDutyMalwareScanStatus tag.

Setup AWS Guardduty Malware Protection for S3 to scan and apply a pre-defined "GuardDutyMalwareScanStatus"[1] tag
to S3 objects with possible tag values ["NO_THREATS_FOUND","THREATS_FOUND","UNSUPPORTED","FAILED"] then send a Guardduty notification to an SNS topic.

Note: The bucket being scanned should contain a bucket policy[2] to restrict access to Malicious objects.

[1] https://docs.aws.amazon.com/guardduty/latest/ug/tag-based-access-s3-malware-protection.html
[2] https://docs.aws.amazon.com/guardduty/latest/ug/tag-based-access-s3-malware-protection.html#apply-tbac-s3-malware-protection