### PR TITLE
[IT-3619] Enable AWS config service

### DIFF
--- a/org-formation/080-aws-config-inventory/README.md
+++ b/org-formation/080-aws-config-inventory/README.md
@@ -1,0 +1,17 @@
+### Purpose of these templates
+The templates in this folder enable [AWS Config](https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html)
+in each account. AWS Config provides a detailed view of the configuration of AWS resources in your AWS account.
+This includes how the resources are related to one another and how they were configured in the past so that you
+can see how the configurations and relationships change over time.
+
+It is in that respect very similar to CloudTrail as it implements an audit trail, but not of management
+actions (API calls) but of the resources within each account itself. The results are stored and updated
+every hour in a centralized S3 bucket within the LogArchive account. And again, similar to CloudTrail,
+that S3 bucket can be the extension point to do further analysis, notification or modification for
+example with [DivvyCloud](https://divvycloud.com/key-capabilities/#unified-visibility-and-monitoring)
+
+> Note that this stack is only the inventory and does not deploy any
+  [Config Rules](https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config.html) or
+  [Conformance Packs](https://docs.aws.amazon.com/config/latest/developerguide/conformance-packs.html),
+  which would also possibly provide a lot of value for an organization, but should be deployed separately
+  in another subfolder (or delegated build) depending on this one.

--- a/org-formation/080-aws-config-inventory/_tasks.yaml
+++ b/org-formation/080-aws-config-inventory/_tasks.yaml
@@ -1,0 +1,22 @@
+Parameters:
+  <<: !Include '../_parameters.yaml'
+
+  appName:
+    Type: String
+    Default: 'config'
+
+# Enable AWS Config in all member accounts.  AWS config in the logcentral account is configured to aggregate
+# all Findings and Config history from member accounts and store them in a centralized s3 bucket in logcentral
+ConfigBase:
+  Type: update-stacks
+  Template: config.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-base'
+  StackDescription: AWS Config - Base
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+    ExcludeAccount: !Ref LogCentralAccount
+    Account: '*'
+  Parameters:
+    resourcePrefix: !Ref resourcePrefix
+    bucketName: !Sub '${resourcePrefix}-${appName}-${CurrentAccount.AccountId}'

--- a/org-formation/080-aws-config-inventory/_tasks.yaml
+++ b/org-formation/080-aws-config-inventory/_tasks.yaml
@@ -18,5 +18,4 @@ ConfigBase:
     ExcludeAccount: !Ref LogCentralAccount
     Account: '*'
   Parameters:
-    resourcePrefix: !Ref resourcePrefix
     bucketName: !Sub '${resourcePrefix}-${appName}-${CurrentAccount.AccountId}'

--- a/org-formation/080-aws-config-inventory/config.yaml
+++ b/org-formation/080-aws-config-inventory/config.yaml
@@ -1,0 +1,122 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks: [W2001]
+
+Parameters:
+  bucketName:
+    Type: String
+    Description: 'Name of the central S3 bucket containing AWS Config audit findings'
+
+Resources:
+  ConfigAuditBucket:
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Type: 'AWS::S3::Bucket'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [E1012, E3001]
+    Properties:
+      BucketName: !Ref bucketName
+      AccessControl: BucketOwnerFullControl
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  ConfigAuditBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [E1012, E3001]
+    Properties:
+      Bucket: !Ref ConfigAuditBucket
+      PolicyDocument: # Taken from https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-policy.html#granting-access-in-another-account
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AWSConfigBucketPermissionsCheck
+            Effect: Allow
+            Principal:
+              Service:
+                - config.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource: !GetAtt ConfigAuditBucket.Arn
+          - Sid: AWSConfigBucketExistenceCheck
+            Effect: Allow
+            Principal:
+              Service:
+                - config.amazonaws.com
+            Action: s3:ListBucket
+            Resource: !GetAtt ConfigAuditBucket.Arn
+          - Sid: AWSConfigBucketDelivery
+            Effect: Allow
+            Principal:
+              Service:
+                - config.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub '${ConfigAuditBucket.Arn}/*'
+            Condition:
+              StringEquals:
+                's3:x-amz-acl': 'bucket-owner-full-control'
+
+  ConfigurationRecorder:
+    Type: 'AWS::Config::ConfigurationRecorder'
+    Properties:
+      RecordingGroup:
+        AllSupported: true
+        IncludeGlobalResourceTypes: true
+      RoleARN: !GetAtt ConfigurationRecorderRole.Arn
+
+  DeliveryChannel:
+    Type: 'AWS::Config::DeliveryChannel'
+    Properties:
+      ConfigSnapshotDeliveryProperties:
+        DeliveryFrequency: One_Hour
+      S3BucketName: !Ref ConfigAuditBucket
+
+  ConfigurationRecorderRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      ManagedPolicyArns:
+      - 'arn:aws:iam::aws:policy/service-role/AWS_ConfigRole'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Sid: ConfigServiceAssumeRole
+          Effect: Allow
+          Principal:
+            Service: 'config.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      Policies:
+      - PolicyName: 's3-policy'
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action: 's3:PutObject'
+            Resource: !Sub '${ConfigAuditBucket.Arn}/*'
+            Condition:
+              StringLike:
+                's3:x-amz-acl': 'bucket-owner-full-control'
+          - Effect: Allow
+            Action: 's3:GetBucketAcl'
+            Resource: !GetAtt ConfigAuditBucket.Arn
+
+Outputs:
+  ConfigAuditBucketName:
+    Value: !Ref ConfigAuditBucket
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ConfigAuditBucketName'
+  ConfigAuditBucketArn:
+    Value: !GetAtt ConfigAuditBucket.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ConfigAuditBucketArn'

--- a/org-formation/README.md
+++ b/org-formation/README.md
@@ -28,6 +28,8 @@ prefixed with numbers to enforce the order they are deployed in.
   Configure Security Hub for all accounts.
 - 077 [Macie](./077-macie) \
   Configure AWS Macie for all accounts.
+- 080 [AWS Config](./080-aws-config-inventory) \
+  Configure AWS Config for all accounts.
 - 090 [Systems Manager](./090-systems-manager) \
   Configure Systems Manager for all accounts.
 - 725 [vpc flow logs](./725-vpc-flow-logs) \

--- a/org-formation/_tasks.yaml
+++ b/org-formation/_tasks.yaml
@@ -36,6 +36,11 @@ Macie:
   DependsOn: [ Types ]
   Path: ./077-macie/_tasks.yaml
 
+AwsConfigInventory:
+  Type: include
+  DependsOn: [ Types ]
+  Path: ./080-aws-config-inventory/_tasks.yaml
+
 AwsSystemsManager:
   Type: include
   DependsOn: [ Types ]


### PR DESCRIPTION
This is a partial revert of 9f5bb53

We need to enabled AWS config service in every organization member account
to collect config data.  This will allow the aggregator account (logcentral)
to collect and aggregate the config data from member accounts, visualize
that data and store it in a central account.

