### PR TITLE
Add oidc perms for standards portal

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -944,7 +944,9 @@ SynapseMonorepoBucketAccessPolicy:
                             "arn:aws:s3:::prod.psychencode.synapse.org",
                             "arn:aws:s3:::staging.psychencode.synapse.org",
                             "arn:aws:s3:::stopadportal.synapse.org",
-                            "arn:aws:s3:::staging.stopadportal.synapse.org"
+                            "arn:aws:s3:::staging.stopadportal.synapse.org",
+                            "arn:aws:s3:::prod.standards.synapse.org",
+                            "arn:aws:s3:::staging.standards.synapse.org"
                           ]
           }
         ]
@@ -995,7 +997,9 @@ SynapseMonorepoFileAccessPolicy:
                             "arn:aws:s3:::prod.psychencode.synapse.org/*",
                             "arn:aws:s3:::staging.psychencode.synapse.org/*",
                             "arn:aws:s3:::stopadportal.synapse.org/*",
-                            "arn:aws:s3:::staging.stopadportal.synapse.org/*"
+                            "arn:aws:s3:::staging.stopadportal.synapse.org/*",
+                            "arn:aws:s3:::prod.standards.synapse.org/*",
+                            "arn:aws:s3:::staging.standards.synapse.org/*"
                           ]
           }
         ]
@@ -1054,7 +1058,9 @@ SynapseMonorepoCloudfrontAccessPolicy:
                             "arn:aws:cloudfront::797640923903:distribution/E14QCZ9L4VTPMD",
                             "arn:aws:cloudfront::797640923903:distribution/ESC37TT819LAK",
                             "arn:aws:cloudfront::797640923903:distribution/E1QXK5X5JV0YKJ",
-                            "arn:aws:cloudfront::797640923903:distribution/E7COI4Z95FFZQ"
+                            "arn:aws:cloudfront::797640923903:distribution/E7COI4Z95FFZQ",
+                            "arn:aws:cloudfront::797640923903:distribution/E1TUIXZC1K5CUN",
+                            "arn:aws:cloudfront::797640923903:distribution/EZWEDLI9NN764"
                           ]
           }
         ]


### PR DESCRIPTION
This PR adds the S3 buckets and distributions for the 'standards' portal to the synapse-monorepo's OIDC deployment role 
