### PR TITLE
Point to schematic staging (Replace)

### DIFF
--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -153,10 +153,10 @@ SchematicDevAppDnsForward:
 
 # forward schematic-staging.api.sagebionetworks.org to schematic-infra ALB
 # https://github.com/Sage-Bionetworks-IT/schematic-infra-v2
-SchematicStageAppDnsForward:
+SchematicStagingAppDnsForward:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/R53/cname.yaml
-  StackName: !Sub '${resourcePrefix}-schematic-stage-cname'
+  StackName: !Sub '${resourcePrefix}-schematic-staging-cname'
   StackDescription: Setup a CNAME for schematic-infra stage ALB
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:

--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -134,7 +134,7 @@ DcaProdAppDnsForward:
 # *.api.sagebionetworks.org
 
 # forward schematic-dev.api.sagebionetworks.org to schematic-infra ALB
-# https://github.com/Sage-Bionetworks/schematic-infra
+# https://github.com/Sage-Bionetworks-IT/schematic-infra-v2
 SchematicDevAppDnsForward:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/R53/cname.yaml
@@ -152,25 +152,7 @@ SchematicDevAppDnsForward:
     TargetHostName: !CopyValue ['schematic-dev-load-balancer-dns', !Ref DnTDevAccount]
 
 # forward schematic-staging.api.sagebionetworks.org to schematic-infra ALB
-# https://github.com/Sage-Bionetworks/schematic-infra
-SchematicStagingAppDnsForward:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/R53/cname.yaml
-  StackName: !Sub '${resourcePrefix}-schematic-staging-cname'
-  StackDescription: Setup a CNAME for schematic-infra staging ALB
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    Account: !Ref SageITAccount
-  Parameters:
-    # the name of the CNAME record
-    SourceHostName: "schematic-staging.api.sagebionetworks.org"
-    # ID of the api.sagebionetworks.org zone (in sageit account)
-    SourceHostedZoneId: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sagebio-api-zone-HostedZoneId']
-    # the value of the CNAME record
-    TargetHostName: !CopyValue ['schematic-stage-staging-DockerFargateStack-LoadBalancerDNS', !Ref DCAProdAccount]
-
-# forward schematic-staging.api.sagebionetworks.org to schematic-infra ALB
-# https://github.com/Sage-Bionetworks/schematic-infra
+# https://github.com/Sage-Bionetworks-IT/schematic-infra-v2
 SchematicStageAppDnsForward:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/R53/cname.yaml
@@ -181,7 +163,7 @@ SchematicStageAppDnsForward:
     Account: !Ref SageITAccount
   Parameters:
     # the name of the CNAME record
-    SourceHostName: "schematic-stage.api.sagebionetworks.org"
+    SourceHostName: "schematic-staging.api.sagebionetworks.org"
     # ID of the api.sagebionetworks.org zone (in sageit account)
     SourceHostedZoneId: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sagebio-api-zone-HostedZoneId']
     # the value of the CNAME record


### PR DESCRIPTION
Deployment of https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/1290/files failed: https://github.com/Sage-Bionetworks-IT/organizations-infra/actions/runs/11919331993/job/33218806052

Due to:
```
 DEBG: Stack sagebase-schematic-stage-cname in account 797640923903 (us-east-1) update starting... (797640923903 = SageITAccount)
ERROR: error updating CloudFormation stack sagebase-schematic-stage-cname in account 797640923903 (us-east-1). 
Resource is not in the state stackUpdateComplete (797640923903 = SageITAccount)
ERROR: Resource DnsRecord failed because [Tried to create resource record set [name='schematic-staging.api.sagebionetworks.org.', type='CNAME'] but it already exists].
ERROR: Stack sagebase-schematic-stage-cname in account 797640923903 (us-east-1) update failed. reason: Resource is not in the state stackUpdateComplete (797640923903 = SageITAccount)
Resource is not in the state stackUpdateComplete
```

I suspect because we're replacing a DNS record with a new stack. Instead, this change should point to the existing stack to update it's values with the new ALB. It should also destroy the "stage" stack DNS forwarding config.