### PR TITLE
Allow developer to assume eks developer viewer role

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -390,6 +390,11 @@ SsoDeveloper:
           "Version": "2012-10-17",
           "Statement": [
               {
+                  "Effect": "Allow",
+                  "Resource": "arn:aws:iam::*:role/eks-developer-viewer-role-*",
+                  "Action": "sts:AssumeRole"
+              },
+              {
                   "Effect": "Deny",
                   "Action": "sts:AssumeRole",
                   "Resource": "*"


### PR DESCRIPTION
**Background:**

- This work is related to this ticket: https://sagebionetworks.jira.com/browse/IBCDPE-1005
- In this pull request https://github.com/Sage-Bionetworks-Workflows/eks-stack/pull/17 I have updated terraform scripts to create a role for Developer level users to assume. This role gives Developer level users cluster wide read access.

**Problem:**

1. The current configuration in this `organizations-infra` repo prevents Developer level users from assuming any role.

**Solution:**

1. Updating configuration to allow Developer level users to assume a role in the format of `role/eks-developer-viewer-role-*`. Wild card is being used here as each individual EKS cluster that might be created within an AWS account will have a role in the format of: `role/eks-developer-viewer-role-${var.cluster_name}`

**Testing:**

1. I tested assuming this new role from the `Administrator` account and verified it got the appropriate EKS cluster access.
2. I was not able to directly test assuming the role from the `Developer` account as it is not currently allowed.