### PR TITLE
[IT-4378] Give SSO user extra IAM permissions

### DIFF
--- a/sceptre/strides-ampad-workflows/templates/jumpcloud-idp.yaml
+++ b/sceptre/strides-ampad-workflows/templates/jumpcloud-idp.yaml
@@ -85,6 +85,15 @@ Resources:
             Condition:
               StringEquals:
                 "SAML:aud": "https://signin.aws.amazon.com/saml"
+      Policies:
+        - PolicyName: IamExtraPermissions
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              Action:
+                - iam:PassRole
+              Effect: Allow
+              Resource: "*"
   AuditorSamlProvider:
     Type: Custom::SAMLProvider
     Properties:


### PR DESCRIPTION
When the user provisions an EC2 instance with an instance profile they need the ability to pass permissions to an EC2 instance.

