### PR TITLE
IT-4016/IT-4017: Give PowerUser permissions and scale down later

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -644,6 +644,17 @@ SsoLlmDeveloper:
     permissionSetName: 'LlmDeveloper'
     managedPolicies:
       - 'arn:aws:iam::aws:policy/PowerUserAccess'
+    inlinePolicy: >-
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Effect": "Deny",
+                  "Action": "sts:AssumeRole",
+                  "Resource": "*"
+              }
+          ]
+      }
     sessionDuration: 'PT12H'
 
 # Role for a user that can only access AWS Athena in the Synapse Dev account

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -643,8 +643,7 @@ SsoLlmDeveloper:
     principalId: !Ref llmDeveloperGroup
     permissionSetName: 'LlmDeveloper'
     managedPolicies:
-      - 'arn:aws:iam::aws:policy/AmazonBedrockFullAccess'
-      - 'arn:aws:iam::aws:policy/AWSCloudFormationFullAccess'
+      - 'arn:aws:iam::aws:policy/PowerUserAccess'
     sessionDuration: 'PT12H'
 
 # Role for a user that can only access AWS Athena in the Synapse Dev account


### PR DESCRIPTION
As LLM developers are using features in the console, we'll keep getting permission errors. After discussion with John, we decided to up to PowerUserAccess, then track and scale down. We may still have to adjust IAM permissions if/as needed.
