### PR TITLE
[IT-2431] Deny insecure access to S3 with an SCP

### DIFF
--- a/org-formation/_scp.yaml
+++ b/org-formation/_scp.yaml
@@ -175,3 +175,20 @@
             Action:
               - organizations:LeaveOrganization
             Resource: "*"
+
+  RequireSecureS3:
+    Type: OC::ORG::ServiceControlPolicy
+    Properties:
+      PolicyName: RequireSecureS3
+      Description: Restrict users from accessing S3 over HTTP
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: DenyInsecureS3
+            Effect: Deny
+            Action:
+              - 's3:*'
+            Resource: '*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': false


### PR DESCRIPTION
Create a service control policy to deny any S3 api calls that don't use a secure transport layer, such as HTTP, effectively forcing HTTPS.

This should address several security findings including IT-2431
