### PR TITLE
Revert "[IT-3831] Update SSO read only access (#1380)"

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -522,7 +522,6 @@ SsoViewer:
     managedPolicies:
       - 'arn:aws:iam::aws:policy/job-function/ViewOnlyAccess'
       - 'arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess'
-      - 'arn:aws:iam::aws:policy/AWSImageBuilderReadOnlyAccess'
     sessionDuration: 'PT12H'
     masterAccountId: !Ref MasterAccount
 
@@ -583,7 +582,6 @@ SsoViewerPlus:
       - arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess
       - arn:aws:iam::aws:policy/AWSNetworkManagerReadOnlyAccess
       - arn:aws:iam::aws:policy/AWSOrganizationsReadOnlyAccess
-      - arn:aws:iam::aws:policy/AWSImageBuilderReadOnlyAccess
     inlinePolicy: >-
       {
         "Version": "2012-10-17",


### PR DESCRIPTION
This reverts commit f2e5bf0c9bd53df2f4dc451d66f64aee224fea47. Due to error "Number of attached policies to role AWSReservedSSO_viewer-plus_0fdf6628dfc35abe for account 050451359079 has exceeded the IAM limit."

