### PR TITLE
PLFM-8554: Install Stack Armor Nessus scanner on all EC2 instances in Synapse account

### DIFF
--- a/org-formation/090-systems-manager/ScheduledMaintenance.yaml
+++ b/org-formation/090-systems-manager/ScheduledMaintenance.yaml
@@ -71,14 +71,14 @@ Resources:
           name: "runShellScript"
           inputs:
             runCommand:
-            - SCRIPT_PATH=/tmp/script.sh
             - SSM_TO_ENV_MAP=( {{ SsmParameterNameToEnvvarMap }} )
             - for KV in ${SSM_TO_ENV_MAP[@]} ; do
-            -   ${KV##*:}=$(aws --region {{ Region }} ssm get-parameters --names ${KV%%:*} --with-decryption --query Parameters[0].Value --output text)
+            -   export ${KV##*:}=$(aws --region {{ Region }} ssm get-parameters --names ${KV%%:*} --with-decryption --query Parameters[0].Value --output text)
             - done
+            - SCRIPT_PATH=/tmp/script.sh
             - wget -O $SCRIPT_PATH {{ ScriptUrl }}
             - chmod +x $SCRIPT_PATH
-            - $SCRIPT_PATH
+            - sudo $SCRIPT_PATH
 
   # Create Maintenance Window
   MaintenanceWindow:
@@ -97,13 +97,9 @@ Resources:
       WindowId: !Ref MaintenanceWindow
       ResourceType: "INSTANCE"
       Targets:
-        - Key: "tag:ssm-group"
+        - Key: "InstanceIds"
           Values:
-            - "foo"
-# TODO run on all instances
-#        - Key: "InstanceIds"
-#          Values:
-#            - "*"
+            - "*"
       Name: "SSMGroupTarget"
 
   # Create Maintenance Window Task

--- a/org-formation/090-systems-manager/ScheduledMaintenance.yaml
+++ b/org-formation/090-systems-manager/ScheduledMaintenance.yaml
@@ -16,41 +16,15 @@ Parameters:
     Description: >-
       space delimited list of key:value, where key is an SSM Parameter Store
       key and value is the shell envvar name to assign, e.g., /foo/bar:ENVVAR1 /bar/baz:ENVVAR2
+  TargetAccountId:
+    Type: 'String'
+    Description: The target account in which to run the Maintenance Task    
 Resources:
-  # Create IAM Role for SSM
-  SSMExecutionRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: "ssm.amazonaws.com"
-            Action: "sts:AssumeRole"
-      Policies:
-        - PolicyName: "SSMExecutionPolicy"
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "ec2:DescribeInstances"
-                  - "ssm:SendCommand"
-                Resource: "*"
-        - PolicyName: "SSMParameterPolicy"
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "ssm:GetParameters"
-                Resource:
-                - !Join [ '', ['arn:', !Ref 'AWS::Partition', ':ssm:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', '*'] ]
   SSMDocument:
     Type: "AWS::SSM::Document"
     Properties:
       DocumentType: "Command"
+      Name: "run-parameterized-script"
       Content:
         schemaVersion: "2.2"
         description: "Run a script on EC2 instances"
@@ -71,6 +45,7 @@ Resources:
           name: "runShellScript"
           inputs:
             runCommand:
+            - sudo su root
             - SSM_TO_ENV_MAP=( {{ SsmParameterNameToEnvvarMap }} )
             - for KV in ${SSM_TO_ENV_MAP[@]} ; do
             -   export ${KV##*:}=$(aws --region {{ Region }} ssm get-parameters --names ${KV%%:*} --with-decryption --query Parameters[0].Value --output text)
@@ -78,7 +53,7 @@ Resources:
             - SCRIPT_PATH=/tmp/script.sh
             - wget -O $SCRIPT_PATH {{ ScriptUrl }}
             - chmod +x $SCRIPT_PATH
-            - sudo $SCRIPT_PATH
+            - $SCRIPT_PATH
 
   # Create Maintenance Window
   MaintenanceWindow:
@@ -97,9 +72,9 @@ Resources:
       WindowId: !Ref MaintenanceWindow
       ResourceType: "INSTANCE"
       Targets:
-        - Key: "InstanceIds"
+        - Key: "tag:scheduled-maintenance"
           Values:
-            - "*"
+            - "stack-armor"
       Name: "SSMGroupTarget"
 
   # Create Maintenance Window Task
@@ -117,7 +92,8 @@ Resources:
         MaintenanceWindowRunCommandParameters:
           Comment: "Running SSM document on instances"
           TimeoutSeconds: 600
-          ServiceRoleArn: !GetAtt SSMExecutionRole.Arn
+          ServiceRoleArn:
+            !Join [ '', ['arn:', !Ref 'AWS::Partition', ':iam::', !Ref 'TargetAccountId', ':role/AWS-SystemsManager-ScheduledMaintenanceExecutionRole'] ]
           Parameters:
             ScriptUrl: [!Ref ScriptURL]
             Region: [!Ref AWS::Region]

--- a/org-formation/090-systems-manager/ScheduledMaintenance.yaml
+++ b/org-formation/090-systems-manager/ScheduledMaintenance.yaml
@@ -14,8 +14,8 @@ Parameters:
   ScriptParameters:
     Type: 'String'
     Description: >-
-      space delimited list of key:value, where key is an SSM Parameter Store 
-      key and value is the shell envvar name to assign
+      space delimited list of key:value, where key is an SSM Parameter Store
+      key and value is the shell envvar name to assign.
 Resources:
   # Create IAM Role for SSM
   SSMExecutionRole:
@@ -55,30 +55,30 @@ Resources:
         schemaVersion: "2.2"
         description: "Run a script on EC2 instances"
         parameters:
-          script_url:
+          ScriptUrl:
             type: String
             description: "The URL of the script to run"
-          region:
+          Region:
             type: String
-            description:  The AWS region
-          ssm_parameter_name_to_envvar_map:
+            description: The AWS region
+          SsmParameterNameToEnvvarMap:
             type: String
             description: >-
-              space delimited list of key:value, where key is an SSM Parameter Store 
-              key and value is the shell envvar name to assign
-          mainSteps:
-          - action: "aws:runShellScript"
-            name: "runShellScript"
-            inputs:
-              runCommand: |
-                SSM_TO_ENV_MAP=( {{ ssm_parameter_name_to_envvar_map }} )
-                for KV in "${SSM_TO_ENV_MAP[@]}" ; do        
-                	"${KV##*:}"=$(aws --region {{ region }} ssm get-parameters --names "${KV%%:*}" --with-decryption --query Parameters[0].Value --output text)
-                done                
-                SCRIPT_PATH=/tmp/script.sh
-                wget -O $SCRIPT_PATH {{ script_url }}
-                chmod +x $SCRIPT_PATH
-                $SCRIPT_PATH
+              space delimited list of key:value, where key is an SSM Parameter Store
+              key and value is the shell envvar name to assign.
+        mainSteps:
+        - action: "aws:runShellScript"
+          name: "runShellScript"
+          inputs:
+            runCommand:
+            - SCRIPT_PATH=/tmp/script.sh
+            - SSM_TO_ENV_MAP=( {{ SsmParameterNameToEnvvarMap }} )
+            - for KV in ${SSM_TO_ENV_MAP[@]} ; do
+            -   ${KV##*:}=$(aws --region {{ Region }} ssm get-parameters --names ${KV%%:*} --with-decryption --query Parameters[0].Value --output text)
+            - done
+            - wget -O $SCRIPT_PATH {{ ScriptUrl }}
+            - chmod +x $SCRIPT_PATH
+            - $SCRIPT_PATH
 
   # Create Maintenance Window
   MaintenanceWindow:
@@ -123,9 +123,9 @@ Resources:
           TimeoutSeconds: 600
           ServiceRoleArn: !GetAtt SSMExecutionRole.Arn
           Parameters:
-            script_url: !Ref ScriptURL
-            region: !Ref AWS::Region
-            ssm_parameter_name_to_envvar_map: !Ref ScriptParameters
+            ScriptUrl: [!Ref ScriptURL]
+            Region: [!Ref AWS::Region]
+            SsmParameterNameToEnvvarMap: [!Ref ScriptParameters]
       Priority: 1
       MaxConcurrency: "1"
       MaxErrors: "1"

--- a/org-formation/090-systems-manager/ScheduledMaintenance.yaml
+++ b/org-formation/090-systems-manager/ScheduledMaintenance.yaml
@@ -1,0 +1,131 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  AWS CloudFormation template that will create an SSM Maintenance
+  Window Task, with associated Maintenance Window, SSM Document,
+  Target and Role to run a given script on the EC2s in the specified account.
+Parameters:
+  Schedule:
+    Type: 'String'
+    Description: 'Schedule to run script'
+    Default: "rate(24 hours)"
+  ScriptURL:
+    Type: 'String'
+    Description: 'URL for the script to run'
+  ScriptParameters:
+    Type: 'String'
+    Description: >-
+      space delimited list of key:value, where key is an SSM Parameter Store 
+      key and value is the shell envvar name to assign
+Resources:
+  # Create IAM Role for SSM
+  SSMExecutionRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: "ssm.amazonaws.com"
+            Action: "sts:AssumeRole"
+      Policies:
+        - PolicyName: "SSMExecutionPolicy"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "ec2:DescribeInstances"
+                  - "ssm:SendCommand"
+                Resource: "*"
+        - PolicyName: "SSMParameterPolicy"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "ssm:GetParameters"
+                Resource:
+                - !Join [ '', ['arn:', !Ref 'AWS::Partition', ':ssm:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', '*'] ]
+  SSMDocument:
+    Type: "AWS::SSM::Document"
+    Properties:
+      DocumentType: "Command"
+      Content:
+        schemaVersion: "2.2"
+        description: "Run a script on EC2 instances"
+        parameters:
+          script_url:
+            type: String
+            description: "The URL of the script to run"
+          region:
+            type: String
+            description:  The AWS region
+          ssm_parameter_name_to_envvar_map:
+            type: String
+            description: >-
+              space delimited list of key:value, where key is an SSM Parameter Store 
+              key and value is the shell envvar name to assign
+          mainSteps:
+          - action: "aws:runShellScript"
+            name: "runShellScript"
+            inputs:
+              runCommand: |
+                SSM_TO_ENV_MAP=( {{ ssm_parameter_name_to_envvar_map }} )
+                for KV in "${SSM_TO_ENV_MAP[@]}" ; do        
+                	"${KV##*:}"=$(aws --region {{ region }} ssm get-parameters --names "${KV%%:*}" --with-decryption --query Parameters[0].Value --output text)
+                done                
+                SCRIPT_PATH=/tmp/script.sh
+                wget -O $SCRIPT_PATH {{ script_url }}
+                chmod +x $SCRIPT_PATH
+                $SCRIPT_PATH
+
+  # Create Maintenance Window
+  MaintenanceWindow:
+    Type: "AWS::SSM::MaintenanceWindow"
+    Properties:
+      Name: "DailyMaintenanceWindow"
+      Schedule: !Ref Schedule
+      Duration: 1 # Duration of the maintenance window in hours
+      Cutoff: 0
+      AllowUnassociatedTargets: False
+
+  # Create Maintenance Window Target
+  MaintenanceWindowTarget:
+    Type: "AWS::SSM::MaintenanceWindowTarget"
+    Properties:
+      WindowId: !Ref MaintenanceWindow
+      ResourceType: "INSTANCE"
+      Targets:
+        - Key: "tag:ssm-group"
+          Values:
+            - "foo"
+# TODO run on all instances
+#        - Key: "InstanceIds"
+#          Values:
+#            - "*"
+      Name: "SSMGroupTarget"
+
+  # Create Maintenance Window Task
+  MaintenanceWindowTask:
+    Type: "AWS::SSM::MaintenanceWindowTask"
+    Properties:
+      WindowId: !Ref MaintenanceWindow
+      Targets:
+        - Key: "WindowTargetIds"
+          Values:
+            - !Ref MaintenanceWindowTarget
+      TaskArn: !Ref SSMDocument
+      TaskType: "RUN_COMMAND"
+      TaskInvocationParameters:
+        MaintenanceWindowRunCommandParameters:
+          Comment: "Running SSM document on instances"
+          TimeoutSeconds: 600
+          ServiceRoleArn: !GetAtt SSMExecutionRole.Arn
+          Parameters:
+            script_url: !Ref ScriptURL
+            region: !Ref AWS::Region
+            ssm_parameter_name_to_envvar_map: !Ref ScriptParameters
+      Priority: 1
+      MaxConcurrency: "1"
+      MaxErrors: "1"

--- a/org-formation/090-systems-manager/ScheduledMaintenance.yaml
+++ b/org-formation/090-systems-manager/ScheduledMaintenance.yaml
@@ -15,7 +15,7 @@ Parameters:
     Type: 'String'
     Description: >-
       space delimited list of key:value, where key is an SSM Parameter Store
-      key and value is the shell envvar name to assign.
+      key and value is the shell envvar name to assign, e.g., /foo/bar:ENVVAR1 /bar/baz:ENVVAR2
 Resources:
   # Create IAM Role for SSM
   SSMExecutionRole:
@@ -65,7 +65,7 @@ Resources:
             type: String
             description: >-
               space delimited list of key:value, where key is an SSM Parameter Store
-              key and value is the shell envvar name to assign.
+              key and value is the shell envvar name to assign, e.g., /foo/bar:ENVVAR1 /bar/baz:ENVVAR2
         mainSteps:
         - action: "aws:runShellScript"
           name: "runShellScript"

--- a/org-formation/090-systems-manager/ScheduledMaintenance.yaml
+++ b/org-formation/090-systems-manager/ScheduledMaintenance.yaml
@@ -18,7 +18,7 @@ Parameters:
       key and value is the shell envvar name to assign, e.g., /foo/bar:ENVVAR1 /bar/baz:ENVVAR2
   TargetAccountId:
     Type: 'String'
-    Description: The target account in which to run the Maintenance Task    
+    Description: The target account in which to run the Maintenance Task
 Resources:
   SSMDocument:
     Type: "AWS::SSM::Document"

--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -60,3 +60,17 @@ PatchMembers:
     IncludeMasterAccount: true
   Parameters:
     ManagementAccountNumber: !Ref accountId
+
+StackArmorNessusScanner:
+  Type: update-stacks
+  Template: ScheduledMaintenance.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-stackarmor-nessus-scsnner'
+  StackDescription: Install Nessus scanner on instances in account
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Accounts:
+        - !Ref SynapseProdAccount
+    IncludeMasterAccount: false
+  Parameters:
+    ScriptURL: https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.10/stack-armor/install-nessus-agent.sh
+    ScriptParameters: /stack-armor/install-nessus-key:STACK_ARMOR_KEY

--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -69,7 +69,7 @@ StackArmorNessusScanner:
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     Accounts:
-        - !Ref SynapseProdAccount
+      - !Ref SynapseProdAccount
     IncludeMasterAccount: false
   Parameters:
     ScriptURL: https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.10/stack-armor/install-nessus-agent.sh

--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -61,16 +61,26 @@ PatchMembers:
   Parameters:
     ManagementAccountNumber: !Ref accountId
 
-StackArmorNessusScanner:
+SysmanScheduledMaintenaceServiceRole:
   Type: update-stacks
-  Template: ScheduledMaintenance.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-stackarmor-nessus-scanner'
-  StackDescription: Install Nessus scanner on instances in account
+  Template: AWS-SystemsManager-ScheduledMaintenanceServiceRole.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-sysman-sched-maint-service-role'
+  StackDescription: Service role for AWS System Manager Scheduled Maintenance
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
-    Accounts:
-      - !Ref SynapseProdAccount
-    IncludeMasterAccount: false
-  Parameters:
-    ScriptURL: https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.10/stack-armor/install-nessus-agent.sh
-    ScriptParameters: /stack-armor/install-nessus-key:STACK_ARMOR_KEY
+    Account: !Ref accountId
+
+
+#StackArmorNessusScanner:
+#  Type: update-stacks
+#  Template: ScheduledMaintenance.yaml
+#  StackName: !Sub '${resourcePrefix}-${appName}-stackarmor-nessus-scanner'
+#  StackDescription: Install Nessus scanner on instances in account
+#  DefaultOrganizationBindingRegion: !Ref primaryRegion
+#  DefaultOrganizationBinding:
+#    Accounts:
+#      - !Ref SynapseProdAccount
+#    IncludeMasterAccount: false
+#  Parameters:
+#    ScriptURL: https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.10/stack-armor/install-nessus-agent.sh
+#    ScriptParameters: /stack-armor/install-nessus-key:STACK_ARMOR_KEY

--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -64,7 +64,7 @@ PatchMembers:
 StackArmorNessusScanner:
   Type: update-stacks
   Template: ScheduledMaintenance.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-stackarmor-nessus-scsnner'
+  StackName: !Sub '${resourcePrefix}-${appName}-stackarmor-nessus-scanner'
   StackDescription: Install Nessus scanner on instances in account
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -106,6 +106,28 @@ GithubOidcSageBionetworksSchematicInfra:
       - !Ref DCAProdAccount
     Region: us-east-1
 
+GithubOidcSageBionetworksSynapseDockerRegistry:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapse-docker-registry
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapse-docker-registry
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "synapse-docker-registry"
+        branches: ["*"]
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref SynapseDevAccount
+      - !Ref SynapseProdAccount
+    Region: us-east-1
+
 GithubOidcSageBionetworksGenieBPCInfra:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks


### PR DESCRIPTION
This PR adds a template to create an SSM Maintenance Window and uses it to run the  Stack Armor scanner installer each day, ensuring that the scanner is installed (or updated to a new version) on any machines deployed to the target account.

The installation script is a parameter, and we 'point to' the Nessus script, stored in GitHub.

The Nessus script requires a secret key.  We store the key in SSM Parameter store and, at execution time, retrieve it and pass it to the script as an environment variable.  The CF template takes a list of key/value pairs as input where the keys are SSM Parameter Store keys and the values are the names of environment variables in the scrip to which the secret values should be assigned.  In the immediate case the Parameter Store key is `/stack-armor/install-nessus-key` and its value is assigned to `STACK_ARMOR_KEY`.