### PR TITLE
[IT-2431] Require secure access for `ConfigAuditBucket`

### DIFF
--- a/org-formation/080-aws-config-inventory/config.yaml
+++ b/org-formation/080-aws-config-inventory/config.yaml
@@ -67,6 +67,16 @@ Resources:
             Condition:
               StringEquals:
                 's3:x-amz-acl': 'bucket-owner-full-control'
+          - Sid: AWSConfigBucketDenyInsecure
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !Sub '${ConfigAuditBucket.Arn}'
+              - !Sub '${ConfigAuditBucket.Arn}/*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'false'
 
   ConfigurationRecorder:
     Type: 'AWS::Config::ConfigurationRecorder'


### PR DESCRIPTION
Secure the `ConfigAuditBucket` by denying any S3 API calls for the bucket that do not use TLS/HTTPS.

This addresses a Security Hub finding from
`cis-aws-foundations-benchmark/v/1.4.0/2.1.2`.

Ref: https://repost.aws/knowledge-center/s3-bucket-policy-for-config-rule
