### PR TITLE
[IT-4124] Remove service user

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -87,20 +87,6 @@ CnbCIServiceAccount:
       - !Ref CnbAccount
     Region: !Ref primaryRegion
 
-# A service account for https://github.com/Sceptre/sceptre-aws
-SceptreCIServiceAccount:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/IAM/service-account.yaml
-  StackName: sceptre-ci-service-access
-  Parameters:
-    ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/AdministratorAccess
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: false
-    Account:
-      - !Ref SceptreDevAccount
-    Region: us-east-1
-
 DnTDevCIServiceAccounts:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/IAM/service-account.yaml


### PR DESCRIPTION
We switch to using github OIDC so removing the service user.

depends on https://github.com/Sceptre/sceptre-aws/pull/18

