### PR TITLE
[IT-4100] Resolve security hub finding 2.1.5.2

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -434,6 +434,7 @@ Resources:
                 - prefix: 'arn:aws:s3:::org-sagebridge-truststore'
                 - prefix: 'arn:aws:s3:::org-sagebridge-ui-test'
                 - prefix: 'arn:aws:s3:::web-mpower-2'
+                - prefix: 'arn:aws:s3:::sage-igenomes'
                 # See ticket DPE-1234
                 - prefix: 'arn:aws:s3:::synapse-croissant-metadata'
                 # This should only match with 2.1.5.1


### PR DESCRIPTION
The arn:aws:s3:::sage-igenomes bucket should be public

