### PR TITLE
Agora redirect dns name change

### DIFF
--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -310,7 +310,7 @@ AgoraDevAppDnsForward:
     Account: !Ref SageITAccount
   Parameters:
     # the name of the CNAME record
-    SourceHostName: "agora.dev.adknowledgeportal.org"
+    SourceHostName: "newagora-dev.adknowledgeportal.org"
     # ID of the adknowledgeportal.org zone (in sageit account)
     SourceHostedZoneId: "Z2DTJC6JTFRHBN"
     # the value of the CNAME record
@@ -328,7 +328,7 @@ AgoraStageAppDnsForward:
     Account: !Ref SageITAccount
   Parameters:
     # the name of the CNAME record
-    SourceHostName: "agora.stage.adknowledgeportal.org"
+    SourceHostName: "newagora-stage.adknowledgeportal.org"
     # ID of the adknowledgeportal.org zone (in sageit account)
     SourceHostedZoneId: "Z2DTJC6JTFRHBN"
     # the value of the CNAME record
@@ -346,7 +346,7 @@ AgoraProdAppDnsForward:
     Account: !Ref SageITAccount
   Parameters:
     # the name of the CNAME record
-    SourceHostName: "agora.prod.adknowledgeportal.org"
+    SourceHostName: "newagora-prod.adknowledgeportal.org"
     # ID of the adknowledgeportal.org zone (in sageit account)
     SourceHostedZoneId: "Z2DTJC6JTFRHBN"
     # the value of the CNAME record


### PR DESCRIPTION
The certificate used for agora is validated for adknowledgeportal.org domain not the dev, stage, and prod sub domains therefore we can't use sub domains unless we redo the certificate.  for simplicity we rename to not use sub domains.


