### PR TITLE
[IT-4151] Ignore CIS 2.2.1 finding in image-central

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -464,3 +464,35 @@ Resources:
           - SecurityHubFindingsQueue
           - Arn
         Id: Target0
+
+  # This rule suppresses findings in org-sagebase-imagecentral for EBS encryption since the volumes
+  # in this account are used for creating public AMIs
+  SuppressFindingsForPublicImagesRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: SecHubSuppress findings in org-sagebase-imagecentral for EBS encryption
+      EventPattern:
+        detail:
+          findings:
+            Resources:
+              Id:
+                # image-central
+                - 'AWS::::Account:867686887310'
+            GeneratorId:
+              # EBS encryption enabled by default
+              - 'cis-aws-foundations-benchmark/v/1.4.0/2.2.1'
+            Workflow:
+              Status:
+              - NEW
+              - NOTIFIED
+        detail-type:
+        - Security Hub Findings - Imported
+        source:
+        - aws.securityhub
+      State: ENABLED
+      Targets:
+      - Arn:
+          Fn::GetAtt:
+          - SecurityHubFindingsQueue
+          - Arn
+        Id: Target0

--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -470,7 +470,7 @@ Resources:
   SuppressFindingsForPublicImagesRule:
     Type: AWS::Events::Rule
     Properties:
-      Description: SecHubSuppress findings in org-sagebase-imagecentral for EBS encryption
+      Description: SecHubSuppress findings for EBS encryption
       EventPattern:
         detail:
           findings:


### PR DESCRIPTION
Ignore "CIS 2.2.1 Ensure EBS volume encryption is enabled" in the image-central account, we don't want it enabled by default since the volumes in this account are used to create public AMI images.