### PR TITLE
Cascade role-session-name to sub-workflows

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -10,6 +10,9 @@ on:
       role-to-assume:
         required: true
         type: string
+      role-session-name:
+        required: true
+        type: string
       role-duration-seconds:
         type: number
         default: 1200
@@ -48,7 +51,7 @@ jobs:
         with:
           aws-region: ${{ inputs.aws-region }}
           role-to-assume: ${{ inputs.role-to-assume }}
-          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          role-session-name: ${{ inputs.role-session-name }}
           role-duration-seconds: ${{ inputs.role-duration-seconds }}
       - name: Deploy with sceptre
         run: |

--- a/.github/workflows/aws-scipool.yaml
+++ b/.github/workflows/aws-scipool.yaml
@@ -11,6 +11,9 @@ on:
       role-to-assume:
         required: true
         type: string
+      role-session-name:
+        required: true
+        type: string
       role-duration-seconds:
         type: number
         default: 1200
@@ -49,7 +52,7 @@ jobs:
         with:
           aws-region: ${{ inputs.aws-region }}
           role-to-assume: ${{ inputs.role-to-assume }}
-          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          role-session-name: ${{ inputs.role-session-name }}
           role-duration-seconds: ${{ inputs.role-duration-seconds }}
       - name: Deploy with sceptre
         # SC-26 & SC-219 workaround: dis-associate and re-associate SC actions on every deploy

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::531805629419:role/sagebase-github-oidc-sage-bionetworks-it
-          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-(${{ github.run_id }} % 1000000000)
           role-duration-seconds: 1200
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,13 +22,19 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
+      - name: Get role session name
+        uses: bhowell2/github-substring-action@1.0.2
+        id: role-session-name
+        with:
+          value: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          length_from_end: 64
       - uses: actions/checkout@v3
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::531805629419:role/sagebase-github-oidc-sage-bionetworks-it
-          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-(${{ github.run_id }} % 1000000000)
+          role-session-name: ${{ steps.role-session-name.outputs.substring }}
           role-duration-seconds: 1200
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -70,36 +70,42 @@ jobs:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::531805629419:role/sagebase-github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/organizations"
   sceptre-admincentral:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::745159704268:role/sagebase-github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/admincentral"
   sceptre-itsandbox:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::804034162148:role/sagebase-github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/itsandbox"
   sceptre-scicomp:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::055273631518:role/sagebase-github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/scicomp"
   sceptre-strides:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::423819316185:role/github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/strides"
   sceptre-strides-ampad-workflows:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::751556145034:role/github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/strides-ampad-workflows"
   sceptre-scipooldev:
     needs: [org-formation]
@@ -107,18 +113,21 @@ jobs:
     with:
       role-to-assume: "arn:aws:iam::465877038949:role/sagebase-github-oidc-sage-bionetworks-it"
       working-dir: "sceptre/scipool"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       sceptre-command: "sceptre launch develop --prune --yes"
   sceptre-scipoolprod:
     needs: [org-formation]
     uses: "./.github/workflows/aws-scipool.yaml"
     with:
       role-to-assume: "arn:aws:iam::237179673806:role/sagebase-github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/scipool"
   sceptre-stridespool:
     needs: [org-formation, sceptre-strides]
     uses: "./.github/workflows/aws-scipool.yaml"
     with:
       role-to-assume: "arn:aws:iam::423819316185:role/github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/scipool"
       sceptre-command: "sceptre launch strides --prune --yes"
   sceptre-bmgfki:
@@ -126,6 +135,7 @@ jobs:
     uses: "./.github/workflows/aws-scipool.yaml"
     with:
       role-to-assume: "arn:aws:iam::464102568320:role/sagebase-github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/scipool"
       sceptre-command: "sceptre launch bmgfki --prune --yes"
   sceptre-sageit-staging:
@@ -133,6 +143,7 @@ jobs:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::797640923903:role/sagebase-github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/sageit"
       sceptre-command: "sceptre launch staging --prune --yes"
   sceptre-sageit-prod:
@@ -140,30 +151,35 @@ jobs:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::797640923903:role/sagebase-github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/sageit"
   sceptre-logcentral:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::231505186444:role/sagebase-github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/logcentral"
   sceptre-synapsedev:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::449435941126:role/sagebase-github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/synapsedev"
   sceptre-synapseprod:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::325565585839:role/sagebase-github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/synapseprod"
   sceptre-bridgedev:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::420786776710:role/sagebase-github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/bridge"
       sceptre-command: "sceptre launch develop --prune --yes"
   sceptre-bridgeprod:
