### PR TITLE
IT-4081: suppress cis-aws-foundations-benchmark/v/1.4.0/3.9 since we use GuardDuty to monitor flow logs

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -377,6 +377,8 @@ Resources:
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/4.1'
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/4.2'
               - 'cis-aws-foundations-benchmark/v/1.4.0/3.5'  # (IT-3619) "3.5 Ensure AWS Config is enabled in all regions"
+              # suppress cis-aws-foundations-benchmark/v/1.4.0/3.9 since we use GuardDuty to monitor flow logs:
+              - 'cis-aws-foundations-benchmark/v/1.4.0/3.9'
             Workflow:
               Status:
               - NEW

--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -83,7 +83,7 @@ StackArmorAgentInstallation:
       Account: '*'
       IncludeMasterAccount: true
   Parameters:
-    EventBridgeRuleSchedule: "cron(0 * * * ? *)"
+    EventBridgeRuleSchedule: "cron(0 2 * * ? *)"
     TargetRegionIds: "us-east-1"
     TargetTagName: execute-script
     TargetTagValue: install-stack-armor-agent


### PR DESCRIPTION
suppress cis-aws-foundations-benchmark/v/1.4.0/3.9 since we use GuardDuty to monitor flow logs