### PR TITLE
Limit role session name

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::531805629419:role/sagebase-github-oidc-sage-bionetworks-it
-          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-(${{ github.run_id }} % 1000000000)
           role-duration-seconds: 1200
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,13 +22,19 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
+      - name: Get role session name
+        uses: bhowell2/github-substring-action@1.0.2
+        id: role-session-name
+        with:
+          value: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          length_from_end: 64
       - uses: actions/checkout@v3
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::531805629419:role/sagebase-github-oidc-sage-bionetworks-it
-          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-(${{ github.run_id }} % 1000000000)
+          role-session-name: ${{ steps.role-session-name.outputs.substring }}
           role-duration-seconds: 1200
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -183,6 +183,20 @@ FPTMinimumAccess:
         ]
       }
 
+# Setup StackArmor read-only access IT-3780
+StackArmorReadOnlyAccess:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.10/templates/IAM/cross-account-access.yaml
+  StackName: stack-armor-read-only-access
+  DefaultOrganizationBinding:
+    Account: !Ref SynapseProdAccount
+    Region: us-east-1
+  Parameters:
+    PrincipalArns:
+      - arn:aws:iam::726064622671:root # StackArmor AWS account ID
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess
 
 #---------- Policies -------------
 CostExplorerAccessPolicy:


### PR DESCRIPTION
The role session name overruns the 64 character limit as the github run id gets larger.  This change ensures the role session name never exceeds 64 characters.   It uses the _suffix_ to make sure the entire run id is included for uniqueness sake.