### PR TITLE
PLFM-8554: Add friendly CNAME to LB for dev' Synapse docker registry

### DIFF
--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -222,9 +222,10 @@ GenieBPCProdAppDnsForward:
     SourceHostedZoneId: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sagebio-app-zone-HostedZoneId']
     # the value of the CNAME record
     TargetHostName: !CopyValue ['genie-bpc-shiny-prod-DockerFargateStack-LoadBalancerDNS', !Ref GenieProdAccount]
-# forward dca-dev.app.sagebionetworks.org to data_curator-infra ALB
-# https://github.com/Sage-Bionetworks/data_curator-infra
 
+
+# forward docker.dev.sagebase.org to dev Synapse Docker registry ALB
+# https://github.com/Sage-Bionetworks/synapse-docker-registry
 SynapseDockerRegistryDevDnsForward:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/R53/cname.yaml

--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -224,7 +224,7 @@ GenieBPCProdAppDnsForward:
     TargetHostName: !CopyValue ['genie-bpc-shiny-prod-DockerFargateStack-LoadBalancerDNS', !Ref GenieProdAccount]
 
 
-# forward docker.dev.sagebase.org to dev Synapse Docker registry ALB
+# forward dev-docker-registry.dev.sagebase.org to dev Synapse Docker registry ALB
 # https://github.com/Sage-Bionetworks/synapse-docker-registry
 SynapseDockerRegistryDevDnsForward:
   Type: update-stacks
@@ -236,7 +236,7 @@ SynapseDockerRegistryDevDnsForward:
     Account: !Ref SynapseDevAccount
   Parameters:
     # the name of the CNAME record
-    SourceHostName: "docker.dev.sagebase.org"
+    SourceHostName: "dev-docker-registry.dev.sagebase.org"
     # ID of the dev.sagebase.org zone (in Synapse dev account)
     SourceHostedZoneId: Z28CDXGXBHW4TT
     # the value of the CNAME record

--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -222,3 +222,22 @@ GenieBPCProdAppDnsForward:
     SourceHostedZoneId: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sagebio-app-zone-HostedZoneId']
     # the value of the CNAME record
     TargetHostName: !CopyValue ['genie-bpc-shiny-prod-DockerFargateStack-LoadBalancerDNS', !Ref GenieProdAccount]
+# forward dca-dev.app.sagebionetworks.org to data_curator-infra ALB
+# https://github.com/Sage-Bionetworks/data_curator-infra
+
+SynapseDockerRegistryDevDnsForward:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/R53/cname.yaml
+  StackName: !Sub '${resourcePrefix}-synapse-docker-registry-dev-cname'
+  StackDescription: Setup a CNAME for synapse-docker-registry dev ALB
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref SageITAccount
+  Parameters:
+    # the name of the CNAME record
+    SourceHostName: "docker.dev.sagebase.org"
+    # ID of the dev.sagebase.org zone (in Synapse dev account)
+    SourceHostedZoneId: Z28CDXGXBHW4TT
+    # the value of the CNAME record
+    TargetHostName: !CopyValue ['registry-dev-DockerFargateStack-LoadBalancerDNS', !Ref SynapseDevAccount]
+  

--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -232,7 +232,7 @@ SynapseDockerRegistryDevDnsForward:
   StackDescription: Setup a CNAME for synapse-docker-registry dev ALB
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
-    Account: !Ref SageITAccount
+    Account: !Ref SynapseDevAccount
   Parameters:
     # the name of the CNAME record
     SourceHostName: "docker.dev.sagebase.org"
@@ -240,4 +240,3 @@ SynapseDockerRegistryDevDnsForward:
     SourceHostedZoneId: Z28CDXGXBHW4TT
     # the value of the CNAME record
     TargetHostName: !CopyValue ['registry-dev-DockerFargateStack-LoadBalancerDNS', !Ref SynapseDevAccount]
-  


### PR DESCRIPTION
Following [this](https://sagebionetworks.jira.com/wiki/spaces/IT/pages/2859302913/Admin+Tasks+for+CDK+Applications) guidance, we add the CNAME `docker.dev.sagebase.org` to direct traffic to the dev' Synapse Docker Registry.