### PR TITLE
[IT-4166] suppress security hub finding 2.1.5.2

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -460,6 +460,95 @@ Resources:
           - Arn
         Id: Target0
 
+  # Same as the above SuppressFindingsForPublicBucketsRule, extending here due to Rule character size limit
+  SuppressFindingsForPublicBucketsRule2:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: SecHubSuppress findings (identified by generatorId) for the infra resources in all accounts
+      EventPattern:
+        detail:
+          findings:
+            Resources:
+              Id:
+                # Cloudfront buckets in org-sagebase-sageit account
+                - prefix: 'arn:aws:s3:::admodelexplorer.org'
+                - prefix: 'arn:aws:s3:::alzdrugtool.synapse.org'
+                - prefix: 'arn:aws:s3:::aws-sso.sageit.org'
+                - prefix: 'arn:aws:s3:::brainsomaticmosaicism.org'
+                - prefix: 'arn:aws:s3:::csbconsortium.org'
+                - prefix: 'arn:aws:s3:::designmanual.sagebase.org'
+                - prefix: 'arn:aws:s3:::install.studies.mobiletoolbox.org'
+                - prefix: 'arn:aws:s3:::it1363.sagebase.org'
+                - prefix: 'arn:aws:s3:::mindkindstudyredirector.org'
+                - prefix: 'arn:aws:s3:::mobiletoolbox.org'
+                - prefix: 'arn:aws:s3:::privacytoolkit.sagebase.org'
+                - prefix: 'arn:aws:s3:::privacytoolkit.sagebionetworks.org'
+                - prefix: 'arn:aws:s3:::prod.bsmn.synapse.org'
+                - prefix: 'arn:aws:s3:::prod.cancercomplexity.synapse.org'
+                - prefix: 'arn:aws:s3:::prod.covid19patientcorps.sagebionetworks.org'
+                - prefix: 'arn:aws:s3:::prod.covidrecoverycorps.org'
+                - prefix: 'arn:aws:s3:::prod.covidrecoverycorpsresearcher.synapse.org'
+                - prefix: 'arn:aws:s3:::prod.csbc-pson.synapse.org'
+                - prefix: 'arn:aws:s3:::prod.dhealth.synapse.org'
+                - prefix: 'arn:aws:s3:::prod.eliteportal.org'
+                - prefix: 'arn:aws:s3:::prod.htan.synapse.org'
+                - prefix: 'arn:aws:s3:::prod.mindkindstudy.org'
+                - prefix: 'arn:aws:s3:::prod.mobiletoolbox.org'
+                - prefix: 'arn:aws:s3:::prod.modeladexplorer.org'
+                - prefix: 'arn:aws:s3:::prod.nf.synapse.org'
+                - prefix: 'arn:aws:s3:::prod.psychencode.synapse.org'
+                - prefix: 'arn:aws:s3:::prod.studies.mobiletoolbox.org'
+                - prefix: 'arn:aws:s3:::prod.wtgmhdc.synapse.org'
+                - prefix: 'arn:aws:s3:::psychencode.org'
+                - prefix: 'arn:aws:s3:::sso.sageit.org'
+                - prefix: 'arn:aws:s3:::staging.admodelexplorer.org'
+                - prefix: 'arn:aws:s3:::staging.alzdrugtool.synapse.org'
+                - prefix: 'arn:aws:s3:::staging.bsmn.synapse.org'
+                - prefix: 'arn:aws:s3:::staging.cancercomplexity.synapse.org'
+                - prefix: 'arn:aws:s3:::staging.covid19patientcorps.sagebionetworks.org'
+                - prefix: 'arn:aws:s3:::staging.covidrecoverycorps.org'
+                - prefix: 'arn:aws:s3:::staging.covidrecoverycorpsresearcher.synapse.org'
+                - prefix: 'arn:aws:s3:::staging.csbc-pson.synapse.org'
+                - prefix: 'arn:aws:s3:::staging.dhealth.synapse.org'
+                - prefix: 'arn:aws:s3:::staging.eliteportal.org'
+                - prefix: 'arn:aws:s3:::staging.htan.synapse.org'
+                - prefix: 'arn:aws:s3:::staging.mindkindstudy.org'
+                - prefix: 'arn:aws:s3:::staging.mobiletoolbox.org'
+                - prefix: 'arn:aws:s3:::staging.modeladexplorer.org'
+                - prefix: 'arn:aws:s3:::staging.nf.synapse.org'
+                - prefix: 'arn:aws:s3:::staging.stopadportal.synapse.org'
+                - prefix: 'arn:aws:s3:::staging.studies.mobiletoolbox.org'
+                - prefix: 'arn:aws:s3:::staging.wtgmhdc.synapse.org'
+                - prefix: 'arn:aws:s3:::static.ampadportal.org'
+                - prefix: 'arn:aws:s3:::static.nf.synapse.org'
+                - prefix: 'arn:aws:s3:::stopadportal.synapse.org'
+                - prefix: 'arn:aws:s3:::test.admodeladexplorer.org'
+                - prefix: 'arn:aws:s3:::vpn.sageit.org'
+                - prefix: 'arn:aws:s3:::www.csbconsortium.org'
+                - prefix: 'arn:aws:s3:::www.csbcpson2018.org'
+                - prefix: 'arn:aws:s3:::www.elevatems.org'
+                - prefix: 'arn:aws:s3:::www.journeypro.org'
+            GeneratorId:
+              - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.1'
+              - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.5.2'
+              - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.5.1'
+              - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.2'
+            Workflow:
+              Status:
+              - NEW
+              - NOTIFIED
+        detail-type:
+        - Security Hub Findings - Imported
+        source:
+        - aws.securityhub
+      State: ENABLED
+      Targets:
+      - Arn:
+          Fn::GetAtt:
+          - SecurityHubFindingsQueue
+          - Arn
+        Id: Target2
+
   # This rule suppresses findings with the given generator IDs only for the IAM accounts specified
   SuppressFindingsForIAMsRule:
     Type: AWS::Events::Rule


### PR DESCRIPTION
Another attempt at PR #1399 which was reverted in PR #1402

My theory is that the `AWS::Events::Rule` has a character size limit
and PR #1401 bumped it over the limit.  This PR creates a separate
suppression rule.

