### PR TITLE
PLFM-7095: setup OIDC for synapse-status-lambda

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -965,66 +965,7 @@ GithubOidcSynapseStatusLambda:
             {
                 "Effect": "Allow",
                 "Action": "sts:AssumeRole",
-                "Resource": "arn:aws:iam::449435941126:role/cdk-hnb659fds-*"
-            },
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "lambda:CreateFunction",
-                    "lambda:DeleteFunction",
-                    "lambda:GetFunction",
-                    "lambda:UpdateFunctionCode",
-                    "lambda:UpdateFunctionConfiguration",
-                    "lambda:AddPermission",
-                    "lambda:RemovePermission",
-                    "lambda:GetFunctionCodeSigningConfig",
-                    "lambda:PutFunctionConcurrency",
-                    "lambda:DeleteFunctionConcurrency"
-                ],
-                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*"
-            },
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "cloudformation:CreateStack",
-                    "cloudformation:UpdateStack",
-                    "cloudformation:DeleteStack",
-                    "cloudformation:DescribeStacks",
-                    "cloudformation:DescribeStackEvents",
-                    "cloudformation:GetTemplateSummary"
-                ],
-                "Resource": "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*"
-            },
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "cloudformation:ListStacks"
-                ],
-                "Resource": "*"
-            },
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "events:PutRule",
-                    "events:PutTargets",
-                    "events:DeleteRule",
-                    "events:RemoveTargets",
-                    "events:DescribeRule"
-                ],
-                "Resource": "*"
-            },
-            {
-              "Effect": "Allow",
-              "Action": [
-                  "ec2:DescribeVpcs",
-                  "ec2:DescribeSubnets",
-                  "ec2:CreateNetworkInterface",
-                  "ec2:DeleteNetworkInterface",
-                  "ec2:DescribeNetworkInterfaces",
-                  "ec2:DescribeRouteTables",
-                  "ec2:DescribeVpnGateways"
-            ],
-              "Resource": "*"
+                "Resource": "arn:aws:iam::${AWS::AccountId}:role/cdk-hnb659fds-*"
             }
         ]
       }

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -953,10 +953,19 @@ GithubOidcSynapseStatusLambda:
                     "iam:DeleteRole",
                     "iam:GetRole",
                     "iam:PutRolePolicy",
-                    "iam:DeleteRolePolicy",
-                    "iam:PassRole"
+                    "iam:DeleteRolePolicy"
                 ],
                 "Resource": "arn:aws:iam::${AWS::AccountId}:role/*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": "iam:PassRole",
+                "Resource": "arn:aws:iam::${AWS::AccountId}:role/SynapseStatusStack-StatusUpdater*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Resource": "arn:aws:iam::449435941126:role/cdk-hnb659fds-*"
             },
             {
                 "Effect": "Allow",
@@ -1011,11 +1020,12 @@ GithubOidcSynapseStatusLambda:
                   "ec2:DescribeSubnets",
                   "ec2:CreateNetworkInterface",
                   "ec2:DeleteNetworkInterface",
-                  "ec2:DescribeNetworkInterfaces"
-              ],
+                  "ec2:DescribeNetworkInterfaces",
+                  "ec2:DescribeRouteTables",
+                  "ec2:DescribeVpnGateways"
+            ],
               "Resource": "*"
             }
-
         ]
       }
   TemplatingContext:

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -984,7 +984,7 @@ GithubOidcSynapseStatusLambda:
         ]
       }
   TemplatingContext:
-    GitHubOrg: "Sage-Bionetworks-IT"
+    GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "synapse-status-lambda"
         branches: ["main"]

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -942,33 +942,9 @@ GithubOidcSynapseStatusLambda:
   Parameters:
     ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
     ProviderRoleName: !Sub ${resourcePrefix}-${appName}-synapse-status-lambda-deploy
-    PolicyDocument: |
-      {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "iam:CreateRole",
-                    "iam:DeleteRole",
-                    "iam:GetRole",
-                    "iam:PutRolePolicy",
-                    "iam:DeleteRolePolicy"
-                ],
-                "Resource": "arn:aws:iam::${AWS::AccountId}:role/*"
-            },
-            {
-                "Effect": "Allow",
-                "Action": "iam:PassRole",
-                "Resource": "arn:aws:iam::${AWS::AccountId}:role/SynapseStatusStack-StatusUpdater*"
-            },
-            {
-                "Effect": "Allow",
-                "Action": "sts:AssumeRole",
-                "Resource": "arn:aws:iam::${AWS::AccountId}:role/cdk-hnb659fds-*"
-            }
-        ]
-      }
+    ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
   TemplatingContext:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -949,6 +949,18 @@ GithubOidcSynapseStatusLambda:
             {
                 "Effect": "Allow",
                 "Action": [
+                    "iam:CreateRole",
+                    "iam:DeleteRole",
+                    "iam:GetRole",
+                    "iam:PutRolePolicy",
+                    "iam:DeleteRolePolicy",
+                    "iam:PassRole"
+                ],
+                "Resource": "arn:aws:iam::${AWS::AccountId}:role/*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
                     "lambda:CreateFunction",
                     "lambda:DeleteFunction",
                     "lambda:GetFunction",
@@ -960,7 +972,7 @@ GithubOidcSynapseStatusLambda:
                     "lambda:PutFunctionConcurrency",
                     "lambda:DeleteFunctionConcurrency"
                 ],
