### PR TITLE
[IT-3831] fix GH OIDC permissions for image builder

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -480,8 +480,8 @@ GithubOidcImageBuilderDeploy:
     ProviderRoleName: !Sub ${resourcePrefix}-${appName}-imagebuilder-deploy
     MaxSessionDuration: 7200
     ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/AWSImageBuilderFullAccess
-      - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
   TemplatingContext:
     GitHubOrg: "Sage-Bionetworks-IT"
     Repositories:


### PR DESCRIPTION
The image builder template can do all sorts of things, like create roles.  Therefore we need to up the permission when deploying it to imagecentral.

