### PR TITLE
[IT-3940] Deploy to the root account

### DIFF
--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -68,7 +68,7 @@ PatchPolicy:
   StackDescription: Setup Systems manager patch policy for the entire Org
   DefaultOrganizationBindingRegion: !Ref primaryRegion
   DefaultOrganizationBinding:
-    Account: !Ref accountId
+    Account: !Ref MasterAccount
   Parameters:
     TargetOrgUnits: !Ref OrganizationRoot
     TargetRegions: !Ref primaryRegion


### PR DESCRIPTION
Cloudformation is giving the error "Only the Management Account of an AWS Organization can create and manage Patch Policies configurations" despite the account being registered as a delegated administrator.

Deploy to the organization root account instead of the sysman account.