### PR TITLE
[IT-4445] Move security suppression to navtive system

### DIFF
--- a/org-formation/075-security-hub/security-hub-suppress-infra.yaml
+++ b/org-formation/075-security-hub/security-hub-suppress-infra.yaml
@@ -389,38 +389,6 @@ Resources:
           - Arn
         Id: Target0
 
-  # Findings to suppress in Bridge accounts.
-  # * Suppress findings for insecure access to S3 buckets in the bridge accounts
-  #   because consent forms are accessed internally by the app via HTTP.
-  SuppressFindingsForBridgeAccounts:
-    Type: AWS::Events::Rule
-    Properties:
-      Description: SecHubSuppress findings for Bridge accounts
-      EventPattern:
-        detail:
-          findings:
-            GeneratorId:
-              # Ensure S3 Bucket Policy is set to deny HTTP requests
-              - 'cis-aws-foundations-benchmark/v/1.4.0/2.1.2'
-            Workflow:
-              Status:
-              - NEW
-              - NOTIFIED
-            AwsAccountId:
-            - '420786776710' # bridge-dev
-            - '649232250620' # bridge-prod
-        detail-type:
-        - Security Hub Findings - Imported
-        source:
-        - aws.securityhub
-      State: ENABLED
-      Targets:
-      - Arn:
-          Fn::GetAtt:
-          - SecurityHubFindingsQueue
-          - Arn
-        Id: Target0
-
   # Findings to suppress for service users in Bridge accounts.
   # * Suppress findings for unused credentials because automation runs less
   #   frequently than every 45 days.

--- a/org-formation/075-security-hub/security-hub.yaml
+++ b/org-formation/075-security-hub/security-hub.yaml
@@ -61,7 +61,7 @@ Resources:
           - Value: "Security Hub"
             Comparison: "EQUALS"
         AwsAccountId:
-          - Value: "797640923903"
+          - Value: "797640923903"      # org-sagebase-sageit
             Comparison: "EQUALS"
         GeneratorId:
           - Value: "cis-aws-foundations-benchmark/v/1.4.0/2.1.1"
@@ -269,6 +269,45 @@ Resources:
             Comparison: "PREFIX"
           - Value: "AWS::::Account:140124849929"   # This should only match with 2.1.5.1
             Comparison: "PREFIX"
+      Actions:
+        - Type: "FINDING_FIELDS_UPDATE"
+          FindingFieldsUpdate:
+            Workflow:
+              Status: "SUPPRESSED"
+            Note:
+              Text: "Automatically suppress Security Hub findings with INFORMATIONAL severity"
+              UpdatedBy: "sechub-automation"
+
+  # Findings to suppress in Bridge accounts.
+  # * Suppress findings for insecure access to S3 buckets in the bridge accounts
+  #   because consent forms are accessed internally by the app via HTTP.
+  SuppressSecHubFindingsForBridgeAccounts:
+    Type: AWS::SecurityHub::AutomationRule
+    Properties:
+      RuleName: "SuppressSecHubFindingsForBridgeAccounts"
+      RuleOrder: "330"
+      RuleStatus: "ENABLED"
+      Description: "Suppress Security Hub findings for AWS Bridge accounts"
+      Criteria:
+        RecordState:
+          - Value: "ACTIVE"
+            Comparison: "EQUALS"
+        WorkflowStatus:
+          - Value: "NEW"
+            Comparison: "EQUALS"
+          - Value: "NOTIFIED"
+            Comparison: "EQUALS"
+        ProductName:
+          - Value: "Security Hub"
+            Comparison: "EQUALS"
+        AwsAccountId:
+          - Value: "420786776710"   # org-sagebase-bridgedev
+            Comparison: "EQUALS"
+          - Value: "649232250620"   # org-sagebase-bridgeprod
+            Comparison: "EQUALS"
+        GeneratorId:
+          - Value: "cis-aws-foundations-benchmark/v/1.4.0/2.1.2"     # 2.1.2 Ensure S3 Bucket Policy is set to deny HTTP requests
+            Comparison: "EQUALS"
       Actions:
         - Type: "FINDING_FIELDS_UPDATE"
           FindingFieldsUpdate:


### PR DESCRIPTION
Move SuppressFindingsForBridgeAccounts to security hub's native automation rules system to suppress findings.

