### PR TITLE
[DPE-1234] Exclude the `synapse-croissant-metadata` as a public S3 bucket

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -423,6 +423,8 @@ Resources:
                 - prefix: 'arn:aws:s3:::mpower.sagebridge.org'
                 - prefix: 'arn:aws:s3:::smart4sure.sagebridge.org'
                 - prefix: 'arn:aws:s3:::parkinsonmpower.org'
+                # See ticket DPE-1234
+                - prefix: 'arn:aws:s3:::synapse-croissant-metadata'
                 # This should only match with 2.1.5.1
                 - 'AWS::::Account:140124849929'
             GeneratorId:


### PR DESCRIPTION
This change adds the public S3 bucket created during https://sagebionetworks.jira.com/browse/DPE-1234 to the list of buckets that is excluded during the scan/flagging process per the comment here: https://github.com/Sage-Bionetworks-Workflows/eks-stack/pull/57#pullrequestreview-2695320548

