### PR TITLE
PLFM-8102: Add missing perms

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -814,6 +814,8 @@ GithubOidcNbConvertDeploy:
       - "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
       - "arn:aws:iam::aws:policy/IAMFullAccess"
       - "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"
+      - "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+      - "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
   TemplatingContext:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:


### PR DESCRIPTION
This PR syncs up the perms that were added manually for a successful deployment from GH CI.
