### PR TITLE
Fix sceptre

### DIFF
--- a/sceptre/scipool/config/develop/sc-portfolio-scheduled-jobs.yaml
+++ b/sceptre/scipool/config/develop/sc-portfolio-scheduled-jobs.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-scheduled-jobs.yaml"
+template:
+  path: "sc-portfolio-scheduled-jobs.yaml"
 stack_name: "sc-portfolio-scheduled-jobs"
 dependencies:
   - "develop/sc-scheduled-jobs-launchrole.yaml"

--- a/sceptre/scipool/config/develop/sc-scheduled-jobs-launchrole.yaml
+++ b/sceptre/scipool/config/develop/sc-scheduled-jobs-launchrole.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-scheduled-jobs-launchrole.yaml"
+template:
+  path: "sc-scheduled-jobs-launchrole.yaml"
 stack_name: "sc-scheduled-jobs-launchrole"
 dependencies:
   - "develop/essentials.yaml"

--- a/sceptre/scipool/config/prod/sc-portfolio-scheduled-jobs.yaml
+++ b/sceptre/scipool/config/prod/sc-portfolio-scheduled-jobs.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-scheduled-jobs.yaml"
+template:
+  path: "sc-portfolio-scheduled-jobs.yaml"
 stack_name: "sc-portfolio-scheduled-jobs"
 dependencies:
   - "prod/sc-scheduled-jobs-launchrole.yaml"

--- a/sceptre/scipool/config/prod/sc-scheduled-jobs-launchrole.yaml
+++ b/sceptre/scipool/config/prod/sc-scheduled-jobs-launchrole.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-scheduled-jobs-launchrole.yaml"
+template:
+  path: "sc-scheduled-jobs-launchrole.yaml"
 stack_name: "sc-scheduled-jobs-launchrole"
 dependencies:
   - "prod/essentials.yaml"

--- a/sceptre/scipool/config/strides/sc-portfolio-scheduled-jobs.yaml
+++ b/sceptre/scipool/config/strides/sc-portfolio-scheduled-jobs.yaml
@@ -1,4 +1,5 @@
-template_path: "sc-portfolio-scheduled-jobs.yaml"
+template:
+  path: "sc-portfolio-scheduled-jobs.yaml"
 stack_name: "sc-portfolio-scheduled-jobs"
 dependencies:
   - "strides/sc-scheduled-jobs-launchrole.yaml"

--- a/sceptre/scipool/config/strides/sc-scheduled-jobs-launchrole.yaml
+++ b/sceptre/scipool/config/strides/sc-scheduled-jobs-launchrole.yaml
@@ -1,2 +1,3 @@
-template_path: "sc-scheduled-jobs-launchrole.yaml"
+template:
+  path: "sc-scheduled-jobs-launchrole.yaml"
 stack_name: "sc-scheduled-jobs-launchrole"


### PR DESCRIPTION
Sceptre deprecated `template_path` key. Update to fix build

