### PR TITLE
[IT-4168] Suppress security hub findings

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -423,6 +423,8 @@ Resources:
                 - prefix: 'arn:aws:s3:::mpower.sagebridge.org'
                 - prefix: 'arn:aws:s3:::smart4sure.sagebridge.org'
                 - prefix: 'arn:aws:s3:::parkinsonmpower.org'
+                - prefix: 'arn:aws:s3:::cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz'
+                - prefix: 'arn:aws:s3:::sagebase-rules-microservice-outputbucket-17vzcnk2xnq0'
                 # See ticket DPE-1234
                 - prefix: 'arn:aws:s3:::synapse-croissant-metadata'
                 # This should only match with 2.1.5.1


### PR DESCRIPTION
The buckets arn:aws:s3:::cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz and arn:aws:s3:::sagebase-rules-microservice-outputbucket-17vzcnk2xnq0 should be public.

