### PR TITLE
IT-3780 Add R/O access for StackArmor

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -183,6 +183,20 @@ FPTMinimumAccess:
         ]
       }
 
+# Setup StackArmor read-only access IT-3780
+StackArmorReadOnlyAccess:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.10/templates/IAM/cross-account-access.yaml
+  StackName: stack-armor-read-only-access
+  DefaultOrganizationBinding:
+    Account: !Ref SynapseProdAccount
+    Region: us-east-1
+  Parameters:
+    PrincipalArns:
+      - arn:aws:iam::726064622671:root # StackArmor AWS account ID
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess
 
 #---------- Policies -------------
 CostExplorerAccessPolicy:


### PR DESCRIPTION
Create Read Only access to EC2 and VPC in the Synapse Prod account for StackArmor.