### PR TITLE
[IT-3758] Setup a bucket for four points

### DIFF
--- a/sceptre/organizations/config/prod/fourpoints.yaml
+++ b/sceptre/organizations/config/prod/fourpoints.yaml
@@ -1,0 +1,8 @@
+# A bucket for 4points for storing cost and usage reports
+template:
+  path: "s3-cur-bucket.j2"
+stack_name: "fourpoints"
+parameters:
+  AllowWriteBucket: 'true'
+  GrantAccess:
+    - 'arn:aws:iam::610061289380:root'   # 4points has access

--- a/sceptre/organizations/templates/s3-cur-bucket.j2
+++ b/sceptre/organizations/templates/s3-cur-bucket.j2
@@ -1,0 +1,158 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: S3 Bucket for CUR data
+Parameters:
+  AllowWriteBucket:
+    Type: String
+    Description: true for read-write, false (default) for read-only bucket
+    AllowedValues:
+      - true
+      - false
+    Default: true
+  BucketVersioning:
+    Type: String
+    Description: Enabled to enable bucket versioning, default is Suspended
+    AllowedValues:
+      - Enabled
+      - Suspended
+    Default: Suspended
+  GrantAccess:
+    Type: CommaDelimitedList
+    Default: "[]"
+    Description: Grant bucket access to accounts, groups, and users.
+    ConstraintDescription: List of ARNs (i.e. ["arn:aws:iam::011223344556:user/jsmith", "arn:aws:iam::544332211006:user/rjones"]
+  EnableDataLifeCycle:
+    Type: String
+    Description: Enabled to enable bucket lifecycle rule, default is Disabled
+    AllowedValues:
+      - Enabled
+      - Disabled
+    Default: Disabled
+  LifecycleDataTransition:
+    Type: Number
+    Description: Number of days until S3 objects are moved to LifecycleDataStorageClass
+    Default: 30
+    MaxValue: 360
+    MinValue: 1
+  LifecycleDataStorageClass:
+    Type: String
+    Description: S3 bucket objects will transition into this storage class
+    AllowedValues:
+      - DEEP_ARCHIVE
+      - INTELLIGENT_TIERING
+      - STANDARD_IA
+      - ONEZONE_IA
+      - GLACIER
+    Default: GLACIER
+  LifecycleDataExpiration:
+    Type: Number
+    Description: Number of days (from creation) when objects are deleted from S3 and the LifecycleDataStorageClass
+    Default: 365000
+    MaxValue: 365000
+    MinValue: 360
+  BucketName:
+    Type: String
+    Description: (Optional) Name of the created bucket.
+    Default: ""
+Conditions:
+  AllowWrite: !Equals [!Ref AllowWriteBucket, true]
+  AllowUserAccess: !Not [!Equals [!Join ['', !Ref GrantAccess], "[]"]]
+  HasBucketName: !Not [!Equals [!Ref BucketName, ""]]
+Resources:
+  Bucket:
+    Type: "AWS::S3::Bucket"
+    Properties:
+      BucketName: !If [HasBucketName, !Ref BucketName, !Ref 'AWS::NoValue']
+      VersioningConfiguration:
+        Status: !Ref BucketVersioning
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
+
+      LifecycleConfiguration:
+        Rules:
+        - Id: DataLifecycleRule
+          Status: !Ref EnableDataLifeCycle
+          ExpirationInDays: !Ref LifecycleDataExpiration
+          Transitions:
+            - TransitionInDays: !Ref LifecycleDataTransition
+              StorageClass: !Ref LifecycleDataStorageClass
+
+  BucketPolicy:
+    Type: "AWS::S3::BucketPolicy"
+    Condition: AllowUserAccess
+    Properties:
+      Bucket: !Ref Bucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: BillingServiceAccess
+            Effect: Allow
+            Principal:
+              Service:
+                - billingreports.amazonaws.com
+            Action:
+              - "s3:GetBucketAcl"
+              - "s3:GetBucketPolicy"
+              - "s3:PutObject"
+            Resource:
+                - !GetAtt Bucket.Arn
+                - !Sub "${Bucket.Arn}/*"
+          - Sid: BcmDataExportServiceAccess
+            Effect: Allow
+            Principal:
+              Service:
+                - bcm-data-exports.amazonaws.com
+            Action:
+              - "s3:GetBucketPolicy"
+              - "s3:PutObject"
+            Resource:
+                - !GetAtt Bucket.Arn
+                - !Sub "${Bucket.Arn}/*"
+          - Sid: BucketAccess
+            # gives grantees access to the bucket
+            Effect: Allow
+            Principal:
+              AWS: !Ref GrantAccess
+            Action:
+              - "s3:ListBucket*"
+              - "s3:GetBucketLocation"
+            Resource: [ !GetAtt Bucket.Arn ]
+          - Sid: ReadObjectAccess
+            # give grantees read access to objects
+            Effect: Allow
+            Principal:
+              AWS: !Ref GrantAccess
+            Action:
+              - "s3:GetObject"
+              - "s3:GetObjectAcl"
+              - "s3:ListMultipartUploadParts"
+              - "s3:GetObjectAttributes"
+            Resource: [ !Sub "${Bucket.Arn}/*" ]
+          - !If
+            - AllowWrite
+            - Sid: PutObjectAccess
+              # gives bucket-account grantees the ability to upload and delete objects
+              Effect: Allow
+              Principal:
+                AWS: !Ref GrantAccess
+              Action:
+                - "s3:PutObject"
+                - "s3:PutObjectAcl"
+                - "s3:DeleteObject*"
+                - "s3:*MultipartUpload*"
+              Resource: [ !Sub "${Bucket.Arn}/*" ]
+            - !Ref AWS::NoValue
+
+Outputs:
+  Bucket:
+    Value: !Ref Bucket
+    Export:
+      Name: !Sub '${AWS::StackName}-Bucket'
+  BucketArn:
+    Value: !GetAtt Bucket.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-BucketArn'


### PR DESCRIPTION
Four point's use cases are broader than initialally anticipated when setting up a storage location for them in PRs #1189 and #1197

This unwinds changes in those PRs.  Instead of giving 4points access to a folder in an existing bucket we create a whole new bucket for them and give them read and write access to the new bucket.

