### PR TITLE
Update lambda-bucket-cleanup version

### DIFF
--- a/sceptre/scipool/config/bmgfki/lambda-bucket-cleanup.yaml
+++ b/sceptre/scipool/config/bmgfki/lambda-bucket-cleanup.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.2/lambda-sc-bucket-cleanup.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.3/lambda-sc-bucket-cleanup.yaml
 stack_name: lambda-sc-bucket-cleanup
 parameters:
   EnableSchedule: "true"

--- a/sceptre/scipool/config/develop/lambda-bucket-cleanup.yaml
+++ b/sceptre/scipool/config/develop/lambda-bucket-cleanup.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.2/lambda-sc-bucket-cleanup.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.3/lambda-sc-bucket-cleanup.yaml
 stack_name: lambda-sc-bucket-cleanup
 parameters:
   ArchivedPeriod: "2"

--- a/sceptre/scipool/config/prod/lambda-bucket-cleanup.yaml
+++ b/sceptre/scipool/config/prod/lambda-bucket-cleanup.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.2/lambda-sc-bucket-cleanup.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.3/lambda-sc-bucket-cleanup.yaml
 stack_name: lambda-sc-bucket-cleanup
 parameters:
   EnableSchedule: "true"

--- a/sceptre/scipool/config/strides/lambda-bucket-cleanup.yaml
+++ b/sceptre/scipool/config/strides/lambda-bucket-cleanup.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.2/lambda-sc-bucket-cleanup.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-sc-bucket-cleanup/1.0.3/lambda-sc-bucket-cleanup.yaml
 stack_name: lambda-sc-bucket-cleanup
 parameters:
   EnableSchedule: "true"


### PR DESCRIPTION
Version 1.0.3 includes an update from python 3.8 to python 3.11

depends on https://github.com/Sage-Bionetworks-IT/lambda-sc-bucket-cleanup/pull/13

