### PR TITLE
IT-4204: Add IAM permissions to llm dev role

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -413,6 +413,40 @@ SynapseLlmDeveloperPolicy:
             "Effect": "Allow",
             "Action": "iam:PassRole",
             "Resource": "*"
+          },
+          {
+            "Effect": "Allow",
+            "Action": [
+              "iam:CreateRole",
+              "iam:PutRolePermissionsBoundary"
+            ],
+            "Resource": "arn:aws:iam::${AWS::AccountId}:role/synllmrole-*",
+            "Condition": {
+              "StringEquals": {
+                "iam:PermissionsBoundary": "${synLlmLambdaExecPermissionBoundary}"
+              }
+            }
+          },
+          {
+            "Effect": "Allow",
+            "Action": [
+              "iam:UpdateRole",
+              "iam:DeleteRole",
+              "iam:AttachRolePolicy",
+              "iam:DetachRolePolicy"
+            ],
+            "Resource": "arn:aws:iam::${AWS::AccountId}:role/synllmrole-*"
+          },
+          {
+            "Effect": "Allow",
+            "Action": [
+              "iam:CreatePolicy",
+              "iam:DeletePolicy",
+              "iam:CreatePolicyVersion",
+              "iam:SetDefaultPolicyVersion",
+              "iam:DeletePolicyVersion"
+            ],
+            "Resource": "arn:aws:iam::${AWS::AccountId}:policy/synllmpol-*"
           }
         ]
       }


### PR DESCRIPTION
This PR adds IAM permissions to create roles and policies to the LLM developer role.
Depends on #1336 to be deployed.
