### PR TITLE
[IT-4055] Remove role for OpenChallenges deployment

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -889,10 +889,9 @@ GithubOidcOpenChallengesDeploy:
     GitHubOrg: "Sage-Bionetworks-IT"
     Repositories:
       - name: "openchallenges"
-        branches: ["dev", "stage", "prod"]
+        branches: ["stage", "prod"]
   DefaultOrganizationBinding:
     Account:
-      - !Ref OpenChallengesDevAccount
       - !Ref OpenChallengesProdAccount
     Region: us-east-1
 


### PR DESCRIPTION
Remove the role to allow GH actions to deploy OpenChallenges
to the org-sagebase-openchallenges-dev AWS account.

