### PR TITLE
IT-3924: Add developer and LLM developer roles to SynapseLLM account

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -610,14 +610,14 @@ SsoApplicationManager:
         ]
       }
 
-SSoSynapseLlmDeveloper:
+SSoLlmDeveloper:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.7/templates/SSO/aws-sso.njk
   TemplatingContext:
     customerManagedPolicies:
       - Name: !Ref CostExplorerPolicyName
-  StackName: !Sub '${resourcePrefix}-${appName}-synapsellmdeveloper'
-  StackDescription: 'Role used by LLM Developer group within Synapse LLM prod account'
+  StackName: !Sub '${resourcePrefix}-${appName}-ssollmdeveloper'
+  StackDescription: 'Role used by an LLM developer'
   TerminationProtection: false
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
@@ -627,23 +627,12 @@ SSoSynapseLlmDeveloper:
       Account: !Ref SynapseLlmProdAccount
   Parameters:
     instanceArn: !Ref instanceArn
-    principalId: !Ref SynapseLlmProdDeveloperGroup
-    permissionSetName: 'llm-developer'
+    principalId: !Ref ssoLlmProdDeveloperGroup
+    permissionSetName: 'ssollmdeveloper'
     managedPolicies:
       - 'arn:aws:iam::aws:policy/AmazonBedrockFullAccess'
       - 'arn:aws:iam::aws:policy/AWSCloudFormationFullAccess'
     sessionDuration: 'PT12H'
-    inlinePolicy: >-
-      {
-          "Version": "2012-10-17",
-          "Statement": [
-              {
-                  "Effect": "Deny",
-                  "Action": "sts:AssumeRole",
-                  "Resource": "*"
-              }
-          ]
-      }
 
 # Role for a user that can only access AWS Athena in the Synapse Dev account
 SsoSynapseDWDevAthenaUser:
@@ -974,10 +963,10 @@ SsoSynapseLlmProdAdmin:
 
 SsoSynapseLlmProdDeveloper:
   Type: update-stacks
-  DependsOn: SsoSynapseLlmDeveloper
+  DependsOn: SsoLlmDeveloper
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.7/templates/SSO/aws-sso.njk
   TemplatingContext: {}
-  StackName: !Sub '${resourcePrefix}-${appName}-synapsellm-prod-llmdeveloper'
+  StackName: !Sub '${resourcePrefix}-${appName}-synapsellmprod-llmdeveloper'
   StackDescription: 'SSO: llm developer role used by SynapseLlm prod developer group'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
@@ -988,7 +977,7 @@ SsoSynapseLlmProdDeveloper:
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref SynapseLlmProdDeveloperGroup
-    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-synapsellmdeveloper-permission-set-arn' ]
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ssollmdeveloper-permission-set-arn' ]
 
 SsoSynapseDevDeveloper:
   Type: update-stacks

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -610,6 +610,41 @@ SsoApplicationManager:
         ]
       }
 
+SSoSynapseLlmDeveloper:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.7/templates/SSO/aws-sso.njk
+  TemplatingContext:
+    customerManagedPolicies:
+      - Name: !Ref CostExplorerPolicyName
+  StackName: !Sub '${resourcePrefix}-${appName}-synapsellmdeveloper'
+  StackDescription: 'Role used by LLM Developer group within Synapse LLM prod account'
+  TerminationProtection: false
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: false
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref SynapseLlmProdAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref SynapseLlmProdDeveloperGroup
+    permissionSetName: 'llm-developer'
+    managedPolicies:
+      - 'arn:aws:iam::aws:policy/AmazonBedrockFullAccess'
+      - 'arn:aws:iam::aws:policy/AWSCloudFormationFullAccess'
+    sessionDuration: 'PT12H'
+    inlinePolicy: >-
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Effect": "Deny",
+                  "Action": "sts:AssumeRole",
+                  "Resource": "*"
+              }
+          ]
+      }
+
 # Role for a user that can only access AWS Athena in the Synapse Dev account
 SsoSynapseDWDevAthenaUser:
   Type: update-stacks
@@ -936,6 +971,24 @@ SsoSynapseLlmProdAdmin:
     instanceArn: !Ref instanceArn
     principalId: !Ref SynapseLlmProdAdminGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
