### PR TITLE
 IT-4497 Allow Developer role to assume Bedrock role in dedicated Bedrock AWS account

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -442,7 +442,7 @@ SsoDeveloper:
               {
                   "Effect": "Deny",
                   "Action": "sts:AssumeRole",
-                  "Resource": "*"
+                  "Resource": "*",
                   "Condition": {
                     "StringNotEquals": {
                         "aws:PrincipalArn": {


### PR DESCRIPTION
Allow Developer role to assume Bedrock role in dedicated Bedrock AWS account

The role is defined here:
https://github.com/Sage-Bionetworks-IT/organizations-infra/blob/master/org-formation/600-access/_tasks.yaml#L197
and it creates the CloudFormation output:
`us-east-1-synapsellmprod-bedrock-full-access-ServiceRoleArn`
so we import the value as an exception to the Deny STS policy statement.
