### PR TITLE
[IT-4287] Automate SSM patching for all instances in all accounts

### DIFF
--- a/org-formation/090-systems-manager/QuickSetup-PatchPolicy-Prod.yaml
+++ b/org-formation/090-systems-manager/QuickSetup-PatchPolicy-Prod.yaml
@@ -1,0 +1,56 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: An SSM patch policy to patch all instances in the given OUs
+Parameters:
+  TargetOrgUnits:
+    Type: String
+    Description: >-
+      Comma separated list of AWS Organizational Units to target.
+  TargetRegions:
+    Type: String
+    Description: >-
+      Comma separated list of AWS Organizational Units to target.
+Resources:
+  PatchPolicy:
+    Type: "AWS::SSMQuickSetup::ConfigurationManager"
+    Properties:
+      Name: "PatchResourceGroup"
+      Description: "Patch all SSM managed nodes in production accounts"
+      ConfigurationDefinitions:
+        Type: AWSQuickSetupType-PatchPolicy
+        Parameters:
+          PatchPolicyName: PatchPolicy
+          # Patch baselines can be found with the command:
+          #   aws ssm describe-patch-baselines |jq '.BaselineIdentities | map({ (.OperatingSystem): (.value = .BaselineId | .label = .BaselineName | .description = .BaselineDescription | .disabled=false | del(.BaselineId, .BaselineName, .OperatingSystem, .BaselineDescription, .DefaultBaseline)) }) | add'
+          #
+          # More information at:
+          #   https://aws.amazon.com/blogs/mt/deploy-aws-systems-manager-quick-setup-programmatically-across-your-aws-organization/
+          #   https://github.com/aws-samples/aws-management-and-governance-samples/blob/master/AWSSystemsManager/Quick-Setup-API/patch-policy-examples/patch-policy-cfn-template.yaml
+          #   https://github.com/aws-samples/aws-management-and-governance-samples/blob/master/AWSSystemsManager/Quick-Setup-API/patch-policy-examples/default-patch-baselines.txt
+          SelectedPatchBaselines: >-
+            {
+              "ALMA_LINUX": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0cb0c4966f86b059b","label":"AWS-AlmaLinuxDefaultPatchBaseline","description":"Default Patch Baseline for Alma Linux Provided by AWS.","disabled":false},
+              "AMAZON_LINUX": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0c10e657807c7a700","label":"AWS-AmazonLinuxDefaultPatchBaseline","description":"Default Patch Baseline for Amazon Linux Provided by AWS.","disabled":false},
+              "AMAZON_LINUX_2": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0be8c61cde3be63f3","label":"AWS-AmazonLinux2DefaultPatchBaseline","description":"Default Patch Baseline for Amazon Linux 2 Provided by AWS.","disabled":false},
+              "AMAZON_LINUX_2022": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0028ca011460d5eaf","label":"AWS-AmazonLinux2022DefaultPatchBaseline","description":"Default Patch Baseline for Amazon Linux 2022 Provided by AWS.","disabled":false},
+              "AMAZON_LINUX_2023": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-05c9c9bf778d4c4d0","label":"AWS-AmazonLinux2023DefaultPatchBaseline","description":"Default Patch Baseline for Amazon Linux 2023 Provided by AWS.","disabled":false},
+              "CENTOS": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-03e3f588eec25344c","label":"AWS-CentOSDefaultPatchBaseline","description":"Default Patch Baseline for CentOS Provided by AWS.","disabled":false},
+              "DEBIAN": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-09a5f8eb62bde80b1","label":"AWS-DebianDefaultPatchBaseline","description":"Default Patch Baseline for Debian Provided by AWS.","disabled":false},
+              "MACOS": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0ee4f94581368c0d4","label":"AWS-MacOSDefaultPatchBaseline","description":"Default Patch Baseline for MacOS Provided by AWS.","disabled":false}},
+              "ORACLE_LINUX": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-06bff38e95fe85c02","label":"AWS-OracleLinuxDefaultPatchBaseline","description":"Default Patch Baseline for Oracle Linux Server Provided by AWS.","disabled":false},
+              "RASPBIAN": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0ec16280999c5c75e","label":"AWS-RaspbianDefaultPatchBaseline","description":"Default Patch Baseline for Raspbian Provided by AWS.","disabled":false},
+              "REDHAT_ENTERPRISE_LINUX": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0cbb3a633de00f07c","label":"AWS-RedHatDefaultPatchBaseline","description":"Default Patch Baseline for Redhat Enterprise Linux Provided by AWS.","disabled":false},
+              "ROCKY_LINUX": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-03ec98bc512aa3ac0","label":"AWS-RockyLinuxDefaultPatchBaseline","description":"Default Patch Baseline for Rocky Linux Provided by AWS.","disabled":false},
+              "SUSE": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-07d8884178197b66b","label":"AWS-SuseDefaultPatchBaseline","description":"Default Patch Baseline for Suse Provided by AWS.","disabled":false},
+              "UBUNTU": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0c7e89f711c3095f4","label":"AWS-UbuntuDefaultPatchBaseline","description":"Default Patch Baseline for Ubuntu Provided by AWS.","disabled":false},
+              "WINDOWS": {"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0fafa8379afee7c83","label":"AWS-WindowsPredefinedPatchBaseline-OS-Applications","description":"For the Windows Server operating system, approves all patches that are classified as CriticalUpdates or SecurityUpdates and that have an MSRC severity of Critical or Important. For Microsoft applications, approves all patches. Patches are auto-approved seven days after release.","disabled":false}
+            }
+          ConfigurationOptionsPatchOperation: "ScanAndInstall"
+          TargetType: '*'
+          TargetOrganizationalUnits: !Ref TargetOrgUnits
+          TargetRegions: !Ref TargetRegions
+Outputs:
+  PatchPolicyArn:
+    Description: 'Patch policy ARN'
+    Value: !Ref PatchPolicy
+    Export:
+      Name: !Sub '${AWS::StackName}-PatchPolicyArn'