+
+SsoSynapseLlmProdDeveloper:
+  Type: update-stacks
+  DependsOn: SsoSynapseLlmDeveloper
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.7/templates/SSO/aws-sso.njk
+  TemplatingContext: {}
+  StackName: !Sub '${resourcePrefix}-${appName}-synapsellm-prod-llmdeveloper'
+  StackDescription: 'SSO: llm developer role used by SynapseLlm prod developer group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref SynapseLlmProdAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref SynapseLlmProdDeveloperGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-synapsellmdeveloper-permission-set-arn' ]
 
 SsoSynapseDevDeveloper:
   Type: update-stacks

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -17,9 +17,13 @@ Parameters:
     Type: String
     Default: '906769aa66-4b16d4b3-7c9c-44b7-85e0-adbf41dbf49d'
 
-  developerGroup:     #JC aws-develoers
+  developerGroup:     #JC aws-developers
     Type: String
     Default: '906769aa66-49d7689b-ae36-472b-bc3d-893753529227'
+
+  llmDeveloperGroup: #JC aws-llmdevelopers
+    Type: String
+    Default: '8458f408-2011-701d-03c4-a27ef3d4489c'
 
   scienceSupporterGroup:      #JC aws-science-supporters
     Type: String
@@ -326,6 +330,10 @@ Parameters:
     Type: String
     Default: 'd478d408-10e1-7071-2273-606c45bb8653'
 
+  SynapseLlmProdLlmDeveloperGroup:  # JC aws-synapsellm-prod-llmdevelopers
+    Type: String
+    Default: '44b8f4c8-9031-7097-01d8-d4e845d7d84d'
+
   #------------- personal AWS accounts ------------------
   BuA2aDwAdminGroup:             #JC aws-BuA2aDw-admins
     Type: String
@@ -616,8 +624,8 @@ SSoLlmDeveloper:
   TemplatingContext:
     customerManagedPolicies:
       - Name: !Ref CostExplorerPolicyName
-  StackName: !Sub '${resourcePrefix}-${appName}-ssollmdeveloper'
-  StackDescription: 'Role used by an LLM developer'
+  StackName: !Sub '${resourcePrefix}-${appName}-llmdeveloper'
+  StackDescription: 'Permission set used by an LLM developer'
   TerminationProtection: false
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
@@ -627,8 +635,8 @@ SSoLlmDeveloper:
       Account: !Ref SynapseLlmProdAccount
   Parameters:
     instanceArn: !Ref instanceArn
-    principalId: !Ref ssoLlmProdDeveloperGroup
-    permissionSetName: 'ssollmdeveloper'
+    principalId: !Ref llmDeveloperGroup
+    permissionSetName: 'llmdeveloper'
     managedPolicies:
       - 'arn:aws:iam::aws:policy/AmazonBedrockFullAccess'
       - 'arn:aws:iam::aws:policy/AWSCloudFormationFullAccess'
@@ -949,7 +957,7 @@ SsoSynapseLlmProdAdmin:
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.7/templates/SSO/aws-sso.njk
   TemplatingContext: {}
   StackName: !Sub '${resourcePrefix}-${appName}-synapsellmprod-admin'
-  StackDescription: 'SSO: admin role used by synapsellmprod admin group'
+  StackDescription: 'SSO: admin role used by SynapseLlm prod admin group'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
@@ -963,11 +971,11 @@ SsoSynapseLlmProdAdmin:
 
 SsoSynapseLlmProdDeveloper:
   Type: update-stacks
-  DependsOn: SsoLlmDeveloper
+  DependsOn: SsoDeveloper
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.7/templates/SSO/aws-sso.njk
   TemplatingContext: {}
