### PR TITLE
bugfix: ignore notices from the CDK CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ci-perform-tasks-parallel": "npx org-formation perform-tasks ./org-formation/_tasks.yaml --verbose --print-stack --max-concurrent-stacks 10 --max-concurrent-tasks 10 --perform-cleanup",
     "validate-tasks": "npx org-formation validate-tasks ./org-formation/_tasks.yaml --verbose --print-stack --failed-tasks-tolerance 0  --max-concurrent-stacks 100 --max-concurrent-tasks 100",
     "cfn-lint": "cfn-lint ./.printed-stacks/**/*.yaml -i W2001,E3001,E1019,W1020,W2509,E3021",
-    "generate-cdk-bootstrap-template": "npx cdk bootstrap --json --show-template > org-formation/200-baseline/tmptemplate.json && cat org-formation/200-baseline/tmptemplate.json",
+    "generate-cdk-bootstrap-template": "npx cdk bootstrap --no-notices --json --show-template > org-formation/200-baseline/tmptemplate.json && cat org-formation/200-baseline/tmptemplate.json",
     "patch-cdk-bootstrap-template": "jq '.Resources.FileAssetsBucketEncryptionKey.Properties += {\"EnableKeyRotation\" :true}' org-formation/200-baseline/tmptemplate.json > org-formation/200-baseline/cdk-bootstrap.json && cat org-formation/200-baseline/cdk-bootstrap.json"
   },
   "repository": {


### PR DESCRIPTION
The deploy pipeline is failing due to jq being unable to parse the output from the CDK CLI. Generating the template locally creates a valid JSON file with 1091 lines and prints a notice to stderr. In the deploy pipeline jq failes to parse line 1093. It seems that in the github-runner environmunt stderr is redirected to stdout, causing the notice to be written to the end of the file.

Disable printing CDK CLI notices in the deploy pipeline.