### PR TITLE
[IT-3831] Update github OIDC access

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -465,6 +465,8 @@ GithubOidcPackerImageDeploy:
         branches: ["master"]
       - name: "packer-winserver-2022"
         branches: ["master"]
+      - name: "aws-ami-monorepo"
+        branches: ["main"]
   DefaultOrganizationBinding:
     Account: !Ref ImageCentralAccount
     Region: us-east-1


### PR DESCRIPTION
Allow Sage-Bionetworks-IT/aws-ami-monorepo to deploy cloudformation and generate AMI images in the AWS org-sagebase-imagecentral account
