### PR TITLE
PLFM-8554: Allow GitHub to deploy the Docker registry to the Synapse AWS accounts

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -106,6 +106,28 @@ GithubOidcSageBionetworksSchematicInfra:
       - !Ref DCAProdAccount
     Region: us-east-1
 
+GithubOidcSageBionetworksSynapseDockerRegistry:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapse-docker-registry
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapse-docker-registry
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "synapse-docker-registry"
+        branches: ["*"]
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref SynapseDevAccount
+      - !Ref SynapseProdAccount
+    Region: us-east-1
+
 GithubOidcSageBionetworksGenieBPCInfra:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks


### PR DESCRIPTION
Allow GitHub to deploy the Docker registry to the Synapse AWS accounts.

This is part of the effort to (1) automate the deployment of the Docker registry and (2) move to Fargate to avoid having to monitor/patch EC2s.