### PR TITLE
[IT-4418] Remove Github OIDC for Agora

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -805,29 +805,6 @@ GithubOidcBridgeDigitalHealthOpenBridgeWeb:
     Account: !Ref SageITAccount
     Region: us-east-1
 
-GithubOidcAgoraInfraDeploy:
-  Type: update-stacks
-  DependsOn: GithubOidcSageBionetworks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
-  StackName: !Sub ${resourcePrefix}-${appName}-agora-infra-deploy
-  Parameters:
-    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-agora-infra-deploy
-    MaxSessionDuration: 7200
-    ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AdministratorAccess"
-      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
-  TemplatingContext:
-    GitHubOrg: "Sage-Bionetworks"
-    Repositories:
-      - name: "agora2-infra"
-        branches: ["main"]
-  DefaultOrganizationBinding:
-    Account:
-      - !Ref AgoraDevAccount
-      - !Ref AgoraProdAccount
-    Region: us-east-1
-
 GithubOidcAgoraInfraV3:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks
@@ -845,28 +822,6 @@ GithubOidcAgoraInfraV3:
     Repositories:
       - name: "agora-infra-v3"
         branches: ["dev","stage","prod"]
-  DefaultOrganizationBinding:
-    Account:
-      - !Ref AgoraDevAccount
-      - !Ref AgoraProdAccount
-    Region: us-east-1
-
-GithubOidcAgoraEBDeploy:
-  Type: update-stacks
-  DependsOn: GithubOidcSageBionetworks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
-  StackName: !Sub ${resourcePrefix}-${appName}-agora-eb-deploy
-  Parameters:
-    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-agora-eb-deploy
-    MaxSessionDuration: 7200
-    ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk"
-  TemplatingContext:
-    GitHubOrg: "Sage-Bionetworks"
-    Repositories:
-      - name: "Agora"
-        branches: ["develop", "prod", "staging"]
   DefaultOrganizationBinding:
     Account:
       - !Ref AgoraDevAccount


### PR DESCRIPTION
The legacy Agora repos have been archived.  Remove the Github OIDC role for them.

