### PR TITLE
remove references to travis-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,6 @@ To debug jinja template processing in sceptre, go the the corresponding
 ## Issues
 * https://sagebionetworks.jira.com/projects/IT
 
-## Builds
-* https://travis-ci.org/Sage-Bionetworks/organizations-infra
-
 ## Secrets
 * We use the [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html)
 to store secrets for this project.  Sceptre retrieves the secrets using

--- a/sceptre/admincentral/README.md
+++ b/sceptre/admincentral/README.md
@@ -47,9 +47,6 @@ We have configured Travis to deploy CF template updates.  Travis deploys using
 ## Issues
 * https://sagebionetworks.jira.com/projects/BRIDGE
 
-## Builds
-* https://travis-ci.org/Sage-Bionetworks/admincentral-infra
-
 ## Secrets
 * We use the [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html)
 to store secrets for this project.  Sceptre retrieves the secrets using

--- a/sceptre/bridge/README.md
+++ b/sceptre/bridge/README.md
@@ -38,9 +38,6 @@ execute the validations by running `pre-commit run --all-files`.
 ## Issues
 * https://sagebionetworks.jira.com/projects/BRIDGE
 
-## Builds
-* https://travis-ci.org/Sage-Bionetworks/Bridge-infra
-
 ## Secrets
 * We use the [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html)
 to store secrets for this project.  Sceptre retrieves the secrets using

--- a/sceptre/imagecentral/README.md
+++ b/sceptre/imagecentral/README.md
@@ -38,9 +38,6 @@ We have configured Travis to deploy CF template updates.  Travis deploys using
 ## Issues
 * https://sagebionetworks.jira.com/projects/IT
 
-## Builds
-* https://travis-ci.org/Sage-Bionetworks/organizations-infra
-
 ## Secrets
 * We use the [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html)
 to store secrets for this project.  Sceptre retrieves the secrets using

--- a/sceptre/itsandbox/README.md
+++ b/sceptre/itsandbox/README.md
@@ -37,9 +37,6 @@ automatically run on every commit.
 ## Issues
 * https://sagebionetworks.jira.com/projects/IT
 
-## Builds
-* https://travis-ci.org/Sage-Bionetworks/organizations-infra
-
 ## Secrets
 * We use the [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html)
 to store secrets for this project.  Sceptre retrieves the secrets using

--- a/sceptre/logcentral/README.md
+++ b/sceptre/logcentral/README.md
@@ -29,9 +29,6 @@ We have configured Travis to deploy CF template updates.  Travis deploys using
 ## Issues
 * https://sagebionetworks.jira.com/projects/IT
 
-## Builds
-* https://travis-ci.org/Sage-Bionetworks/logcentral-infra
-
 ## Secrets
 * We use the [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html)
 to store secrets for this project.  Sceptre retrieves the secrets using

--- a/sceptre/sageit/README.md
+++ b/sceptre/sageit/README.md
@@ -24,9 +24,6 @@ We have configured Travis to deploy CF template updates.  Travis deploys using
 ## Issues
 * https://sagebionetworks.jira.com/projects/IT
 
-## Builds
-* https://travis-ci.org/Sage-Bionetworks/sageit-infra
-
 ## Secrets
 * We use the [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html)
 to store secrets for this project.  Sceptre retrieves the secrets using

--- a/sceptre/scicomp/README.md
+++ b/sceptre/scicomp/README.md
@@ -24,9 +24,6 @@ We have configured Travis to deploy CF template updates.  Travis deploys using
 ## Issues
 * https://sagebionetworks.jira.com/projects/IT
 
-## Builds
-* https://travis-ci.org/Sage-Bionetworks/scicomp-infra
-
 ## Secrets
 * We use the [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html)
 to store secrets for this project.  Sceptre retrieves the secrets using

--- a/sceptre/synapsedev/README.md
+++ b/sceptre/synapsedev/README.md
@@ -24,9 +24,6 @@ We have configured Travis to deploy CF template updates.  Travis deploys using
 ## Issues
 * https://sagebionetworks.jira.com/projects/IT
 
-## Builds
-* https://travis-ci.org/Sage-Bionetworks/synapsedev-infra
-
 ## Secrets
 * We use the [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html)
 to store secrets for this project.  Sceptre retrieves the secrets using

--- a/sceptre/synapseprod/README.md
+++ b/sceptre/synapseprod/README.md
@@ -24,9 +24,6 @@ We have configured Travis to deploy CF template updates.  Travis deploys using
 ## Issues
 * https://sagebionetworks.jira.com/projects/IT
 
-## Builds
-* https://travis-ci.org/Sage-Bionetworks/organizations-infra
-
 ## Secrets
 * We use the [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html)
 to store secrets for this project.  Sceptre retrieves the secrets using


### PR DESCRIPTION
We no longer use travis CI so remove references to it.
