### PR TITLE
[IT-3721] Re-enable VPC flow logs automation

### DIFF
--- a/org-formation/725-vpc-flow-logs/_tasks.yaml
+++ b/org-formation/725-vpc-flow-logs/_tasks.yaml
@@ -20,17 +20,16 @@ VpcFlowLogsBucket:
     LifecycleDataStorageClass: "GLACIER"
     LifecycleDataExpiration: "360"
 
-# temporarily disable due to issue IT-3721
 # Use AWS config to enable VPC flow logs and configure it to send logs to the central S3 bucket
-#AutoEnableVpcFlowLogs:
-#  DependsOn: VpcFlowLogsBucket
-#  Type: update-stacks
-#  Template: aws-config-rule.yaml
-#  StackName: !Sub '${resourcePrefix}-${appName}-remediate'
-#  StackDescription: Use AWS config to automatically enable VPC flow logs
-#  DefaultOrganizationBindingRegion: !Ref primaryRegion
-#  DefaultOrganizationBinding:
-#    IncludeMasterAccount: true
-#    Account: '*'
-#  Parameters:
-#    CentralizedS3LoggingBucket: !CopyValue [!Sub '${resourcePrefix}-${appName}-bucket-BucketName', !Ref LogCentralAccount]
+AutoEnableVpcFlowLogs:
+  DependsOn: VpcFlowLogsBucket
+  Type: update-stacks
+  Template: aws-config-rule.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-remediate'
+  StackDescription: Use AWS config to automatically enable VPC flow logs
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+    Account: '*'
+  Parameters:
+    CentralizedS3LoggingBucket: !CopyValue [!Sub '${resourcePrefix}-${appName}-bucket-BucketName', !Ref LogCentralAccount]


### PR DESCRIPTION
We disabled deployment of VPC config to automate enabling of VPC flow log in commit 110dacee because we got the following error during deployment..

```
Resource handler returned message: "Invalid request provided: NoAvailableConfigurationRecorder"
```

I've noticed that AWS config configuration recorder is now enabled in every account.  I don't know whether AWS changed something in the back end to enable this or whether it just took time for config recorder to establish recordings.

This deployment now works because a configuration recorder has been established all organization accounts.  Now we re-enable the VPC flow log automation which is really just revert of the previous commit to disable the automation.
