### PR TITLE
Plfm 8754 synapse-ops repo's to deploy Synapse infrastructure

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -158,17 +158,53 @@ GithubOidcSageBionetworksSynapse:
   TemplatingContext:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
-      - name: "synapse-docker-registry"
-        branches: ["*"]
       - name: "nbconvert-webapp"
         branches: ["master", "develop"]
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref SynapseDevAccount
+      - !Ref SynapseProdAccount
+    Region: us-east-1
+
+GithubOidcSageBionetworksSynapseOpsDev:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapse-ops-dev
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapse-ops-dev
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
       - name: "synapse-ops-dev"
-        branches: ["main"]
-      - name: "synapse-ops-prod"
         branches: ["main"]
   DefaultOrganizationBinding:
     Account:
       - !Ref SynapseDevAccount
+    Region: us-east-1
+
+GithubOidcSageBionetworksSynapseOpsProd:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapse-ops-prod
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-synapse-ops-prod
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks"
+    Repositories:
+      - name: "synapse-ops-prod"
+        branches: ["main"]
+  DefaultOrganizationBinding:
+    Account:
       - !Ref SynapseProdAccount
     Region: us-east-1
 


### PR DESCRIPTION
Allow the synapse-ops repo's to deploy to the Synapse AWS Accounts.