### PR TITLE
Fix lambda-finops-s3-cost-report deploy pipeline

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -296,6 +296,12 @@ GithubOidcLambdaTemplateDeploySage:
                           ]
           },
           {
+              "Sid": "CfnValidate",
+              "Effect": "Allow",
+              "Action": [ "cloudformation:ValidateTemplate" ],
+              "Resource": [ "*" ]
+          },
+          {
               "Sid": "SamValidate",
               "Effect": "Allow",
               "Action": [ "iam:ListPolicies" ],
@@ -357,6 +363,12 @@ GithubOidcLambdaTemplateDeploySageIT:
               "Resource": [ "arn:aws:s3:::bootstrap-awss3cloudformationbucket-19qromfd235z9/*",
                             "arn:aws:s3:::essentials-awss3lambdaartifactsbucket-x29ftznj6pqw/*"
                           ]
+          },
+          {
+              "Sid": "CfnValidate",
+              "Effect": "Allow",
+              "Action": [ "cloudformation:ValidateTemplate" ],
+              "Resource": [ "*" ]
           },
           {
               "Sid": "SamValidate",


### PR DESCRIPTION
A new cloudformation validation command was added to the deploy pipeline, but the github oidc role doesn't have permission to run the command `aws cloudformation validate-template`.

Grant `cloudformation:ValidateTemplate` access to the OIDC role used by our lambda projects.
