### PR TITLE
fix security hub automation rul parameter value

### DIFF
--- a/org-formation/075-security-hub/security-hub.yaml
+++ b/org-formation/075-security-hub/security-hub.yaml
@@ -114,8 +114,8 @@ Resources:
             Comparison: "EQUALS"
           - Value: "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/1.14"
             Comparison: "EQUALS"
-          - Value: "cis-aws-foundations-benchmark/v/1.4.0/1.6"
-            Comparison: "EQUALS" # same as v/1.2.0/rule/1.14
+          - Value: "cis-aws-foundations-benchmark/v/1.4.0/1.6"   # same as v/1.2.0/rule/1.14
+            Comparison: "EQUALS"
           - Value: "aws-foundational-security-best-practices/v/1.0.0/IAM.6"
             Comparison: "EQUALS"
           - Value: "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/2.7"


### PR DESCRIPTION
To fix [deployment failure](https://github.com/Sage-Bionetworks-IT/organizations-infra/actions/runs/15616262509/job/43989721007):

```
ERROR: Resource SuppressSecHubFindingsInAllAccounts failed because Properties
validation failed for resource SuppressSecHubFindingsInAllAccounts with message:
[#/Criteria/GeneratorId/3/Comparison: cis-aws-foundations-benchmark/v/1.4.0/1.6 is not a valid enum value].
```
