### PR TITLE
[IT-3660] Automate creation of Synapse owner.txt file

### DIFF
--- a/sceptre/aws-opendata/config/prod/brainseq-bucket.yaml
+++ b/sceptre/aws-opendata/config/prod/brainseq-bucket.yaml
@@ -1,5 +1,5 @@
 template:
-  path: "opendata-bucket.yaml"
+  path: "opendata-bucket.j2"
 stack_name: "brainseq-bucket"
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/aws-opendata/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/aws-opendata/config/prod/cfn-s3objects-macro.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.5/cfn-s3objects-macro.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.6/cfn-s3objects-macro.yaml
 stack_name: "cfn-s3objects-macro"
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/aws-opendata/config/prod/cfn-s3objects-macro.yaml
+++ b/sceptre/aws-opendata/config/prod/cfn-s3objects-macro.yaml
@@ -1,0 +1,6 @@
+template:
+  type: http
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.5/cfn-s3objects-macro.yaml
+stack_name: "cfn-s3objects-macro"
+dependencies:
+  - "prod/bootstrap.yaml"

--- a/sceptre/aws-opendata/config/prod/single-cell-human-blood-atlas.yaml
+++ b/sceptre/aws-opendata/config/prod/single-cell-human-blood-atlas.yaml
@@ -1,5 +1,5 @@
 template:
-  path: "opendata-bucket.yaml"
+  path: "opendata-bucket.j2"
 stack_name: "single-cell-human-blood-atlas"
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/aws-opendata/config/prod/ukbiobank-bucket.yaml
+++ b/sceptre/aws-opendata/config/prod/ukbiobank-bucket.yaml
@@ -1,5 +1,5 @@
 template:
-  path: "opendata-bucket.yaml"
+  path: "opendata-bucket.j2"
 stack_name: "ukbiobank-bucket"
 dependencies:
   - "prod/bootstrap.yaml"

--- a/sceptre/aws-opendata/templates/opendata-bucket.j2
+++ b/sceptre/aws-opendata/templates/opendata-bucket.j2
@@ -1,7 +1,16 @@
 # This bucket template is mostly copied from
 # https://assets.opendata.aws/aws-onboarding-handbook-for-data-providers-en-US.pdf
 # with slight modifications to support Synapse based storage location
+#
+# This template supports the automated creation of Synapse owner.txt file.
+# Example config:
+#
+#   sceptre_user_data:
+#     SynapseIDs:
+#       - "3489135" # Synapse team ID
+
 AWSTemplateFormatVersion: '2010-09-09'
+Transform: S3Objects
 Description: >-
   This template creates the AWS infrastructure to publish a public
   data set on S3. It creates a publicly-accessible S3 bucket for
@@ -126,6 +135,27 @@ Resources:
             Resource:
               - !Sub arn:aws:s3:::${DataSetBucket}/*
     Type: AWS::S3::BucketPolicy
+
+  # Add owner file to the synapse bucket, requires the cloudformation S3 objects macro
+  # https://github.com/Sage-Bionetworks/aws-infra/tree/master/lambdas/cfn-s3objects-macro
+  {% if sceptre_user_data.SynapseIDs is defined %}
+  SynapseOwnerFile:
+    Type: AWS::S3::Object
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3001
+    Properties:
+      Target:
+        Bucket: !Ref Bucket
+        Key: owner.txt
+        ContentType: text
+      Body: >-
+  {%     for SynapseID in sceptre_user_data.SynapseIDs %}
+          {{ SynapseID }}
+  {%     endfor %}
+  {% endif %}
 
 Outputs:
   DataBucket:


### PR DESCRIPTION
This adds the ability to create an Synapse owner.txt file when provisioning a Synapse bucket.

* Change cloudformation template to a jinja template.
* Install S3 objects macro[1] to aws-opendata account
* Use the macro to create and update the owner.txt file

To create the file add something like this to the Sceptre config:

```
sceptre_user_data:
  SynapseIDs:
    - "3489135" # Synapse team ID
```

[1] https://github.com/aws-cloudformation/aws-cloudformation-macros/tree/master/S3Objects

