### PR TITLE
[IT-4287] Use SSM QuickSetup to create a Patch Policy

### DIFF
--- a/org-formation/090-systems-manager/QuickSetup-PatchPolicy.yaml
+++ b/org-formation/090-systems-manager/QuickSetup-PatchPolicy.yaml
@@ -1,15 +1,46 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: An SSM patch policy to patch all instances in the given OUs
 Parameters:
-  TargetOrgUnits:
+  TargetOrgRoot:
     Type: String
     Description: >-
-      Comma separated list of AWS Organizational Units to target.
+      AWS Organization root ID to target.
   TargetRegions:
     Type: String
     Description: >-
-      Comma separated list of AWS Organizational Units to target.
+      Comma separated list of AWS regions to target.
 Resources:
+  PatchLogBucket:
+    Type: "AWS::S3::Bucket"
+    Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+  PatchLogBucketPolicy:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref PatchLogBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          # All member accounts need write access to this bucket
+          - Effect: Allow
+            Principal: '*'
+            Action:
+              - 's3:Get*'
+              - 's3:List*'
+              - 's3:Put*'
+            Resource:
+              - !Sub '${PatchLogBucket.Arn}'
+              - !Sub '${PatchLogBucket.Arn}/*'
+            Condition:
+              # require an account principal associated with our Org
+              StringEquals:
+                "aws:PrincipalOrgID": !Ref TargetOrgRoot
+              ArnLike:
+                "aws:PrincipalArn": "arn:aws:iam::*:root"
   PatchPolicy:
     Type: "AWS::SSMQuickSetup::ConfigurationManager"
     Properties:
@@ -17,8 +48,10 @@ Resources:
       Description: "Patch all SSM managed nodes"
       ConfigurationDefinitions:
       - Type: AWSQuickSetupType-PatchPolicy
+        LocalDeploymentExecutionRoleName: AWS-QuickSetup-StackSet-Local-ExecutionRole
+        LocalDeploymentAdministrationRoleArn: "arn:aws:iam::531805629419:role/AWS-QuickSetup-PatchPolicy-LocalAdministrationRole"
         Parameters:
-          PatchPolicyName: PatchPolicy
+          PatchPolicyName: PatchPolicyAll
           # Patch baselines can be found with the command:
           #   aws ssm describe-patch-baselines |jq '.BaselineIdentities | map({ (.OperatingSystem): (.value = .BaselineId | .label = .BaselineName | .description = .BaselineDescription | .disabled=false | del(.BaselineId, .BaselineName, .OperatingSystem, .BaselineDescription, .DefaultBaseline)) }) | add'
           #
@@ -26,6 +59,12 @@ Resources:
           #   https://aws.amazon.com/blogs/mt/deploy-aws-systems-manager-quick-setup-programmatically-across-your-aws-organization/
           #   https://github.com/aws-samples/aws-management-and-governance-samples/blob/master/AWSSystemsManager/Quick-Setup-API/patch-policy-examples/patch-policy-cfn-template.yaml
           #   https://github.com/aws-samples/aws-management-and-governance-samples/blob/master/AWSSystemsManager/Quick-Setup-API/patch-policy-examples/default-patch-baselines.txt
+          ConfigurationOptionsPatchOperation: "ScanAndInstall"
+          ConfigurationOptionsScanValue: "cron(0 17 ? * * *)"  # 10am PST
+          ConfigurationOptionsInstallValue: "cron(0 19 ? * WED *)"  # 12pm PST
+          OutputLogEnableS3: true
+          OutputS3BucketName: !Ref PatchLogBucket
+          OutputBucketRegion: !Ref "AWS::Region"
           PatchBaselineRegion: 'us-east-1'
           SelectedPatchBaselines: '{"ALMA_LINUX":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0cb0c4966f86b059b","label":"AWS-AlmaLinuxDefaultPatchBaseline","description":"Default
             Patch Baseline for Alma Linux Provided by AWS.","disabled":false},"AMAZON_LINUX":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0c10e657807c7a700","label":"AWS-AmazonLinuxDefaultPatchBaseline","description":"Default
@@ -42,13 +81,12 @@ Resources:
             Patch Baseline for Rocky Linux Provided by AWS.","disabled":false},"SUSE":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-07d8884178197b66b","label":"AWS-SuseDefaultPatchBaseline","description":"Default
             Patch Baseline for Suse Provided by AWS.","disabled":false},"UBUNTU":{"value":"pb-06e3563bd35503f2b","label":"custom-UbuntuServer-Blog-Baseline","description":"Default
             Patch Baseline for Ubuntu Provided by AWS.","disabled":false},"WINDOWS":{"value":"pb-016889927b2bb8542","label":"custom-WindowsServer-Blog-Baseline","disabled":false}}'