-                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:SynapsestatusStack-StatusUpdaterFunction*"
+                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*"
             },
             {
                 "Effect": "Allow",
@@ -980,7 +992,30 @@ GithubOidcSynapseStatusLambda:
                     "cloudformation:ListStacks"
                 ],
                 "Resource": "*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "events:PutRule",
+                    "events:PutTargets",
+                    "events:DeleteRule",
+                    "events:RemoveTargets",
+                    "events:DescribeRule"
+                ],
+                "Resource": "*"
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:DescribeVpcs",
+                  "ec2:DescribeSubnets",
+                  "ec2:CreateNetworkInterface",
+                  "ec2:DeleteNetworkInterface",
+                  "ec2:DescribeNetworkInterfaces"
+              ],
+              "Resource": "*"
             }
+
         ]
       }
   TemplatingContext:

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -960,20 +960,7 @@ GithubOidcSynapseStatusLambda:
                     "lambda:PutFunctionConcurrency",
                     "lambda:DeleteFunctionConcurrency"
                 ],
-                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:prod-StatusUpdaterFunction*"
-            },
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "iam:CreateRole",
-                    "iam:DeleteRole",
-                    "iam:GetRole",
-                    "iam:GetRolePolicy",
-                    "iam:PutRolePolicy",
-                    "iam:DeleteRolePolicy",
-                    "iam:PassRole"
-                ],
-                "Resource": "arn:aws:iam::${AWS::AccountId}:role/prod-StatusUpdaterFunction*"
+                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:SynapsestatusStack-StatusUpdaterFunction*"
             },
             {
                 "Effect": "Allow",
@@ -985,7 +972,7 @@ GithubOidcSynapseStatusLambda:
                     "cloudformation:DescribeStackEvents",
                     "cloudformation:GetTemplateSummary"
                 ],
-                "Resource": "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${Stack}/*"
+                "Resource": "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*"
             },
             {
                 "Effect": "Allow",

--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -934,6 +934,78 @@ GithubOidcSceptreAws:
       - !Ref SceptreDevAccount
     Region: us-east-1
 
+GithubOidcSynapseStatusLambda:
+  Type: update-stacks
+  DependsOn: GithubOidcSageBionetworks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
+  StackName: !Sub ${resourcePrefix}-${appName}-synapse-status-lambda
+  Parameters:
+    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
+    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-synapse-status-lambda-deploy
+    PolicyDocument: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "lambda:CreateFunction",
+                    "lambda:DeleteFunction",
+                    "lambda:GetFunction",
+                    "lambda:UpdateFunctionCode",
+                    "lambda:UpdateFunctionConfiguration",
+                    "lambda:AddPermission",
+                    "lambda:RemovePermission",
+                    "lambda:GetFunctionCodeSigningConfig",
+                    "lambda:PutFunctionConcurrency",
+                    "lambda:DeleteFunctionConcurrency"
+                ],
+                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:prod-StatusUpdaterFunction*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "iam:CreateRole",
+                    "iam:DeleteRole",
+                    "iam:GetRole",
+                    "iam:GetRolePolicy",
+                    "iam:PutRolePolicy",
+                    "iam:DeleteRolePolicy",
+                    "iam:PassRole"
+                ],
+                "Resource": "arn:aws:iam::${AWS::AccountId}:role/prod-StatusUpdaterFunction*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "cloudformation:CreateStack",
+                    "cloudformation:UpdateStack",
+                    "cloudformation:DeleteStack",
+                    "cloudformation:DescribeStacks",
+                    "cloudformation:DescribeStackEvents",
+                    "cloudformation:GetTemplateSummary"
+                ],
+                "Resource": "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${Stack}/*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "cloudformation:ListStacks"
+                ],
+                "Resource": "*"
+            }
+        ]
+      }
+  TemplatingContext:
+    GitHubOrg: "Sage-Bionetworks-IT"
+    Repositories:
+      - name: "synapse-status-lambda"
+        branches: ["main"]
+  DefaultOrganizationBinding:
+    Account:
+      - !Ref SynapseProdAccount
+    Region: us-east-1
+
 ############################### Managed Policies ###############################
 # Managed policies used in github OIDC providers
 # Note: Managed policies can be used as work around for the AWS cloudformation


### PR DESCRIPTION
This PR creates an OIDC role with permissions to deploy the Synapse status lambda (https://github.com/Sage-Bionetworks/synapse-status-lambda/pull/1/files)  to the SynapseProd account.
