### PR TITLE
IT-4450: Add perms for ApiGateway to deployment role

### DIFF
--- a/sceptre/synapseprod/templates/SynapseCMK-template.json
+++ b/sceptre/synapseprod/templates/SynapseCMK-template.json
@@ -221,6 +221,13 @@
                                 {
                                     "Effect": "Allow",
                                     "Action": [
+                                        "apigateway:*"
+                                    ],
+                                    "Resource": "*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
                                         "bedrock:*"
                                     ],
                                     "Resource": "*"


### PR DESCRIPTION
This PR adds the permission to call ApiGateway to the deployer role in SynapseProd.
The role in SynapseDev already has the permission.

This is needed to deploy stack-546.
