### PR TITLE
IT-3988: Widen permissions

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -648,7 +648,7 @@ SsoLlmDeveloper:
           "Statement": [
               {
                   "Effect": "Allow",
-                  "Action": "s3:PutObject",
+                  "Action": "s3:*",
                   "Resource": "arn:aws:s3:::cf-template*"
               }
           ]


### PR DESCRIPTION
The putObject permission was not enough, widen to allow any action but still restrict object prefix.
