### PR TITLE
[IT-4025] Remove github OIDC for schematic

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -100,28 +100,6 @@ GithubOidcSageBionetworksDataCuratorInfra:
       - !Ref DCAProdAccount
     Region: us-east-1
 
-GithubOidcSageBionetworksSchematicInfra:
-  Type: update-stacks
-  DependsOn: GithubOidcSageBionetworks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
-  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-schematic-infra
-  Parameters:
-    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-schematic-infra
-    ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AdministratorAccess"
-      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
-  TemplatingContext:
-    GitHubOrg: "Sage-Bionetworks"
-    Repositories:
-      - name: "schematic-infra"
-        branches: ["*"]
-  DefaultOrganizationBinding:
-    Account:
-      - !Ref DnTDevAccount
-      - !Ref DCAProdAccount
-    Region: us-east-1
-
 GithubOidcSageBionetworksItSchematicInfraV2:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks


### PR DESCRIPTION
Schematic was updated with a new deployment "GithubOidcSageBionetworksItSchematicInfraV2", therefore we can remove the old deployment OIDC resource.
