### PR TITLE
Give SSO developer role IAM read access

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -410,6 +410,7 @@ SsoDeveloper:
     permissionSetName: 'Developer'
     managedPolicies:
       - 'arn:aws:iam::aws:policy/PowerUserAccess'
+      - 'arn:aws:iam::aws:policy/IAMReadOnlyAccess'
       - 'arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk'
       - 'arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess'
       - 'arn:aws:iam::aws:policy/AmazonBedrockFullAccess'


### PR DESCRIPTION
The PowerUserAccess policy does not allow access to IAM, From the docs[1].. `Provides full access to AWS services and resources, but does not allow management of Users and groups.`

Developers should be able to view AWS user and group info.

[1] https://docs.aws.amazon.com/aws-managed-policy/latest/reference/PowerUserAccess.html

