### PR TITLE
It 3780

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::531805629419:role/sagebase-github-oidc-sage-bionetworks-it
-          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-(${{ github.run_id }} % 1000000000)
           role-duration-seconds: 1200
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -183,6 +183,20 @@ FPTMinimumAccess:
         ]
       }
 
+# Setup StackArmor read-only access IT-3780
+StackArmorReadOnlyAccess:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.10/templates/IAM/cross-account-access.yaml
+  StackName: stack-armor-read-only-access
+  DefaultOrganizationBinding:
+    Account: !Ref SynapseProdAccount
+    Region: us-east-1
+  Parameters:
+    PrincipalArns:
+      - arn:aws:iam::726064622671:root # StackArmor AWS account ID
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess
 
 #---------- Policies -------------
 CostExplorerAccessPolicy:


### PR DESCRIPTION
`deploy.yaml` breaks when the github run id becomes so long that it pushes the length of the name of the deployment role over the 64 character limit. `GitHubActions-Sage-Bionetworks-IT-organizations-infra-` is 54 characters so the suffix can't be more than 10 characters. This change limits the suffix length so it doesn't exceed the max.  (`Substring` would be ideal but GitHub Actions doesn't have such a function.) There is a concern about uniqueness in CloudTrail logs, but those logs persist only 90 days.  By the time the suffix starts repeating, much more than 90 days will have passed.