-          ConfigurationOptionsPatchOperation: "ScanAndInstall"
           TargetType: '*'
-          TargetOrganizationalUnits: !Ref TargetOrgUnits
+          TargetOrganizationalRoot: !Ref TargetOrgRoot
           TargetRegions: !Ref TargetRegions
 Outputs:
   PatchPolicyArn:
     Description: 'Patch policy ARN'
-    Value: !Ref PatchPolicy
+    Value: !Ref PatchPolicyAll
     Export:
       Name: !Sub '${AWS::StackName}-PatchPolicyArn'

--- a/org-formation/090-systems-manager/QuickSetup-PatchPolicy.yaml
+++ b/org-formation/090-systems-manager/QuickSetup-PatchPolicy.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: An SSM patch policy to patch all instances in the given OUs
+Description: An SSM patch policy to patch all instances in the given AWS Organization
 Parameters:
   TargetOrgRoot:
     Type: String
@@ -10,7 +10,7 @@ Parameters:
     Description: >-
       Comma separated list of AWS regions to target.
 Resources:
-  PatchLogBucket:
+  QuickSetupPatchLogBucket:
     Type: "AWS::S3::Bucket"
     Properties:
       PublicAccessBlockConfiguration:
@@ -18,10 +18,10 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-  PatchLogBucketPolicy:
+  QuickSetupPatchLogBucketPolicy:
     Type: 'AWS::S3::BucketPolicy'
     Properties:
-      Bucket: !Ref PatchLogBucket
+      Bucket: !Ref QuickSetupPatchLogBucket
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -33,15 +33,15 @@ Resources:
               - 's3:List*'
               - 's3:Put*'
             Resource:
-              - !Sub '${PatchLogBucket.Arn}'
-              - !Sub '${PatchLogBucket.Arn}/*'
+              - !Sub '${QuickSetupPatchLogBucket.Arn}'
+              - !Sub '${QuickSetupPatchLogBucket.Arn}/*'
             Condition:
               # require an account principal associated with our Org
               StringEquals:
                 "aws:PrincipalOrgID": !Ref TargetOrgRoot
               ArnLike:
                 "aws:PrincipalArn": "arn:aws:iam::*:root"
-  PatchPolicy:
+  QuickSetupPatchPolicy:
     Type: "AWS::SSMQuickSetup::ConfigurationManager"
     Properties:
       Name: "PatchResourceGroup"
@@ -63,7 +63,7 @@ Resources:
           ConfigurationOptionsScanValue: "cron(0 17 ? * * *)"  # 10am PST
           ConfigurationOptionsInstallValue: "cron(0 19 ? * WED *)"  # 12pm PST
           OutputLogEnableS3: true
-          OutputS3BucketName: !Ref PatchLogBucket
+          OutputS3BucketName: !Ref QuickSetupPatchLogBucket
           OutputBucketRegion: !Ref "AWS::Region"
           PatchBaselineRegion: 'us-east-1'
           SelectedPatchBaselines: '{"ALMA_LINUX":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0cb0c4966f86b059b","label":"AWS-AlmaLinuxDefaultPatchBaseline","description":"Default
@@ -81,12 +81,13 @@ Resources:
             Patch Baseline for Rocky Linux Provided by AWS.","disabled":false},"SUSE":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-07d8884178197b66b","label":"AWS-SuseDefaultPatchBaseline","description":"Default
             Patch Baseline for Suse Provided by AWS.","disabled":false},"UBUNTU":{"value":"pb-06e3563bd35503f2b","label":"custom-UbuntuServer-Blog-Baseline","description":"Default
             Patch Baseline for Ubuntu Provided by AWS.","disabled":false},"WINDOWS":{"value":"pb-016889927b2bb8542","label":"custom-WindowsServer-Blog-Baseline","disabled":false}}'
+          RebootOption: 'NoReboot'
           TargetType: '*'
           TargetOrganizationalRoot: !Ref TargetOrgRoot
           TargetRegions: !Ref TargetRegions
 Outputs:
   PatchPolicyArn:
     Description: 'Patch policy ARN'
-    Value: !Ref PatchPolicyAll
+    Value: !Ref QuickSetupPatchPolicy
     Export:
       Name: !Sub '${AWS::StackName}-PatchPolicyArn'

