### PR TITLE
[IT-3891] Setup github CI deployments to Open Challege accounts

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -794,10 +794,11 @@ GithubOidcOpenChallengesDeploy:
     GitHubOrg: "Sage-Bionetworks-IT"
     Repositories:
       - name: "openchallenges"
-        branches: ["dev", "prod"]
+        branches: ["dev", "stage", "prod"]
   DefaultOrganizationBinding:
     Account:
-      - !Ref ITSandboxAccount
+      - !Ref OpenChallengesDevAccount
+      - !Ref OpenChallengesProdAccount
     Region: us-east-1
 
 ############################### Managed Policies ###############################


### PR DESCRIPTION
Setup github OIDC to allow github CI to deploy to openchallenges accounts.

depends on https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/1213
depends on https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/1216

