### PR TITLE
IT-4226: Deploy vpce for opensearch in synapseprod

### DIFF
--- a/sceptre/synapseprod/config/prod/synapse-ops-vpc-v2.yaml
+++ b/sceptre/synapseprod/config/prod/synapse-ops-vpc-v2.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.9.1/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.9.2/vpc.yaml
 stack_name: synapse-ops-vpc-v2
 parameters:
   VpcSubnetPrefix: "10.30"

--- a/sceptre/synapseprod/config/prod/synapse-ops-vpc-v2.yaml
+++ b/sceptre/synapseprod/config/prod/synapse-ops-vpc-v2.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.10/vpc.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.9.1/vpc.yaml
 stack_name: synapse-ops-vpc-v2
 parameters:
   VpcSubnetPrefix: "10.30"
@@ -8,3 +8,4 @@ parameters:
   PrivateSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
   PublicSubnetZones: "us-east-1c,us-east-1d,us-east-1e"
   IncludeBastianSecurityGroup: "false"
+  IncludeOpenSearchServerlessEndpoint: "true"


### PR DESCRIPTION
This PR updates the ops VPC in synapseprod to add a vpce for opensearchserverless.
