### PR TITLE
Fix 4point access policy

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -186,8 +186,8 @@ FPTMinimumAccess:
             "Effect": "Allow",
             "Action": ["bcm-data-exports:*"],
             "Resource": [
-                  "Fn::Sub": "arn:aws:bcm-data-exports:${AWS::Region}:${AWS::AccountId}:export/*",
-                  "Fn::Sub": "arn:aws:bcm-data-exports:${AWS::Region}:${AWS::AccountId}:table/COST_AND_USAGE_REPORT"
+                  "arn:aws:bcm-data-exports:*:*:export/*",
+                  "arn:aws:bcm-data-exports:*:*:table/COST_AND_USAGE_REPORT"
                   ]
           },
           {
@@ -195,44 +195,6 @@ FPTMinimumAccess:
             "Effect": "Allow",
             "Action": ["cur:PutReportDefinition"],
             "Resource": "*"
-          },
-          {
-            "Sid": "AllowListingOfBucket",
-            "Principal": {
-                "AWS": ["arn:aws:iam::610061289380:root"]
-            },
-            "Effect": "Allow",
-            "Action": ["s3:ListBucket"],
-            "Resource": ["arn:aws:s3:::cost-and-usage-reports.sagebase.org"],
-            "Condition": {
-                "StringEquals": {
-                    "s3:prefix": ["", "4points/"],
-                    "s3:delimiter": ["/"]
-                }
-            }
-          },
-          {
-            "Sid": "AllowListingOfFolder",
-            "Principal": {
-                "AWS": ["arn:aws:iam::610061289380:root"]
-            },
-            "Action": ["s3:ListBucket"],
-            "Effect": "Allow",
-            "Resource": ["arn:aws:s3:::cost-and-usage-reports.sagebase.org"],
-            "Condition": {
-                "StringLike": {
-                    "s3:prefix": ["4points/*"]
-                }
-            }
-          },
-          {
-            "Sid": "AllowAllS3ActionsInFolder",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": ["arn:aws:iam::610061289380:root"]
-            },
-            "Action": ["s3:*"],
-            "Resource": ["arn:aws:s3:::cost-and-usage-reports.sagebase.org/4points/*"]
           }
         ]
       }


### PR DESCRIPTION
This is a fix for commit 96e340e93d8

* cannot set AWS pseudo parameters in org-formation yaml so we change it to '*'
* the policy was mixing up IAM and resource policies. iam policies do not support a principal parameter. principal is only allowed in resource policies. We remnoved the policies and moved them to the bucket policy.

