### PR TITLE
[IT-3831] Update SSO read only access

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -522,6 +522,7 @@ SsoViewer:
     managedPolicies:
       - 'arn:aws:iam::aws:policy/job-function/ViewOnlyAccess'
       - 'arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess'
+      - 'arn:aws:iam::aws:policy/AWSImageBuilderReadOnlyAccess'
     sessionDuration: 'PT12H'
     masterAccountId: !Ref MasterAccount
 
@@ -582,6 +583,7 @@ SsoViewerPlus:
       - arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess
       - arn:aws:iam::aws:policy/AWSNetworkManagerReadOnlyAccess
       - arn:aws:iam::aws:policy/AWSOrganizationsReadOnlyAccess
+      - arn:aws:iam::aws:policy/AWSImageBuilderReadOnlyAccess
     inlinePolicy: >-
       {
         "Version": "2012-10-17",


### PR DESCRIPTION
This reverts commit 58070be5e7dc39cd2fc88903409d4e1113a55536.

Try this again after making a request to increase IAM quota from the
default 10 managed policies per role to 20 per role.

Note: quota increase requests cannot be made at the org level, it needs
to be done in each member account and there is no automation for making
the request.  We need to manually login to every account to make the request