### PR TITLE
debug: add output to CDK template generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "ci-perform-tasks-parallel": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 10 --max-concurrent-tasks 10 --perform-cleanup",
     "validate-tasks": "npx org-formation validate-tasks ./org-formation/_tasks.yaml --verbose --print-stack --failed-tasks-tolerance 0  --max-concurrent-stacks 100 --max-concurrent-tasks 100",
     "cfn-lint": "cfn-lint ./.printed-stacks/**/*.yaml -i W2001,E3001,E1019,W1020,W2509,E3021",
-    "generate-cdk-bootstrap-template": "npx cdk bootstrap --json --show-template > org-formation/200-baseline/tmptemplate.json",
-    "patch-cdk-bootstrap-template": "jq '.Resources.FileAssetsBucketEncryptionKey.Properties += {\"EnableKeyRotation\" :true}' org-formation/200-baseline/tmptemplate.json > org-formation/200-baseline/cdk-bootstrap.json"
+    "generate-cdk-bootstrap-template": "npx cdk bootstrap --json --show-template > org-formation/200-baseline/tmptemplate.json && cat org-formation/200-baseline/tmptemplate.json",
+    "patch-cdk-bootstrap-template": "jq '.Resources.FileAssetsBucketEncryptionKey.Properties += {\"EnableKeyRotation\" :true}' org-formation/200-baseline/tmptemplate.json > org-formation/200-baseline/cdk-bootstrap.json && cat org-formation/200-baseline/cdk-bootstrap.json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Attempt to debug an issue in the deploy pipeline by printing the contents of the auto-generated CDK bootstrap template.