### PR TITLE
[IT-4166] Minify AWS event rule

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -461,16 +461,16 @@ Resources:
         Id: Target0
 
   # Same as the above SuppressFindingsForPublicBucketsRule, extending here due to Rule character size limit
-  SuppressFindingsForSageItPublicBucketsRule:
+  SuppressFindingsForPublicBucketsRule2:
     Type: AWS::Events::Rule
     Properties:
-      Description: SecHubSuppress findings (identified by generatorId) for public buckets in SageIT
+      Description: SecHubSuppress findings (identified by generatorId) for the infra resources in all accounts
       EventPattern:
         detail:
           findings:
             Resources:
               # public buckets in org-sagebase-sageit account
-              # need to minify due to character AWS limit of 2048 on rules
+              # need to minify due to character limit of 2048 on cloudformation parameters
               {Id: [{prefix: 'arn:aws:s3:::admodelexplorer.org'}, {prefix: 'arn:aws:s3:::alzdrugtool.synapse.org'}, {prefix: 'arn:aws:s3:::aws-sso.sageit.org'}, {prefix: 'arn:aws:s3:::brainsomaticmosaicism.org'}, {prefix: 'arn:aws:s3:::csbconsortium.org'}, {prefix: 'arn:aws:s3:::designmanual.sagebase.org'}, {prefix: 'arn:aws:s3:::install.studies.mobiletoolbox.org'}, {prefix: 'arn:aws:s3:::it1363.sagebase.org'}, {prefix: 'arn:aws:s3:::mindkindstudyredirector.org'}, {prefix: 'arn:aws:s3:::mobiletoolbox.org'}, {prefix: 'arn:aws:s3:::privacytoolkit.sagebase.org'}, {prefix: 'arn:aws:s3:::privacytoolkit.sagebionetworks.org'}, {prefix: 'arn:aws:s3:::prod.bsmn.synapse.org'}, {prefix: 'arn:aws:s3:::prod.cancercomplexity.synapse.org'}, {prefix: 'arn:aws:s3:::prod.covid19patientcorps.sagebionetworks.org'}, {prefix: 'arn:aws:s3:::prod.covidrecoverycorps.org'}, {prefix: 'arn:aws:s3:::prod.covidrecoverycorpsresearcher.synapse.org'}, {prefix: 'arn:aws:s3:::prod.csbc-pson.synapse.org'}, {prefix: 'arn:aws:s3:::prod.dhealth.synapse.org'}, {prefix: 'arn:aws:s3:::prod.eliteportal.org'}, {prefix: 'arn:aws:s3:::prod.htan.synapse.org'}, {prefix: 'arn:aws:s3:::prod.mindkindstudy.org'}, {prefix: 'arn:aws:s3:::prod.mobiletoolbox.org'}, {prefix: 'arn:aws:s3:::prod.modeladexplorer.org'}, {prefix: 'arn:aws:s3:::prod.nf.synapse.org'}, {prefix: 'arn:aws:s3:::prod.psychencode.synapse.org'}, {prefix: 'arn:aws:s3:::prod.studies.mobiletoolbox.org'}, {prefix: 'arn:aws:s3:::prod.wtgmhdc.synapse.org'}, {prefix: 'arn:aws:s3:::psychencode.org'}, {prefix: 'arn:aws:s3:::sso.sageit.org'}, {prefix: 'arn:aws:s3:::staging.admodelexplorer.org'}, {prefix: 'arn:aws:s3:::staging.alzdrugtool.synapse.org'}, {prefix: 'arn:aws:s3:::staging.bsmn.synapse.org'}, {prefix: 'arn:aws:s3:::staging.cancercomplexity.synapse.org'}, {prefix: 'arn:aws:s3:::staging.covid19patientcorps.sagebionetworks.org'}, {prefix: 'arn:aws:s3:::staging.covidrecoverycorps.org'}, {prefix: 'arn:aws:s3:::staging.covidrecoverycorpsresearcher.synapse.org'}, {prefix: 'arn:aws:s3:::staging.csbc-pson.synapse.org'}, {prefix: 'arn:aws:s3:::staging.dhealth.synapse.org'}, {prefix: 'arn:aws:s3:::staging.eliteportal.org'}, {prefix: 'arn:aws:s3:::staging.htan.synapse.org'}, {prefix: 'arn:aws:s3:::staging.mindkindstudy.org'}, {prefix: 'arn:aws:s3:::staging.mobiletoolbox.org'}, {prefix: 'arn:aws:s3:::staging.modeladexplorer.org'}, {prefix: 'arn:aws:s3:::staging.nf.synapse.org'}, {prefix: 'arn:aws:s3:::staging.stopadportal.synapse.org'}, {prefix: 'arn:aws:s3:::staging.studies.mobiletoolbox.org'}, {prefix: 'arn:aws:s3:::staging.wtgmhdc.synapse.org'}, {prefix: 'arn:aws:s3:::static.ampadportal.org'}, {prefix: 'arn:aws:s3:::static.nf.synapse.org'}, {prefix: 'arn:aws:s3:::stopadportal.synapse.org'}, {prefix: 'arn:aws:s3:::test.admodeladexplorer.org'}, {prefix: 'arn:aws:s3:::vpn.sageit.org'}, {prefix: 'arn:aws:s3:::www.csbconsortium.org'}, {prefix: 'arn:aws:s3:::www.csbcpson2018.org'}, {prefix: 'arn:aws:s3:::www.elevatems.org'}, {prefix: 'arn:aws:s3:::www.journeypro.org'}]}
             GeneratorId:
               - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.1'