--- a/org-formation/090-systems-manager/QuickSetup-PatchPolicy.yaml
+++ b/org-formation/090-systems-manager/QuickSetup-PatchPolicy.yaml
@@ -14,7 +14,7 @@ Resources:
     Type: "AWS::SSMQuickSetup::ConfigurationManager"
     Properties:
       Name: "PatchResourceGroup"
-      Description: "Patch all SSM managed nodes in all accounts"
+      Description: "Patch all SSM managed nodes"
       ConfigurationDefinitions:
         Type: AWSQuickSetupType-PatchPolicy
         Parameters:

--- a/org-formation/090-systems-manager/QuickSetup-PatchPolicy.yaml
+++ b/org-formation/090-systems-manager/QuickSetup-PatchPolicy.yaml
@@ -14,7 +14,7 @@ Resources:
     Type: "AWS::SSMQuickSetup::ConfigurationManager"
     Properties:
       Name: "PatchResourceGroup"
-      Description: "Patch all SSM managed nodes in production accounts"
+      Description: "Patch all SSM managed nodes in all accounts"
       ConfigurationDefinitions:
         Type: AWSQuickSetupType-PatchPolicy
         Parameters:

--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -61,6 +61,18 @@ PatchMembers:
   Parameters:
     ManagementAccountNumber: !Ref accountId
 
+PatchPolicy:
+  Type: update-stacks
+  Template: QuickSetup-PatchPolicy-Prod.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-patchpolicy'
+  StackDescription: Setup Systems manager patch policy for prod OUs
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref accountId
+  Parameters:
+    TargetOrgUnits: !Ref PlatformOU
+    TargetRegions: !Ref primaryRegion
+
 # This will run the Stack Armor Nessus installation script each day
 # on any EC2 in us-east-1 tagged with execute-script:install-stack-armor-agent
 # Since the script is idempotent, running every day ensures the script

--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -65,12 +65,12 @@ PatchPolicy:
   Type: update-stacks
   Template: QuickSetup-PatchPolicy.yaml
   StackName: !Sub '${resourcePrefix}-${appName}-patchpolicy'
-  StackDescription: Setup Systems manager patch policy for prod OUs
+  StackDescription: Setup Systems manager patch policy for the entire Org
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
     Account: !Ref accountId
   Parameters:
-    TargetOrgUnits: !Ref PlatformOU
+    TargetOrgUnits: !Ref OrganizationRoot
     TargetRegions: !Ref primaryRegion
 
 # This will run the Stack Armor Nessus installation script each day

--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -63,7 +63,7 @@ PatchMembers:
 
 PatchPolicy:
   Type: update-stacks
-  Template: QuickSetup-PatchPolicy-Prod.yaml
+  Template: QuickSetup-PatchPolicy.yaml
   StackName: !Sub '${resourcePrefix}-${appName}-patchpolicy'
   StackDescription: Setup Systems manager patch policy for prod OUs
   DefaultOrganizationBindingRegion: !Ref primaryRegion


### PR DESCRIPTION
Use SSM Quick Setup to create a Patch Policy that applies to all managed nodes in the Platform organizational unit (Synapse accounts and Bridge accounts).

User Guide:
https://docs.aws.amazon.com/systems-manager/latest/userguide/quick-setup-patch-manager.html 

AWS Blog:
https://aws.amazon.com/blogs/mt/deploy-aws-systems-manager-quick-setup-programmatically-across-your-aws-organization/

Examples:
https://github.com/aws-samples/aws-management-and-governance-samples/blob/master/AWSSystemsManager/Quick-Setup-API/patch-policy-examples/patch-policy-cfn-template.yaml
https://github.com/aws-samples/aws-management-and-governance-samples/blob/master/AWSSystemsManager/Quick-Setup-API/patch-policy-examples/default-patch-baselines.txt

