### PR TITLE
Fix public read bucket

### DIFF
--- a/sceptre/admincentral/templates/cfn-snippets-bucket.yaml
+++ b/sceptre/admincentral/templates/cfn-snippets-bucket.yaml
@@ -17,12 +17,25 @@ Resources:
         config:
           ignore_checks: [ "W3045" ]
     Properties:
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: BucketOwnerEnforced
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
       Tags:
         - Key: "OwnerEmail"
           Value: !Ref OwnerEmail
+  BucketPolicy:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref CloudformationSnippetsBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: '*'
+            Action: 's3:GetObject'
+            Resource: !Sub '${CloudformationSnippetsBucket.Arn}/*'
   # requires the cloudformation S3 objects macro
   # https://github.com/Sage-Bionetworks-IT/cfn-s3objects-macro
   ServiceCatalogSupportSnippet:

--- a/sceptre/bridge/templates/bridge.yaml
+++ b/sceptre/bridge/templates/bridge.yaml
@@ -255,14 +255,32 @@ Resources:
     Type: AWS::S3::Bucket
     Condition: CreateProdResources
     Properties:
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: BucketOwnerEnforced
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
       BucketName: android-apps.sagebridge.org
       WebsiteConfiguration:
         IndexDocument: index.html
         ErrorDocument: error.html
     DeletionPolicy: Retain
+  AndroidAppBucketPolicy:
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - W1001
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref AWSS3AndroidAppBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: '*'
+            Action: 's3:GetObject'
+            Resource: !Sub '${AWSS3AndroidAppBucket.Arn}/*'
 Outputs:
   AwsDefaultVpcId:
     Value: !Ref AwsDefaultVpcId

--- a/sceptre/bridge/templates/essentials.yaml
+++ b/sceptre/bridge/templates/essentials.yaml
@@ -10,23 +10,22 @@ Resources:
           ignore_checks: [ "W3045" ]
     DeletionPolicy: Delete
     Properties:
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: BucketOwnerEnforced
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
   AWSIAMS3LambdaArtifactsBucketPolicy:
-    Type: "AWS::S3::BucketPolicy"
+    Type: 'AWS::S3::BucketPolicy'
     Properties:
       Bucket: !Ref AWSS3LambdaArtifactsBucket
       PolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
-          -
-            Sid: "AllowPublicRead"
-            Effect: "Allow"
-            Principal:
-              AWS: "*"
-            Action: "s3:GetObject"
-            Resource: !Sub "arn:aws:s3:::${AWSS3LambdaArtifactsBucket}/*"
+          - Effect: Allow
+            Principal: '*'
+            Action: 's3:GetObject'
+            Resource: !Sub '${AWSS3LambdaArtifactsBucket.Arn}/*'
   # KMS Keys
   AWSKmsInfraKey:
     Type: "AWS::KMS::Key"

--- a/sceptre/imagecentral/templates/ec2-image-builder.yaml
+++ b/sceptre/imagecentral/templates/ec2-image-builder.yaml
@@ -40,9 +40,11 @@ Resources:
           ignore_checks: [ "W3045" ]
     DeletionPolicy: Delete
     Properties:
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: BucketOwnerEnforced
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
       Tags:
         - Key: "OwnerEmail"
           Value: !Ref OwnerEmail

--- a/sceptre/sageit/templates/admodeladexplorer-redirector.yaml
+++ b/sceptre/sageit/templates/admodeladexplorer-redirector.yaml
@@ -21,9 +21,11 @@ Resources:
         config:
           ignore_checks: [ "W3045" ]
     Properties:
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: BucketOwnerEnforced
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
       BucketName: !Sub
       - ${stackPrefix}.admodeladexplorer.org
       - { stackPrefix: !Ref StackType }

--- a/sceptre/sageit/templates/s3webredirect.yaml
+++ b/sceptre/sageit/templates/s3webredirect.yaml
@@ -28,9 +28,11 @@ Resources:
         config:
           ignore_checks: [W3045]
     Properties:
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: BucketOwnerEnforced
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
       BucketName: !Ref RedirectFrom
       WebsiteConfiguration:
         IndexDocument: index.html
@@ -42,7 +44,17 @@ Resources:
               HttpRedirectCode: "307"
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
-
+  WebsiteBucketPolicy:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref WebsiteBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: '*'
+            Action: 's3:GetObject'
+            Resource: !Sub '${WebsiteBucket.Arn}/*'
   Cloudfront:
     Type: AWS::CloudFront::Distribution
     Properties:


### PR DESCRIPTION
This is a fix for PR #1220  which I tried to fix in PR #1225 but now encountered the following error..

```
develop/sc-product-ec2-linux-docker-notebook sc-product-ec2-linux-docker-notebook
AWS::CloudFormation::Stack UPDATE_IN_PROGRESS Transform AWS::Include failed with:
S3 URI must reference a valid S3 object to which you have access.
```

Which i think means that the bucket is still not setup as a public read bucket.

This fix is derived from the example in AWS docs to setup an S3 public bucket[1]

[1] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-bucket.html#aws-resource-s3-bucket--examples--Granting_public_access_to_S3_buckets

