### PR TITLE
IT-3988: Add permission to create object in S3

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -641,6 +641,18 @@ SsoLlmDeveloper:
     managedPolicies:
       - 'arn:aws:iam::aws:policy/AmazonBedrockFullAccess'
       - 'arn:aws:iam::aws:policy/AWSCloudFormationFullAccess'
+#   https://stackoverflow.com/questions/58125181/cloud-formation-cant-upload-template-file
+    inlinePolicy: >-
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Effect": "Allow",
+                  "Action": "s3:PutObject",
+                  "Resource": "arn:aws:s3:::cf-template*"
+              }
+          ]
+      }
     sessionDuration: 'PT12H'
 
 # Role for a user that can only access AWS Athena in the Synapse Dev account


### PR DESCRIPTION
This PR adds a in-line policy to LLMDeveloper role that gives the permission to create objects in S3 (upload templates).