--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -461,73 +461,17 @@ Resources:
         Id: Target0
 
   # Same as the above SuppressFindingsForPublicBucketsRule, extending here due to Rule character size limit
-  SuppressFindingsForPublicBucketsRule2:
+  SuppressFindingsForSageItPublicBucketsRule:
     Type: AWS::Events::Rule
     Properties:
-      Description: SecHubSuppress findings (identified by generatorId) for the infra resources in all accounts
+      Description: SecHubSuppress findings (identified by generatorId) for public buckets in SageIT
       EventPattern:
         detail:
           findings:
             Resources:
-              Id:
-                # Cloudfront buckets in org-sagebase-sageit account
-                - prefix: 'arn:aws:s3:::admodelexplorer.org'
-                - prefix: 'arn:aws:s3:::alzdrugtool.synapse.org'
-                - prefix: 'arn:aws:s3:::aws-sso.sageit.org'
-                - prefix: 'arn:aws:s3:::brainsomaticmosaicism.org'
-                - prefix: 'arn:aws:s3:::csbconsortium.org'
-                - prefix: 'arn:aws:s3:::designmanual.sagebase.org'
-                - prefix: 'arn:aws:s3:::install.studies.mobiletoolbox.org'
-                - prefix: 'arn:aws:s3:::it1363.sagebase.org'
-                - prefix: 'arn:aws:s3:::mindkindstudyredirector.org'
-                - prefix: 'arn:aws:s3:::mobiletoolbox.org'
-                - prefix: 'arn:aws:s3:::privacytoolkit.sagebase.org'
-                - prefix: 'arn:aws:s3:::privacytoolkit.sagebionetworks.org'
-                - prefix: 'arn:aws:s3:::prod.bsmn.synapse.org'
-                - prefix: 'arn:aws:s3:::prod.cancercomplexity.synapse.org'
-                - prefix: 'arn:aws:s3:::prod.covid19patientcorps.sagebionetworks.org'
-                - prefix: 'arn:aws:s3:::prod.covidrecoverycorps.org'
-                - prefix: 'arn:aws:s3:::prod.covidrecoverycorpsresearcher.synapse.org'
-                - prefix: 'arn:aws:s3:::prod.csbc-pson.synapse.org'
-                - prefix: 'arn:aws:s3:::prod.dhealth.synapse.org'
-                - prefix: 'arn:aws:s3:::prod.eliteportal.org'
-                - prefix: 'arn:aws:s3:::prod.htan.synapse.org'
-                - prefix: 'arn:aws:s3:::prod.mindkindstudy.org'
-                - prefix: 'arn:aws:s3:::prod.mobiletoolbox.org'
-                - prefix: 'arn:aws:s3:::prod.modeladexplorer.org'
-                - prefix: 'arn:aws:s3:::prod.nf.synapse.org'
-                - prefix: 'arn:aws:s3:::prod.psychencode.synapse.org'
-                - prefix: 'arn:aws:s3:::prod.studies.mobiletoolbox.org'
-                - prefix: 'arn:aws:s3:::prod.wtgmhdc.synapse.org'
-                - prefix: 'arn:aws:s3:::psychencode.org'
-                - prefix: 'arn:aws:s3:::sso.sageit.org'
-                - prefix: 'arn:aws:s3:::staging.admodelexplorer.org'
-                - prefix: 'arn:aws:s3:::staging.alzdrugtool.synapse.org'
-                - prefix: 'arn:aws:s3:::staging.bsmn.synapse.org'
-                - prefix: 'arn:aws:s3:::staging.cancercomplexity.synapse.org'
-                - prefix: 'arn:aws:s3:::staging.covid19patientcorps.sagebionetworks.org'
-                - prefix: 'arn:aws:s3:::staging.covidrecoverycorps.org'
-                - prefix: 'arn:aws:s3:::staging.covidrecoverycorpsresearcher.synapse.org'
-                - prefix: 'arn:aws:s3:::staging.csbc-pson.synapse.org'
-                - prefix: 'arn:aws:s3:::staging.dhealth.synapse.org'
-                - prefix: 'arn:aws:s3:::staging.eliteportal.org'
-                - prefix: 'arn:aws:s3:::staging.htan.synapse.org'
-                - prefix: 'arn:aws:s3:::staging.mindkindstudy.org'
-                - prefix: 'arn:aws:s3:::staging.mobiletoolbox.org'
-                - prefix: 'arn:aws:s3:::staging.modeladexplorer.org'
-                - prefix: 'arn:aws:s3:::staging.nf.synapse.org'
-                - prefix: 'arn:aws:s3:::staging.stopadportal.synapse.org'
-                - prefix: 'arn:aws:s3:::staging.studies.mobiletoolbox.org'
-                - prefix: 'arn:aws:s3:::staging.wtgmhdc.synapse.org'
-                - prefix: 'arn:aws:s3:::static.ampadportal.org'
-                - prefix: 'arn:aws:s3:::static.nf.synapse.org'
-                - prefix: 'arn:aws:s3:::stopadportal.synapse.org'
-                - prefix: 'arn:aws:s3:::test.admodeladexplorer.org'
-                - prefix: 'arn:aws:s3:::vpn.sageit.org'
-                - prefix: 'arn:aws:s3:::www.csbconsortium.org'
-                - prefix: 'arn:aws:s3:::www.csbcpson2018.org'
-                - prefix: 'arn:aws:s3:::www.elevatems.org'
-                - prefix: 'arn:aws:s3:::www.journeypro.org'
+              # public buckets in org-sagebase-sageit account
+              # need to minify due to character AWS limit of 2048 on rules
+              {Id: [{prefix: 'arn:aws:s3:::admodelexplorer.org'}, {prefix: 'arn:aws:s3:::alzdrugtool.synapse.org'}, {prefix: 'arn:aws:s3:::aws-sso.sageit.org'}, {prefix: 'arn:aws:s3:::brainsomaticmosaicism.org'}, {prefix: 'arn:aws:s3:::csbconsortium.org'}, {prefix: 'arn:aws:s3:::designmanual.sagebase.org'}, {prefix: 'arn:aws:s3:::install.studies.mobiletoolbox.org'}, {prefix: 'arn:aws:s3:::it1363.sagebase.org'}, {prefix: 'arn:aws:s3:::mindkindstudyredirector.org'}, {prefix: 'arn:aws:s3:::mobiletoolbox.org'}, {prefix: 'arn:aws:s3:::privacytoolkit.sagebase.org'}, {prefix: 'arn:aws:s3:::privacytoolkit.sagebionetworks.org'}, {prefix: 'arn:aws:s3:::prod.bsmn.synapse.org'}, {prefix: 'arn:aws:s3:::prod.cancercomplexity.synapse.org'}, {prefix: 'arn:aws:s3:::prod.covid19patientcorps.sagebionetworks.org'}, {prefix: 'arn:aws:s3:::prod.covidrecoverycorps.org'}, {prefix: 'arn:aws:s3:::prod.covidrecoverycorpsresearcher.synapse.org'}, {prefix: 'arn:aws:s3:::prod.csbc-pson.synapse.org'}, {prefix: 'arn:aws:s3:::prod.dhealth.synapse.org'}, {prefix: 'arn:aws:s3:::prod.eliteportal.org'}, {prefix: 'arn:aws:s3:::prod.htan.synapse.org'}, {prefix: 'arn:aws:s3:::prod.mindkindstudy.org'}, {prefix: 'arn:aws:s3:::prod.mobiletoolbox.org'}, {prefix: 'arn:aws:s3:::prod.modeladexplorer.org'}, {prefix: 'arn:aws:s3:::prod.nf.synapse.org'}, {prefix: 'arn:aws:s3:::prod.psychencode.synapse.org'}, {prefix: 'arn:aws:s3:::prod.studies.mobiletoolbox.org'}, {prefix: 'arn:aws:s3:::prod.wtgmhdc.synapse.org'}, {prefix: 'arn:aws:s3:::psychencode.org'}, {prefix: 'arn:aws:s3:::sso.sageit.org'}, {prefix: 'arn:aws:s3:::staging.admodelexplorer.org'}, {prefix: 'arn:aws:s3:::staging.alzdrugtool.synapse.org'}, {prefix: 'arn:aws:s3:::staging.bsmn.synapse.org'}, {prefix: 'arn:aws:s3:::staging.cancercomplexity.synapse.org'}, {prefix: 'arn:aws:s3:::staging.covid19patientcorps.sagebionetworks.org'}, {prefix: 'arn:aws:s3:::staging.covidrecoverycorps.org'}, {prefix: 'arn:aws:s3:::staging.covidrecoverycorpsresearcher.synapse.org'}, {prefix: 'arn:aws:s3:::staging.csbc-pson.synapse.org'}, {prefix: 'arn:aws:s3:::staging.dhealth.synapse.org'}, {prefix: 'arn:aws:s3:::staging.eliteportal.org'}, {prefix: 'arn:aws:s3:::staging.htan.synapse.org'}, {prefix: 'arn:aws:s3:::staging.mindkindstudy.org'}, {prefix: 'arn:aws:s3:::staging.mobiletoolbox.org'}, {prefix: 'arn:aws:s3:::staging.modeladexplorer.org'}, {prefix: 'arn:aws:s3:::staging.nf.synapse.org'}, {prefix: 'arn:aws:s3:::staging.stopadportal.synapse.org'}, {prefix: 'arn:aws:s3:::staging.studies.mobiletoolbox.org'}, {prefix: 'arn:aws:s3:::staging.wtgmhdc.synapse.org'}, {prefix: 'arn:aws:s3:::static.ampadportal.org'}, {prefix: 'arn:aws:s3:::static.nf.synapse.org'}, {prefix: 'arn:aws:s3:::stopadportal.synapse.org'}, {prefix: 'arn:aws:s3:::test.admodeladexplorer.org'}, {prefix: 'arn:aws:s3:::vpn.sageit.org'}, {prefix: 'arn:aws:s3:::www.csbconsortium.org'}, {prefix: 'arn:aws:s3:::www.csbcpson2018.org'}, {prefix: 'arn:aws:s3:::www.elevatems.org'}, {prefix: 'arn:aws:s3:::www.journeypro.org'}]}
             GeneratorId:
               - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.1'
               - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.5.2'


### PR DESCRIPTION
Fix the following AWS deployment failure[1] by minifying the value of the parameter:
```
ERROR: Resource SuppressFindingsForPublicBucketsRule2 failed because
Resource handler returned message: "Parameter EventPattern for rule
sagebase-securityhub-supp-SuppressFindingsForPublic-UQVAKg5lkGea
exceeds limit of 2048.
```

[1] https://github.com/Sage-Bionetworks-IT/organizations-infra/actions/runs/14889997994/job/41819446177

