### PR TITLE
PLFM-8102: Add oidc perms to push image to repo and deploy lambda from image

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -810,8 +810,11 @@ GithubOidcNbConvertDeploy:
     ProviderRoleName: !Sub ${resourcePrefix}-${appName}-nbconvert-deploy
     MaxSessionDuration: 7200
     ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AdministratorAccess"
-      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
+      - "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"
+      - "arn:aws:iam::aws:policy/AmazonLambdaFullAccess"
+      - "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
+      - "arn:aws:iam::aws:policy/IAMFullAccess"
+      - "arn:aws:iam::aws:policy/CloudFormationFullAccess"
   TemplatingContext:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -800,6 +800,51 @@ GithubOidcOpenChallengesDeploy:
       - !Ref ITSandboxAccount
     Region: us-east-1
 
+GithubOidcNbConvertDeploy:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-nbconvert-deploy
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-nbconvert-deploy
+    MaxSessionDuration: 7200
+    PolicyDocument: >-
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Effect": "Allow",
+                  "Action": [
+                      "ecr:CompleteLayerUpload",
+                      "ecr:UploadLayerPart",
+                      "ecr:InitiateLayerUpload",
+                      "ecr:BatchCheckLayerAvailability",
+                      "ecr:PutImage"
+                  ],
+                  "Resource": [
+                      "arn:aws:ecr:region:449435941126:repository/dev-nbconvert",
+                      "arn:aws:ecr:region:325565585839:repository/prod-nbconvert"
+                  ]
+              },
+              {
+                  "Effect": "Allow",
+                  "Action": "ecr:GetAuthorizationToken",
+                  "Resource": "*"
+              }
+          ]
+      }
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "nbconvert-webapp"
+        branches: ["master"]
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref SynapseDevAccount
+      - !Ref SynapseProdAccount
+    Region: us-east-1
+
 ############################### Managed Policies ###############################
 # Managed policies used in github OIDC providers
 # Note: Managed policies can be used as work around for the AWS cloudformation

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -825,6 +825,7 @@ GithubOidcNbConvertDeploy:
                       "ecr:PutImage"
                   ],
                   "Resource": [
+                      "arn:aws:ecr:region:449435941126:repository/nbconvert",
                       "arn:aws:ecr:region:449435941126:repository/dev-nbconvert",
                       "arn:aws:ecr:region:325565585839:repository/prod-nbconvert"
                   ]

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -811,32 +811,10 @@ GithubOidcNbConvertDeploy:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ProviderRoleName: !Sub ${resourcePrefix}-${appName}-nbconvert-deploy
     MaxSessionDuration: 7200
-    PolicyDocument: >-
-      {
-          "Version": "2012-10-17",
-          "Statement": [
-              {
-                  "Effect": "Allow",
-                  "Action": [
-                      "ecr:CompleteLayerUpload",
-                      "ecr:UploadLayerPart",
-                      "ecr:InitiateLayerUpload",
-                      "ecr:BatchCheckLayerAvailability",
-                      "ecr:PutImage"
-                  ],
-                  "Resource": [
-                      "arn:aws:ecr:region:449435941126:repository/nbconvert",
-                      "arn:aws:ecr:region:449435941126:repository/dev-nbconvert",
-                      "arn:aws:ecr:region:325565585839:repository/prod-nbconvert"
-                  ]
-              },
-              {
-                  "Effect": "Allow",
-                  "Action": "ecr:GetAuthorizationToken",
-                  "Resource": "*"
-              }
-          ]
-      }
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"
+      - "arn:aws:iam::aws:policy/AmazonLambdaFullAccess"
+      - "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
   TemplatingContext:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -800,6 +800,8 @@ GithubOidcOpenChallengesDeploy:
       - !Ref ITSandboxAccount
     Region: us-east-1
 
+# Permissions to push an image to private registry
+# See: https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push-iam.html
 GithubOidcNbConvertDeploy:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -800,8 +800,6 @@ GithubOidcOpenChallengesDeploy:
       - !Ref ITSandboxAccount
     Region: us-east-1
 
-# Permissions to push an image to private registry
-# See: https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push-iam.html
 GithubOidcNbConvertDeploy:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks
@@ -812,9 +810,8 @@ GithubOidcNbConvertDeploy:
     ProviderRoleName: !Sub ${resourcePrefix}-${appName}-nbconvert-deploy
     MaxSessionDuration: 7200
     ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"
-      - "arn:aws:iam::aws:policy/AmazonLambdaFullAccess"
-      - "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
   TemplatingContext:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:


### PR DESCRIPTION
This PR sets up OIDC role with permissions to push a docker image to a repo from the nbconvert GH repo, and create a lambda from that image.
