### PR TITLE
[IT-4236] Suppress security hub finding

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -379,6 +379,7 @@ Resources:
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/4.1'
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/4.2'
               - 'cis-aws-foundations-benchmark/v/1.4.0/3.5'  # (IT-3619) "3.5 Ensure AWS Config is enabled in all regions"
+              - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.5.1'  # (IT-4193) "2.1.5.1 S3 Block Public Access setting should be enabled"
             Workflow:
               Status:
               - NEW

--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -379,7 +379,7 @@ Resources:
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/4.1'
               - 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/4.2'
               - 'cis-aws-foundations-benchmark/v/1.4.0/3.5'  # (IT-3619) "3.5 Ensure AWS Config is enabled in all regions"
-              - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.5.1'  # (IT-4193) "2.1.5.1 S3 Block Public Access setting should be enabled"
+              - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.5.1'  # (IT-4236) "2.1.5.1 S3 Block Public Access setting should be enabled"
             Workflow:
               Status:
               - NEW


### PR DESCRIPTION
suppress finding "S3 Block Public Access setting should be enabled at the bucket-level" for all accounts.

We can remediate this check by enabling all those settings however it would mean that all buckets in an AWS account would need to be private.  We have legittimate use case for public buckets in our AWS accounts therefore remediating this check does not make sense.

