### PR TITLE
PLFM-8102: Fix deployment

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -812,10 +812,10 @@ GithubOidcNbConvertDeploy:
     MaxSessionDuration: 7200
     ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"
-      - "arn:aws:iam::aws:policy/AmazonLambdaFullAccess"
+      - "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
       - "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
       - "arn:aws:iam::aws:policy/IAMFullAccess"
-      - "arn:aws:iam::aws:policy/CloudFormationFullAccess"
+      - "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"
   TemplatingContext:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:


### PR DESCRIPTION
This PR fixes a wrong name for the Cloudformation policy, and updates the name of the lambda policy (other one is deprecated).
