### PR TITLE
[IT-3831] GH OIDC image builder deployments

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -465,6 +465,26 @@ GithubOidcPackerImageDeploy:
         branches: ["master"]
       - name: "packer-winserver-2022"
         branches: ["master"]
+  DefaultOrganizationBinding:
+    Account: !Ref ImageCentralAccount
+    Region: us-east-1
+
+# GH OIDC for AWS image builder deployments to AWS imagecentral account
+GithubOidcImageBuilderDeploy:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-imagebuilder-deploy
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-imagebuilder-deploy
+    MaxSessionDuration: 7200
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonEC2FullAccess
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks-IT"
+    Repositories:
       - name: "aws-ami-monorepo"
         branches: ["main"]
   DefaultOrganizationBinding:


### PR DESCRIPTION
Instead of piggy backing on a packer role it's probably better to create a separate role for image builder deployments.

