### PR TITLE
[IT-4089] Suppress access-key rotation for service users

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -526,9 +526,7 @@ Resources:
 
   # Findings to suppress in Bridge accounts.
   # * Suppress findings for insecure access to S3 buckets in the bridge accounts
-  #   because consent forms are accessed via HTTP
-  # * Suppress findings for unused credentials because automation runs less
-  #   frequently than every 45 days.
+  #   because consent forms are accessed internally by the app via HTTP.
   SuppressFindingsForBridgeAccounts:
     Type: AWS::Events::Rule
     Properties:
@@ -539,8 +537,47 @@ Resources:
             GeneratorId:
               # Ensure S3 Bucket Policy is set to deny HTTP requests
               - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.2'
+            Workflow:
+              Status:
+              - NEW
+              - NOTIFIED
+            AwsAccountId:
+            - '420786776710' # bridge-dev
+            - '649232250620' # bridge-prod
+        detail-type:
+        - Security Hub Findings - Imported
+        source:
+        - aws.securityhub
+      State: ENABLED
+      Targets:
+      - Arn:
+          Fn::GetAtt:
+          - SecurityHubFindingsQueue
+          - Arn
+        Id: Target0
+
+  # Findings to suppress for service users in Bridge accounts.
+  # * Suppress findings for unused credentials because automation runs less
+  #   frequently than every 45 days.
+  # * Suppress findings for access key rotation because we don't know everywhere
+  #   that they're used, creating a risk of a prolonged outage and data loss.
+  SuppressFindingsForBridgeServiceUsers:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: SecHubSuppress findings for Bridge accounts
+      EventPattern:
+        detail:
+          findings:
+            GeneratorId:
               # Disable credentials unused for more than 45 days
               - 'cis-aws-foundations-benchmark/v/1.4.0/1.12'
+              # Disable credentials unused for more than 90 days
+              - 'cis-aws-foundations-benchmark/v/1.4.0/1.14'
+            Resources:
+              Id:
+                - 'arn:aws:iam::649232250620:user/BridgeDocsAndRepoBuild'
+                - 'arn:aws:iam::649232250620:user/TravisUser'
+                - 'arn:aws:iam::649232250620:user/web-mpower-2-ci'
             Workflow:
               Status:
               - NEW


### PR DESCRIPTION
Don't require the Bridge service users to rotate access keys every 90 days. A lack of certainty around knowing all locations to update creates a risk of a prolonged outage with data loss.

Also refactor suppression for credentials unused for 45 days so that it is also restricted to the Bridge service users.
