### PR TITLE
Allow lambda projects to deploy from "main" branch

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -428,13 +428,13 @@ GithubOidcLambdaTemplateDeploySageIT:
     GitHubOrg: "Sage-Bionetworks-IT"
     Repositories:
       - name: "lambda-*"
-        branches: ["master"]
+        branches: ["master", "main"]
       - name: "cfn-cr-*"
-        branches: ["master"]
+        branches: ["master", "main"]
       - name: "cfn-macro-*"
-        branches: ["master"]
+        branches: ["master", "main"]
       - name: "cfn-*-macro"
-        branches: ["master"]
+        branches: ["master", "main"]
   DefaultOrganizationBinding:
     Account: !Ref AdminCentralAccount
     Region: us-east-1


### PR DESCRIPTION
The HEAD branch of the lambda-template project was changed from "master" to "main" as part of creating lambda-tag-patch-group for IT-3940, which was later deleted.

Allow lambda-template and future projects created from it to assume OIDC roles for deploying from a "main" branch.