### PR TITLE
[IT-4380] Update redirects

### DIFF
--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -310,7 +310,7 @@ AgoraDevAppDnsForward:
     Account: !Ref SageITAccount
   Parameters:
     # the name of the CNAME record
-    SourceHostName: "newagora-dev.adknowledgeportal.org"
+    SourceHostName: "agora-dev.adknowledgeportal.org"
     # ID of the adknowledgeportal.org zone (in sageit account)
     SourceHostedZoneId: "Z2DTJC6JTFRHBN"
     # the value of the CNAME record
@@ -328,7 +328,7 @@ AgoraStageAppDnsForward:
     Account: !Ref SageITAccount
   Parameters:
     # the name of the CNAME record
-    SourceHostName: "newagora-stage.adknowledgeportal.org"
+    SourceHostName: "agora-stage.adknowledgeportal.org"
     # ID of the adknowledgeportal.org zone (in sageit account)
     SourceHostedZoneId: "Z2DTJC6JTFRHBN"
     # the value of the CNAME record
@@ -346,7 +346,7 @@ AgoraProdAppDnsForward:
     Account: !Ref SageITAccount
   Parameters:
     # the name of the CNAME record
-    SourceHostName: "newagora-prod.adknowledgeportal.org"
+    SourceHostName: "agora-prod.adknowledgeportal.org"
     # ID of the adknowledgeportal.org zone (in sageit account)
     SourceHostedZoneId: "Z2DTJC6JTFRHBN"
     # the value of the CNAME record


### PR DESCRIPTION
Update application endpoints for Agora

This will require one additional manual step of updating the route53
record `agora.adknowledgeportal.org` to forward to
`agora-prod.adknowledgeportal.org`

