### PR TITLE
fix bucket settings

### DIFF
--- a/sceptre/admincentral/templates/cfn-snippets-bucket.yaml
+++ b/sceptre/admincentral/templates/cfn-snippets-bucket.yaml
@@ -17,7 +17,6 @@ Resources:
         config:
           ignore_checks: [ "W3045" ]
     Properties:
-      AccessControl: PublicRead
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerEnforced

--- a/sceptre/bridge/templates/bridge.yaml
+++ b/sceptre/bridge/templates/bridge.yaml
@@ -255,7 +255,6 @@ Resources:
     Type: AWS::S3::Bucket
     Condition: CreateProdResources
     Properties:
-      AccessControl: PublicRead
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerEnforced

--- a/sceptre/bridge/templates/essentials.yaml
+++ b/sceptre/bridge/templates/essentials.yaml
@@ -10,7 +10,6 @@ Resources:
           ignore_checks: [ "W3045" ]
     DeletionPolicy: Delete
     Properties:
-      AccessControl: PublicRead
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerEnforced

--- a/sceptre/imagecentral/templates/ec2-image-builder.yaml
+++ b/sceptre/imagecentral/templates/ec2-image-builder.yaml
@@ -40,7 +40,6 @@ Resources:
           ignore_checks: [ "W3045" ]
     DeletionPolicy: Delete
     Properties:
-      AccessControl: PublicRead
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerEnforced

--- a/sceptre/sageit/templates/admodeladexplorer-redirector.yaml
+++ b/sceptre/sageit/templates/admodeladexplorer-redirector.yaml
@@ -21,7 +21,6 @@ Resources:
         config:
           ignore_checks: [ "W3045" ]
     Properties:
-      AccessControl: PublicRead
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerEnforced

--- a/sceptre/sageit/templates/s3webredirect.yaml
+++ b/sceptre/sageit/templates/s3webredirect.yaml
@@ -28,7 +28,6 @@ Resources:
         config:
           ignore_checks: [W3045]
     Properties:
-      AccessControl: PublicRead
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerEnforced


### PR DESCRIPTION
AWS has deprecated the use of ALCs for S3 buckets
so we remove AccessControl and keep OwnershipControls

```
AWS::S3::Bucket UPDATE_FAILED Resource handler returned message:
"Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced
setting
```

