### PR TITLE
Update pre-commit linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v1.27.0
+    rev: v1.36.1
     hooks:
       - id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: remove-tabs
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.33.0
+    rev: 0.33.1
     hooks:
       - id: check-github-workflows
       - id: check-github-actions

--- a/sceptre/sageit/templates/accounts.yaml
+++ b/sceptre/sageit/templates/accounts.yaml
@@ -1,6 +1,10 @@
 ---
 Description: Setup IAM policies, groups and accounts
 AWSTemplateFormatVersion: 2010-09-09
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks: [W3037]
 Resources:
   # !! IMPORTANT !! - AWS API will refuse to remove users that have attached resources.
   # Therefore you must do the following before deleting them from this file:

--- a/sceptre/synapsedev/templates/SynapseCMK-template.json
+++ b/sceptre/synapsedev/templates/SynapseCMK-template.json
@@ -1,6 +1,15 @@
 {
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "The master encryption key used to encypt/decypt all Synapse master secrets",
+    "Metadata": {
+        "cfn-lint": {
+            "config": {
+                "ignore_checks": [
+                    "W3037"
+                ]
+            }
+        }
+    },
     "Parameters": {
         "Stack": {
             "Description": "The stack",

--- a/sceptre/synapsedev/templates/accounts.yaml
+++ b/sceptre/synapsedev/templates/accounts.yaml
@@ -3,7 +3,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Metadata:
   cfn-lint:
     config:
-      ignore_checks: [ "W1011" ]
+      ignore_checks: [ "W1011", "W3037" ]
 Parameters:
   InitNewUserPassword:
     Type: String

--- a/sceptre/synapseprod/templates/SynapseCMK-template.json
+++ b/sceptre/synapseprod/templates/SynapseCMK-template.json
@@ -1,6 +1,15 @@
 {
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "The master encryption key used to encypt/decypt all Synapse master secrets",
+    "Metadata": {
+        "cfn-lint": {
+            "config": {
+                "ignore_checks": [
+                    "W3037"
+                ]
+            }
+        }
+    },
     "Parameters": {
         "Stack": {
             "Description": "The stack",


### PR DESCRIPTION
* Update linters
* Ignore linter warning `W3037` because it doesn't make sense..

```
W3037 'listcertificates,' is not one of ['addtagstocertificate', 'deletecertificate',
'describecertificate', 'exportcertificate', 'getaccountconfiguration', 'getcertificate',
'importcertificate', 'listcertificates', 'listtagsforcertificate', 'putaccountconfiguration',
'removetagsfromcertificate', 'renewcertificate', 'requestcertificate',
'resendvalidationemail', 'revokecertificate', 'updatecertificateoptions']
sceptre/sageit/templates/accounts.yaml:24:11
```

`listcertificates` is in the list of valid permissions.
