### PR TITLE
[IT-3512] Github OIDC for OpenChallenges deployment

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -787,3 +787,25 @@ GithubOidcAgoraEBDeploy:
       - !Ref AgoraDevAccount
       - !Ref AgoraProdAccount
     Region: us-east-1
+
+GithubOidcOpenChallengesDeploy:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-openchallenges-deploy
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-openchallenges-deploy
+    MaxSessionDuration: 7200
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks-IT"
+    Repositories:
+      - name: "OpenChallenges"
+        branches: ["dev", "prod"]
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref ITSandboxAccount
+    Region: us-east-1


### PR DESCRIPTION
Setup Github OIDC to allow Github CI to deploy the Challenges application to AWS accounts from the Sage-Bionetworks-IT/OpenChallenges[1] repo.

It's only setup to deploy to ITSandbox account for now since that's where we are dev/testing it at this time.

[1] https://github.com/Sage-Bionetworks-IT/openchallenges