### PR TITLE
IT-3924: Enable access to SynapseLLM prod from SynapseDev account

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -226,6 +226,7 @@ SynapseLlmProdBedrockFullAccess:
   Parameters:
     PrincipalArns:
       - arn:aws:iam::325565585839:root # SynapseProd AWS account ID
+      - arn:aws:iam::449435941126:root # SynapseDev AWS account ID
     ManagedPolicyArns:
       - arn:aws:iam::aws:policy/AmazonBedrockFullAccess
 


### PR DESCRIPTION
This PR gives the Synapse Dev account the permission to access BedRock in the SynapseLLM prod account.