--- a/org-formation/090-systems-manager/QuickSetup-PatchPolicy.yaml
+++ b/org-formation/090-systems-manager/QuickSetup-PatchPolicy.yaml
@@ -1,0 +1,54 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: An SSM patch policy to patch all instances in the given OUs
+Parameters:
+  TargetOrgUnits:
+    Type: String
+    Description: >-
+      Comma separated list of AWS Organizational Units to target.
+  TargetRegions:
+    Type: String
+    Description: >-
+      Comma separated list of AWS Organizational Units to target.
+Resources:
+  PatchPolicy:
+    Type: "AWS::SSMQuickSetup::ConfigurationManager"
+    Properties:
+      Name: "PatchResourceGroup"
+      Description: "Patch all SSM managed nodes"
+      ConfigurationDefinitions:
+      - Type: AWSQuickSetupType-PatchPolicy
+        Parameters:
+          PatchPolicyName: PatchPolicy
+          # Patch baselines can be found with the command:
+          #   aws ssm describe-patch-baselines |jq '.BaselineIdentities | map({ (.OperatingSystem): (.value = .BaselineId | .label = .BaselineName | .description = .BaselineDescription | .disabled=false | del(.BaselineId, .BaselineName, .OperatingSystem, .BaselineDescription, .DefaultBaseline)) }) | add'
+          #
+          # More information at:
+          #   https://aws.amazon.com/blogs/mt/deploy-aws-systems-manager-quick-setup-programmatically-across-your-aws-organization/
+          #   https://github.com/aws-samples/aws-management-and-governance-samples/blob/master/AWSSystemsManager/Quick-Setup-API/patch-policy-examples/patch-policy-cfn-template.yaml
+          #   https://github.com/aws-samples/aws-management-and-governance-samples/blob/master/AWSSystemsManager/Quick-Setup-API/patch-policy-examples/default-patch-baselines.txt
+          PatchBaselineRegion: 'us-east-1'
+          SelectedPatchBaselines: '{"ALMA_LINUX":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0cb0c4966f86b059b","label":"AWS-AlmaLinuxDefaultPatchBaseline","description":"Default
+            Patch Baseline for Alma Linux Provided by AWS.","disabled":false},"AMAZON_LINUX":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0c10e657807c7a700","label":"AWS-AmazonLinuxDefaultPatchBaseline","description":"Default
+            Patch Baseline for Amazon Linux Provided by AWS.","disabled":false},"AMAZON_LINUX_2":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0be8c61cde3be63f3","label":"AWS-AmazonLinux2DefaultPatchBaseline","description":"Baseline
+            containing all Security and Bugfix updates approved for Amazon Linux 2 instances","disabled":false},"AMAZON_LINUX_2022":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0028ca011460d5eaf","label":"AWS-AmazonLinux2022DefaultPatchBaseline","description":"Default
+            Patch Baseline for Amazon Linux 2022 Provided by AWS.","disabled":false},"AMAZON_LINUX_2023":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-05c9c9bf778d4c4d0","label":"AWS-AmazonLinux2023DefaultPatchBaseline","description":"Default
+            Patch Baseline for Amazon Linux 2023 Provided by AWS.","disabled":false},"CENTOS":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-03e3f588eec25344c","label":"AWS-CentOSDefaultPatchBaseline","description":"Default
+            Patch Baseline for CentOS Provided by AWS.","disabled":false},"DEBIAN":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-09a5f8eb62bde80b1","label":"AWS-DebianDefaultPatchBaseline","description":"Default
+            Patch Baseline for Debian Provided by AWS.","disabled":false},"MACOS":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0ee4f94581368c0d4","label":"AWS-MacOSDefaultPatchBaseline","description":"Default
+            Patch Baseline for MacOS Provided by AWS.","disabled":false},"ORACLE_LINUX":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-06bff38e95fe85c02","label":"AWS-OracleLinuxDefaultPatchBaseline","description":"Default
+            Patch Baseline for Oracle Linux Server Provided by AWS.","disabled":false},"RASPBIAN":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0ec16280999c5c75e","label":"AWS-RaspbianDefaultPatchBaseline","description":"Default
+            Patch Baseline for Raspbian Provided by AWS.","disabled":false},"REDHAT_ENTERPRISE_LINUX":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0cbb3a633de00f07c","label":"AWS-RedHatDefaultPatchBaseline","description":"Default
+            Patch Baseline for Redhat Enterprise Linux Provided by AWS.","disabled":false},"ROCKY_LINUX":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-03ec98bc512aa3ac0","label":"AWS-RockyLinuxDefaultPatchBaseline","description":"Default
+            Patch Baseline for Rocky Linux Provided by AWS.","disabled":false},"SUSE":{"value":"arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-07d8884178197b66b","label":"AWS-SuseDefaultPatchBaseline","description":"Default
+            Patch Baseline for Suse Provided by AWS.","disabled":false},"UBUNTU":{"value":"pb-06e3563bd35503f2b","label":"custom-UbuntuServer-Blog-Baseline","description":"Default
+            Patch Baseline for Ubuntu Provided by AWS.","disabled":false},"WINDOWS":{"value":"pb-016889927b2bb8542","label":"custom-WindowsServer-Blog-Baseline","disabled":false}}'
+          ConfigurationOptionsPatchOperation: "ScanAndInstall"
+          TargetType: '*'
+          TargetOrganizationalUnits: !Ref TargetOrgUnits
+          TargetRegions: !Ref TargetRegions
+Outputs:
+  PatchPolicyArn:
+    Description: 'Patch policy ARN'
+    Value: !Ref PatchPolicy
+    Export:
+      Name: !Sub '${AWS::StackName}-PatchPolicyArn'

