### PR TITLE
[IT-4347] Remove deployment of CloudWatch-CrossAccountSharingRole

### DIFF
--- a/org-formation/740-cloudwatch-dashboard/_tasks.yaml
+++ b/org-formation/740-cloudwatch-dashboard/_tasks.yaml
@@ -29,19 +29,6 @@ LinkManagementAccount:
     MonitoringAccountId: !Ref MonitorCentralAccount
     SinkIdentifier: "6046cc13-135d-4e41-ae56-63327a7a7b8c"
 
-# Allow member accounts to share cloudwatch data with MonitorCentral
-CrossAccountSharingRole:
-  Type: update-stacks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.8.6/templates/Cloudwatch/CrossAccountSharingRole-AccountList.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-CrossAccountSharingRole'
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    Account: '*'
-    ExcludeAccount: !Ref MonitorCentralAccount
-  Parameters:
-    MonitoringAccountIds: !Ref MonitorCentralAccount
-
-
 AgoraCwDashboards:
   Type: update-stacks
   Template: ./agora-cw-dashboards.njk


### PR DESCRIPTION
CloudWatch-CrossAccountSharingRole resource is being deployed multiple times which is causing failures during creation of new AWS accounts.

I believe what is happening is that the AWS cloudwatch service is creating a CloudWatch-CrossAccountSharingRole when we vend new AWS accounts thru our CI/CD.  Then org-formation is deploying the duplicate role later in the vending process which causes the failure.

Since AWS is already creating the required role I guess the fix would be to remove the deployment of that role from our org-formation setup.

