### PR TITLE
IT-3686: Update cfn-cr-synapse-tagger lambda in dev' Service Catalog account

### DIFF
--- a/sceptre/scipool/config/develop/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-synapse-tagger.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.3/cfn-cr-synapse-tagger.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.4/cfn-cr-synapse-tagger.yaml
 stack_name: cfn-cr-synapse-tagger
 stack_tags:
   OwnerEmail: "it@sagebase.org"


### PR DESCRIPTION
Update cfn-cr-synapse-tagger lambda in dev' Service Catalog account, changing from v 0.1.3 to v 0.1.4.