### PR TITLE
IT-3924: case-sensitive

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -934,7 +934,7 @@ SsoSynapseLlmProdAdmin:
       Account: !Ref SynapseLlmProdAccount
   Parameters:
     instanceArn: !Ref instanceArn
-    principalId: !Ref synapseLlmProdAdminGroup
+    principalId: !Ref SynapseLlmProdAdminGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
 
 SsoSynapseDevDeveloper:


### PR DESCRIPTION
This PR should fix the deployment error ' ERROR: Task SsoSynapseLlmProdAdmin validated failed. reason: unable to parse expression on attribute parameter principalId. Is there an error in the expression? {"Ref":"synapseLlmProdAdminGroup"} '
