### PR TITLE
[IT-4244] update SSO ImageCentralAmiLibrarian policy

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -1100,8 +1100,54 @@ SsoImageCentralAmiLibrarian:
     permissionSetName: 'AMI-Librarian'
     managedPolicies:
       - 'arn:aws:iam::aws:policy/AmazonEC2FullAccess'
-      - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
+      - 'arn:aws:iam::aws:policy/AmazonS3FullAccess'
+      - 'arn:aws:iam::aws:policy/AWSCloudFormationFullAccess'
     sessionDuration: 'PT12H'
+    inlinePolicy: >-
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "InstanceRoleAccess",
+            "Effect": "Allow",
+            "Action": [
+              "iam:CreateRole",
+              "iam:AttachRolePolicy",
+              "iam:DetachRolePolicy",
+              "iam:DeleteRole"
+            ],
+            "Resource": "arn:aws:iam::867686887310:role/executionServiceEC2Role/*"
+          },
+          {
+            "Sid": "InstanceProfileAccess",
+            "Effect": "Allow",
+            "Action": [
+              "iam:AddRoleToInstanceProfile",
+              "iam:CreateInstanceProfile",
+              "iam:GetInstanceProfile",
+              "iam:PassRole",
+              "iam:DeleteInstanceProfile",
+              "iam:GetInstanceProfile",
+              "iam:RemoveRoleFromInstanceProfile"
+            ],
+            "Resource": "*"
+          },
+          {
+            "Sid": "ImageInfrastructureConfigurationAccess",
+            "Effect": "Allow",
+            "Action": [
+              "iam:CreateServiceLinkedRole",
+              "iam:GetInstanceProfile",
+              "iam:GetRole",
+              "iam:PassRole",
+              "sns:Publish",
+              "ecr:BatchGetRepositoryScanningConfiguration",
+              "inspector2:BatchGetAccountStatus"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
 
 SsoBridgeDevAdmin:
   Type: update-stacks


### PR DESCRIPTION
We switch from using packer to using the AWS image builder to build AMIs (in issue IT-3831).  This change requires AMI librarians to have a different set of access to build and deploy AMIs with cloudformation templates.

Note: This new least privileged policy was auto generated using the aws-leastprivilege[1] app.

[1] https://github.com/iann0036/aws-leastprivilege
