### PR TITLE
IT-4077 Add suppression rules for cis-aws-foundations-benchmark/v/1.4.0

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -364,8 +364,10 @@ Resources:
           findings:
             GeneratorId:
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/4.3'
+              - 'cis-aws-foundations-benchmark/v/1.4.0/5.3' # same as v/1.2.0/rule/4.3
               - 'aws-foundational-security-best-practices/v/1.0.0/EC2.2'
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/1.14'
+              - 'cis-aws-foundations-benchmark/v/1.4.0/1.6' # same as v/1.2.0/rule/1.14
               - 'aws-foundational-security-best-practices/v/1.0.0/IAM.6'
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/2.7'
               - 'cis-aws-foundations-benchmark/v/1.4.0/3.7'

--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -83,7 +83,7 @@ StackArmorAgentInstallation:
       Account: '*'
       IncludeMasterAccount: true
   Parameters:
-    EventBridgeRuleSchedule: "cron(0 * * * ? *)"
+    EventBridgeRuleSchedule: "cron(0 2 * * ? *)"
     TargetRegionIds: "us-east-1"
     TargetTagName: execute-script
     TargetTagValue: install-stack-armor-agent


### PR DESCRIPTION
Add suppression rules for cis-aws-foundations-benchmark/v/1.4.0.
Existing rules were for cis-aws-foundations-benchmark/v/1.2.0 but we've upgraded.
