### PR TITLE
packer-rstudio has been deprecated

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -407,8 +407,6 @@ GithubOidcPackerImageDeploy:
         branches: ["master"]
       - name: "packer-base-ubuntu-jammy"
         branches: ["master"]
-      - name: "packer-rstudio"
-        branches: ["master"]
       - name: "packer-amazonlinux-docker"
         branches: ["master"]
       - name: "imagecentral-dashboard"


### PR DESCRIPTION
This rstudio aws AMI is no longer used.  The repo[1] for it has been archived as well.

  [1] https://github.com/Sage-Bionetworks-IT/packer-rstudio

