### PR TITLE
[IT-3658] Give the S3 launch role permission to update the nested lambda

### DIFF
--- a/sceptre/scipool/templates/sc-s3-launchrole.yaml
+++ b/sceptre/scipool/templates/sc-s3-launchrole.yaml
@@ -49,6 +49,7 @@ Resources:
                   - "lambda:DeleteFunction"
                   - "lambda:GetFunction"
                   - "lambda:GetFunctionConfiguration"
+                  - "lambda:UpdateFunctionCode"
                   - "lambda:AddPermission"
                   - "lambda:RemovePermission"
                   - "lambda:InvokeFunction"


### PR DESCRIPTION
The current launch role is able to create and terminate products, but not update them.