### PR TITLE
[IT-3758] Give 4 points access to usage reports

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -180,6 +180,59 @@ FPTMinimumAccess:
             "Effect": "Allow",
             "Action": "ce:*",
             "Resource": "*"
+          },
+          {
+            "Sid": "CreateCurExportsInDataExports",
+            "Effect": "Allow",
+            "Action": ["bcm-data-exports:*"],
+            "Resource": [
+                  "Fn::Sub": "arn:aws:bcm-data-exports:${AWS::Region}:${AWS::AccountId}:export/*",
+                  "Fn::Sub": "arn:aws:bcm-data-exports:${AWS::Region}:${AWS::AccountId}:table/COST_AND_USAGE_REPORT"
+                  ]
+          },
+          {
+            "Sid": "CurDataAccess",
+            "Effect": "Allow",
+            "Action": ["cur:PutReportDefinition"],
+            "Resource": "*"
+          },
+          {
+            "Sid": "AllowListingOfBucket",
+            "Principal": {
+                "AWS": ["arn:aws:iam::610061289380:root"]
+            },
+            "Effect": "Allow",
+            "Action": ["s3:ListBucket"],
+            "Resource": ["arn:aws:s3:::cost-and-usage-reports.sagebase.org"],
+            "Condition": {
+                "StringEquals": {
+                    "s3:prefix": ["", "4points/"],
+                    "s3:delimiter": ["/"]
+                }
+            }
+          },
+          {
+            "Sid": "AllowListingOfFolder",
+            "Principal": {
+                "AWS": ["arn:aws:iam::610061289380:root"]
+            },
+            "Action": ["s3:ListBucket"],
+            "Effect": "Allow",
+            "Resource": ["arn:aws:s3:::cost-and-usage-reports.sagebase.org"],
+            "Condition": {
+                "StringLike": {
+                    "s3:prefix": ["4points/*"]
+                }
+            }
+          },
+          {
+            "Sid": "AllowAllS3ActionsInFolder",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": ["arn:aws:iam::610061289380:root"]
+            },
+            "Action": ["s3:*"],
+            "Resource": ["arn:aws:s3:::cost-and-usage-reports.sagebase.org/4points/*"]
           }
         ]
       }

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -164,6 +164,7 @@ FPTMinimumAccess:
       - arn:aws:iam::aws:policy/job-function/Billing
       - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
       - arn:aws:iam::aws:policy/AWSSupportAccess
+      - arn:aws:iam::aws:policy/AWSAccountUsageReportAccess
     PolicyDocument: >-
       {
         "Version": "2012-10-17",


### PR DESCRIPTION
Four points needs access to AWS usage reports to generate cost summery level reports.

from  four points...
```
Good morning.  I have accessed the account to complete our first month of billing. 
I just realized we don’t have access to the usage report that we need.
I will only be able to provide summary level reporting this month. 
Can we get the detail billing report and a CUR report setup for our use?  
I can provide details on what we need if needed.
```

* Give four points access to view usage from aws portal
* Give four points full access to bucket folder "cost-and-usage-reports.sagebase.org/4points" to allow sending their reports to that folder.  Setup this policy from  bcm-data-exports-access-examples[1] and example-bucket-policies-folders[2] docs.

[1] https://docs.aws.amazon.com/cur/latest/userguide/bcm-data-exports-access.html#bcm-data-exports-access-examples
[2]  https://docs.aws.amazon.com/AmazonS3/latest/userguide/example-bucket-policies.html#example-bucket-policies-folders
