### PR TITLE
[IT-4374] add missing replace() to remove parens

### DIFF
--- a/sceptre/scipool/templates/sc-tag-options.j2
+++ b/sceptre/scipool/templates/sc-tag-options.j2
@@ -8,7 +8,7 @@ Resources:
     Properties:
       Active: true
       Key: "CostCenter"
-      Value: {{ CostCenter }}
+      Value: {{ CostCenter.replace(' ','').replace('(','').replace(')','').replace('+','').replace('.','').replace('-','').replace('_','').replace('/','') }}
   {% endfor %}
 {% endif %}
 
@@ -30,7 +30,7 @@ Outputs:
 {% if sceptre_user_data.CostCenters is defined %}
   {% for CostCenter in sceptre_user_data.CostCenters %}
   {{ CostCenter.replace(' ','').replace('(','').replace(')','').replace('+','').replace('.','').replace('-','').replace('_','').replace('/','') }}CostCenterTag:
-    Value: !Ref "{{ CostCenter.replace(' ','').replace('+','').replace('.','').replace('-','').replace('_','').replace('/','') }}CostCenterTag"
+    Value: !Ref "{{ CostCenter.replace(' ','').replace('(','').replace(')','').replace('+','').replace('.','').replace('-','').replace('_','').replace('/','') }}CostCenterTag"
     Export:
       Name: !Sub "${AWS::Region}-${AWS::StackName}-{{ CostCenter.replace(' ','').replace('(','').replace(')','').replace('+','').replace('.','').replace('-','').replace('_','').replace('/','') }}CostCenterTag"
   {% endfor %}

--- a/sceptre/scipool/templates/sc-tag-options.j2
+++ b/sceptre/scipool/templates/sc-tag-options.j2
@@ -8,7 +8,7 @@ Resources:
     Properties:
       Active: true
       Key: "CostCenter"
-      Value: {{ CostCenter.replace(' ','').replace('(','').replace(')','').replace('+','').replace('.','').replace('-','').replace('_','').replace('/','') }}
+      Value: {{ CostCenter.replace('(','').replace(')','') }}
   {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
A couple values were missed when adding replace() to remove special characters from CostCenter tag options.