-  StackName: !Sub '${resourcePrefix}-${appName}-synapsellmprod-llmdeveloper'
-  StackDescription: 'SSO: llm developer role used by SynapseLlm prod developer group'
+  StackName: !Sub '${resourcePrefix}-${appName}-synapsellmprod-developer'
+  StackDescription: 'SSO: developer role used by SynapseLlm prod developer group'
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
@@ -977,7 +985,25 @@ SsoSynapseLlmProdDeveloper:
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref SynapseLlmProdDeveloperGroup
-    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ssollmdeveloper-permission-set-arn' ]
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
+
+# SsoSynapseLlmProdLlmDeveloper:
+#   Type: update-stacks
+#   DependsOn: SsoLlmDeveloper
+#   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.7/templates/SSO/aws-sso.njk
+#   TemplatingContext: {}
+#   StackName: !Sub '${resourcePrefix}-${appName}-synapsellmprod-llmdeveloper'
+#   StackDescription: 'SSO: LLM developer role used by SynapseLlm prod LLM developer group'
+#   DefaultOrganizationBindingRegion: !Ref primaryRegion
+#   DefaultOrganizationBinding:
+#     IncludeMasterAccount: true
+#   OrganizationBindings:
+#     TargetBinding:
+#       Account: !Ref SynapseLlmProdAccount
+#   Parameters:
+#     instanceArn: !Ref instanceArn
+#     principalId: !Ref SynapseLlmProdLlmDeveloperGroup
+#     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-llmdeveloper-permission-set-arn' ]
 
 SsoSynapseDevDeveloper:
   Type: update-stacks

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -618,7 +618,7 @@ SsoApplicationManager:
         ]
       }
 
-SSoLlmDeveloper:
+SsoLlmDeveloper:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.7/templates/SSO/aws-sso.njk
   TemplatingContext:
@@ -987,23 +987,23 @@ SsoSynapseLlmProdDeveloper:
     principalId: !Ref SynapseLlmProdDeveloperGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
 
-# SsoSynapseLlmProdLlmDeveloper:
-#   Type: update-stacks
-#   DependsOn: SsoLlmDeveloper
-#   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.7/templates/SSO/aws-sso.njk
-#   TemplatingContext: {}
-#   StackName: !Sub '${resourcePrefix}-${appName}-synapsellmprod-llmdeveloper'
-#   StackDescription: 'SSO: LLM developer role used by SynapseLlm prod LLM developer group'
-#   DefaultOrganizationBindingRegion: !Ref primaryRegion
-#   DefaultOrganizationBinding:
-#     IncludeMasterAccount: true
-#   OrganizationBindings:
-#     TargetBinding:
-#       Account: !Ref SynapseLlmProdAccount
-#   Parameters:
-#     instanceArn: !Ref instanceArn
-#     principalId: !Ref SynapseLlmProdLlmDeveloperGroup
-#     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-llmdeveloper-permission-set-arn' ]
+SsoSynapseLlmProdLlmDeveloper:
+  Type: update-stacks
+  DependsOn: SsoLlmDeveloper
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.7/templates/SSO/aws-sso.njk
+  TemplatingContext: {}
+  StackName: !Sub '${resourcePrefix}-${appName}-synapsellmprod-llmdeveloper'
+  StackDescription: 'SSO: LLM developer role used by SynapseLlm prod LLM developer group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref SynapseLlmProdAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref SynapseLlmProdLlmDeveloperGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-llmdeveloper-permission-set-arn' ]
 
 SsoSynapseDevDeveloper:
   Type: update-stacks

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -621,7 +621,7 @@ SSoSynapseLlmDeveloper:
   TerminationProtection: false
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
-    IncludeMasterAccount: false
+    IncludeMasterAccount: true
   OrganizationBindings:
     TargetBinding:
       Account: !Ref SynapseLlmProdAccount

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -625,7 +625,7 @@ SsoLlmDeveloper:
     customerManagedPolicies:
       - Name: !Ref CostExplorerPolicyName
   StackName: !Sub '${resourcePrefix}-${appName}-llmdeveloper'
-  StackDescription: 'Permission set used by an LLM developer'
+  StackDescription: 'Permission set used by an Large Language Model developer'
   TerminationProtection: false
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
@@ -636,7 +636,7 @@ SsoLlmDeveloper:
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref llmDeveloperGroup
-    permissionSetName: 'llmdeveloper'
+    permissionSetName: 'LlmDeveloper'
     managedPolicies:
       - 'arn:aws:iam::aws:policy/AmazonBedrockFullAccess'
       - 'arn:aws:iam::aws:policy/AWSCloudFormationFullAccess'


### PR DESCRIPTION
This PR

- creates a 'developer' role in the SynapseLLM prod account based on the existing SSO developer permission set
- creates an 'llmdeveloper' permission set associated with an 'aws-llm-developers' JC group (following pattern seen for permission sets)
- creates a 'llm-developer' role in the SynapseLLM prod account based on the permission set created above

