### PR TITLE
[IT-3831] Update SSO read only access

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -522,6 +522,7 @@ SsoViewer:
     managedPolicies:
       - 'arn:aws:iam::aws:policy/job-function/ViewOnlyAccess'
       - 'arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess'
+      - 'arn:aws:iam::aws:policy/AWSImageBuilderReadOnlyAccess'
     sessionDuration: 'PT12H'
     masterAccountId: !Ref MasterAccount
 
@@ -582,6 +583,7 @@ SsoViewerPlus:
       - arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess
       - arn:aws:iam::aws:policy/AWSNetworkManagerReadOnlyAccess
       - arn:aws:iam::aws:policy/AWSOrganizationsReadOnlyAccess
+      - arn:aws:iam::aws:policy/AWSImageBuilderReadOnlyAccess
     inlinePolicy: >-
       {
         "Version": "2012-10-17",


### PR DESCRIPTION
As instructed in our wiki[1], this will allow SSO read only users the ability
to search for Sage generated shared AMIs from any AWS account.

[1] https://sagebionetworks.jira.com/wiki/spaces/IT/pages/914882624/AWS+Image+Repository