### PR TITLE
[IT-4190] Suppress security hub rule

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -379,6 +379,7 @@ Resources:
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/4.1'
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/4.2'
               - 'cis-aws-foundations-benchmark/v/1.4.0/3.5'  # (IT-3619) "3.5 Ensure AWS Config is enabled in all regions"
+              - 'cis-aws-foundations-benchmark/v/1.4.0/5.1'  # (IT-4190) "5.1 Ensure no Network ACLs allow ingress from 0.0.0.0/0 to remote server administration ports"
             Workflow:
               Status:
               - NEW


### PR DESCRIPTION
I recommend we suppress this finding:
  5.1 Ensure no Network ACLs allow ingress from 0.0.0.0/0 to remote server administration ports

It’s typically normal to allow NACL ingress from all ports. This is in fact how the default AWS VPC is setup.
I think it’s already cumbersome to configure access in AWS, closing off NACL ports without an explicit reason would just makes it more cumbersome and confusing to configure access to resources.  There is an additional mechanism, security groups, that would need to be setup to allow access to resources.

