### PR TITLE
[IT-4228] Setup github OIDC access for codeocean-infra

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -1041,3 +1041,24 @@ SynapseMonorepoCloudfrontAccessPolicy:
         ]
       }
     PolicyName: SynapseMonorepoCloudfrontAccessPolicy
+
+GithubOidcSageBionetworksItCodeOceanInfra:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-it-codeocean-infra
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-it-codeocean-infra
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks-IT"
+    Repositories:
+      - name: "codeocean-infra"
+        branches: ["main"]
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref CodeOceanInfraAccount
+    Region: us-east-1

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -1060,5 +1060,5 @@ GithubOidcSageBionetworksItCodeOceanInfra:
         branches: ["main"]
   DefaultOrganizationBinding:
     Account:
-      - !Ref CodeOceanInfraAccount
+      - !Ref CodeOceanProdAccount
     Region: us-east-1


### PR DESCRIPTION
We have setup a SageBionetworks-IT/codeocean-infra[1] repo to deploy the code ocean application to AWS.  This will allow the repo access to deploy resources to the AWS org-sagebase-codeocean-prod account.

[1] https://github.com/Sage-Bionetworks-IT/codeocean-infra
