### PR TITLE
[IT-4445] Suppress CIS 2.1.5.2 finding

### DIFF
--- a/org-formation/075-security-hub/security-hub.yaml
+++ b/org-formation/075-security-hub/security-hub.yaml
@@ -76,6 +76,8 @@ Resources:
             Comparison: "PREFIX"
           - Value: "arn:aws:s3:::www"
             Comparison: "PREFIX"
+          - Value: "arn:aws:s3:::static"
+            Comparison: "PREFIX"
       Actions:
         - Type: "FINDING_FIELDS_UPDATE"
           FindingFieldsUpdate:


### PR DESCRIPTION
Suppress CIS 2.1.5.2 security hub findings for static website buckets in
org-sagebase-sageit account. Static websites are hosted by cloudfront
and should be public.
