### PR TITLE
IT-3924: Add cross-account for SynapseProd

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -215,6 +215,7 @@ StackArmorReadOnlyAccess:
       - arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess
 
 # Setup SynapseProd cross-account access the BedRock in SynapseLlmProd
+# https://repost.aws/knowledge-center/bedrock-invoke-with-cross-account
 SynapseProdBedrockFullAccess:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.10/templates/IAM/cross-account-access.yaml

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -219,7 +219,7 @@ StackArmorReadOnlyAccess:
 SynapseLlmProdBedrockFullAccess:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.10/templates/IAM/cross-account-access.yaml
-  StackName: synapseprod-bedrock-full-access
+  StackName: synapsellmprod-bedrock-full-access
   DefaultOrganizationBinding:
     Account: !Ref SynapseLlmProdAccount
     Region: us-east-1

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -214,6 +214,20 @@ StackArmorReadOnlyAccess:
       - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
       - arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess
 
+# Setup SynapseProd cross-account access the BedRock in SynapseLlmProd
+SynapseProdBedrockFullAccess:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.10/templates/IAM/cross-account-access.yaml
+  StackName: synapseprod-bedrock-full-access
+  DefaultOrganizationBinding:
+    Account: !Ref SynapseLlmProdAccount
+    Region: us-east-1
+  Parameters:
+    PrincipalArns:
+      - arn:aws:iam::325565585839:root # SynapseProd AWS account ID
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonBedrockFullAccess
+
 #---------- Policies -------------
 CostExplorerAccessPolicy:
   Type: update-stacks

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -214,9 +214,9 @@ StackArmorReadOnlyAccess:
       - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
       - arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess
 
-# Setup SynapseProd cross-account access the BedRock in SynapseLlmProd
+# Setup cross-account access to BedRock in SynapseLlmProd account
 # https://repost.aws/knowledge-center/bedrock-invoke-with-cross-account
-SynapseProdBedrockFullAccess:
+SynapseLlmProdBedrockFullAccess:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.10/templates/IAM/cross-account-access.yaml
   StackName: synapseprod-bedrock-full-access


### PR DESCRIPTION
This PR adds cross account access to Bedrock in SynapseLlmProd from SynapseProd
