### PR TITLE
IT-4212: Add permission to call lambda

### DIFF
--- a/org-formation/300-account-defaults/bedrock-agent-role.yaml
+++ b/org-formation/300-account-defaults/bedrock-agent-role.yaml
@@ -27,6 +27,10 @@ Resources:
                 Action: "bedrock:InvokeModel"
                 Resource:
                   - !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/*"
+              - Effect: Allow
+                Action: "lambda:InvokeFunction"
+                Resource:
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*"
 
 Outputs:
   BedrockAgentRoleArn:


### PR DESCRIPTION
This PR adds the permission to call a lambda to the role assumed by the Bedrock agent
