### PR TITLE
Should be stack name, not vpc name to copy output

### DIFF
--- a/org-formation/710-tgw/_tasks.yaml
+++ b/org-formation/710-tgw/_tasks.yaml
@@ -149,7 +149,7 @@ Mappings:
       '055273631518': 'snowflakevpc'   # org-sagebase-scicomp
       '420786776710': 'bridge-aux'   # org-sagebase-bridgedev
       '325565585839': 'synapse-ops-vpc-v2' # org-sagebase-synapseprod
-      '449435941126': 'sagevpc' # org-sagebase-synapsedev
+      '449435941126': 'vpc' # org-sagebase-synapsedev
   TgwSpokesSynapseDev:
     VpcName:
       '449435941126': 'synapse-dev-vpc-2'      # org-sagebase-synapsedev


### PR DESCRIPTION
Previous PR (#1202) failed at accessing an output value from the infra VPC stack (' !CopyValue [!Join ["-", [!Ref primaryRegion, !FindInMap [TgwSpokesB, VpcName, !Ref CurrentAccount], 'PrivateSubnet']]] ') so we need the stack name in the map, not the vpc name.
