### PR TITLE
IT-4204: Add IAM permission boundary for synapse llm lambda exec role

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -417,3 +417,26 @@ SynapseLlmDeveloperPolicy:
         ]
       }
     PolicyName: SynapseLlmDeveloperPolicy
+
+SynapseLlmLambdaExecRoleBoundary:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.1/templates/IAM/managed-policy.yaml
+  StackName: synllm-lambdaexecrole-boundary
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+    Account:
+      - !Ref SynapseLlmProdAccount
+    Region: !Ref primaryRegion
+  Parameters:
+    PolicyDocument: >-
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": ["logs:*", "bedrock:*" ],
+            "Resource": "*"
+          }
+        ]
+      }
+    PolicyName: SynLlmLambdaExecRoleBoundary


### PR DESCRIPTION
This PR creates a managed policy that's going to be used as an IAM permission boundary. The boundary will be associated with roles created by LLM developers, the roles are assumed by lambda functions.

See https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
and https://aws.amazon.com/blogs/security/when-and-where-to-use-iam-permissions-boundaries/

Note: only put minimal boundary here