@@ -171,16 +187,19 @@ jobs:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::649232250620:role/sagebase-github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/bridge"
   sceptre-imagecentral:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::867686887310:role/sagebase-github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/imagecentral"
   sceptre-aws-opendata:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::373143421983:role/github-oidc-sage-bionetworks-it"
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
       working-dir: "sceptre/aws-opendata"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,48 +64,51 @@ jobs:
         run: npm run print-tasks-failfast
       - name: Deploy with ofn
         run: npm run ci-perform-tasks-parallel
+    # Map a step output to a job output
+    outputs:
+      role-session-name: ${{ steps.role-session-name.outputs.substring }}
 
   sceptre-organizations:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::531805629419:role/sagebase-github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/organizations"
   sceptre-admincentral:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::745159704268:role/sagebase-github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/admincentral"
   sceptre-itsandbox:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::804034162148:role/sagebase-github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/itsandbox"
   sceptre-scicomp:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::055273631518:role/sagebase-github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/scicomp"
   sceptre-strides:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::423819316185:role/github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/strides"
   sceptre-strides-ampad-workflows:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::751556145034:role/github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/strides-ampad-workflows"
   sceptre-scipooldev:
     needs: [org-formation]
@@ -113,21 +116,21 @@ jobs:
     with:
       role-to-assume: "arn:aws:iam::465877038949:role/sagebase-github-oidc-sage-bionetworks-it"
       working-dir: "sceptre/scipool"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       sceptre-command: "sceptre launch develop --prune --yes"
   sceptre-scipoolprod:
     needs: [org-formation]
     uses: "./.github/workflows/aws-scipool.yaml"
     with:
       role-to-assume: "arn:aws:iam::237179673806:role/sagebase-github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/scipool"
   sceptre-stridespool:
     needs: [org-formation, sceptre-strides]
     uses: "./.github/workflows/aws-scipool.yaml"
     with:
       role-to-assume: "arn:aws:iam::423819316185:role/github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/scipool"
       sceptre-command: "sceptre launch strides --prune --yes"
   sceptre-bmgfki:
@@ -135,7 +138,7 @@ jobs:
     uses: "./.github/workflows/aws-scipool.yaml"
     with:
       role-to-assume: "arn:aws:iam::464102568320:role/sagebase-github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/scipool"
       sceptre-command: "sceptre launch bmgfki --prune --yes"
   sceptre-sageit-staging:
@@ -143,7 +146,7 @@ jobs:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::797640923903:role/sagebase-github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/sageit"
       sceptre-command: "sceptre launch staging --prune --yes"
   sceptre-sageit-prod:
@@ -151,35 +154,35 @@ jobs:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::797640923903:role/sagebase-github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/sageit"
   sceptre-logcentral:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::231505186444:role/sagebase-github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/logcentral"
   sceptre-synapsedev:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::449435941126:role/sagebase-github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/synapsedev"
   sceptre-synapseprod:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::325565585839:role/sagebase-github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/synapseprod"
   sceptre-bridgedev:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::420786776710:role/sagebase-github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/bridge"
       sceptre-command: "sceptre launch develop --prune --yes"
   sceptre-bridgeprod:
@@ -187,19 +190,19 @@ jobs:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::649232250620:role/sagebase-github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/bridge"
   sceptre-imagecentral:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::867686887310:role/sagebase-github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/imagecentral"
   sceptre-aws-opendata:
     needs: [org-formation]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::373143421983:role/github-oidc-sage-bionetworks-it"
-      role-session-name: ${{ steps.role-session-name.outputs.substring }}
+      role-session-name: ${{ needs.org-formation.outputs.role-session-name }}
       working-dir: "sceptre/aws-opendata"

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -183,6 +183,20 @@ FPTMinimumAccess:
         ]
       }
 
+# Setup StackArmor read-only access IT-3780
+StackArmorReadOnlyAccess:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.10/templates/IAM/cross-account-access.yaml
+  StackName: stack-armor-read-only-access
+  DefaultOrganizationBinding:
+    Account: !Ref SynapseProdAccount
+    Region: us-east-1
+  Parameters:
+    PrincipalArns:
+      - arn:aws:iam::726064622671:root # StackArmor AWS account ID
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess
 
 #---------- Policies -------------
 CostExplorerAccessPolicy:


### PR DESCRIPTION
The error that occurred in the root workflow, `deploy.yaml` also occurs in the sub-workflows.  This change propagates the fix (managing the role session name length) to the sub-workflows.