--- a/org-formation/090-systems-manager/QuickSetup-PatchPolicy.yaml
+++ b/org-formation/090-systems-manager/QuickSetup-PatchPolicy.yaml
@@ -62,6 +62,8 @@ Resources:
           ConfigurationOptionsPatchOperation: "ScanAndInstall"
           ConfigurationOptionsScanValue: "cron(0 17 ? * * *)"  # 10am PST
           ConfigurationOptionsInstallValue: "cron(0 19 ? * WED *)"  # 12pm PST
+          # Don't automatically attach instance profiles to instances, we manage them with CFN
+          IsPolicyAttachAllowed: false
           OutputLogEnableS3: true
           OutputS3BucketName: !Ref QuickSetupPatchLogBucket
           OutputBucketRegion: !Ref "AWS::Region"

--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -61,6 +61,18 @@ PatchMembers:
   Parameters:
     ManagementAccountNumber: !Ref accountId
 
+PatchPolicy:
+  Type: update-stacks
+  Template: QuickSetup-PatchPolicy.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-patchpolicy'
+  StackDescription: Setup Systems manager patch policy for the entire Org
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref MasterAccount
+  Parameters:
+    TargetOrgUnits: !Ref OrganizationRoot
+    TargetRegions: !Ref primaryRegion
+
 # This will run the Stack Armor Nessus installation script each day
 # on any EC2 in us-east-1 tagged with execute-script:install-stack-armor-agent
 # Since the script is idempotent, running every day ensures the script

--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -70,7 +70,7 @@ PatchPolicy:
   DefaultOrganizationBinding:
     Account: !Ref MasterAccount
   Parameters:
-    TargetOrgUnits: !Ref OrganizationRoot
+    TargetOrgRoot: !Ref OrganizationRoot
     TargetRegions: !Ref primaryRegion
 
 # This will run the Stack Armor Nessus installation script each day

--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -61,7 +61,7 @@ PatchMembers:
   Parameters:
     ManagementAccountNumber: !Ref accountId
 
-PatchPolicy:
+QuickSetupPatchPolicy:
   Type: update-stacks
   Template: QuickSetup-PatchPolicy.yaml
   StackName: !Sub '${resourcePrefix}-${appName}-patchpolicy'


### PR DESCRIPTION
A second attempt at creating a Patch Policy using SSM QuickSetup
to update all managed nodes in the organization. Add poorly-
documented parameters. Also create an S3 bucket for patch logs
(every member account must have write access to the bucket).

The local deployment roles were created automatically by SSM QuickSetup
by creating an empty patch policy in AWS Portal.

Documentation provided by AWS in a support case:

General process:
https://repost.aws/questions/QUscQKRgKDQ0O7gjhTuioxzw/do-i-need-to-be-in-the-managerment-account-to-use-system-manager-patch-manager-to-patch-instances-across-an-organization
https://docs.aws.amazon.com/systems-manager/latest/userguide/quick-setup-config-types.html
https://docs.aws.amazon.com/systems-manager/latest/userguide/quick-setup-patch-manager.html
https://docs.aws.amazon.com/systems-manager/latest/userguide/quick-setup-getting-started.html
https://docs.aws.amazon.com/systems-manager/latest/userguide/quick-setup-api.html

Patch Baselines:
https://docs.aws.amazon.com/cli/latest/reference/ssm/describe-patch-baselines.html
https://docs.aws.amazon.com/systems-manager/latest/userguide/patch-manager-manage-patch-baselines.html

Permissions:
https://docs.aws.amazon.com/systems-manager/latest/userguide/quick-setup-patch-manager.html#patch-policy-instance-profile-service-role

CloudFormation API:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ssmquicksetup-configurationmanager-configurationdefinition.html
https://docs.aws.amazon.com/quick-setup/latest/APIReference/API_ConfigurationDefinitionInput.html

GitHub examples:
https://github.com/aws-samples/aws-management-and-governance-samples/blob/master/AWSSystemsManager/Quick-Setup-API/patch-policy-examples/patch-policy-cfn-template.yaml
https://github.com/aws-samples/aws-management-and-governance-samples/tree/master/AWSSystemsManager/Quick-Setup-API/patch-policy-examples
