### PR TITLE
[IT-4228] Setup SSO access to AWS codeocean account

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -338,6 +338,10 @@ Parameters:
     Type: String
     Default: '44b8f4c8-9031-7097-01d8-d4e845d7d84d'
 
+  CodeOceanProdAdminGroup:     # JC aws-codeocean-prod-admins
+    Type: String
+    Default: '8408c468-40f1-70e2-f2ca-ec2874400609'
+
   #------------- personal AWS accounts ------------------
   BuA2aDwAdminGroup:             #JC aws-BuA2aDw-admins
     Type: String
@@ -2217,4 +2221,22 @@ SsoOpenchallengesProdAdmin:
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref OpenchallengesProdAdminGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
+
+
+SsoCodeOceanProdAdmin:
+  Type: update-stacks
+  DependsOn: SsoAdministrator
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.11/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-codeocean-prod-admin'
+  StackDescription: 'SSO: admin role used by CodeOcean prod admin group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref OpenChallengesProdAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref CodeOceanProdAdminGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -2235,7 +2235,7 @@ SsoCodeOceanProdAdmin:
     IncludeMasterAccount: true
   OrganizationBindings:
     TargetBinding:
-      Account: !Ref OpenChallengesProdAccount
+      Account: !Ref CodeOceanProdAccount
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref CodeOceanProdAdminGroup


### PR DESCRIPTION
Setup admin access to org-sagebase-codeocean account

depends on https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/1317
