### PR TITLE
Remove references to AWS OpsWorks

### DIFF
--- a/org-formation/090-systems-manager/patch-resource-group.yaml
+++ b/org-formation/090-systems-manager/patch-resource-group.yaml
@@ -15,7 +15,6 @@ Resources:
             - "AWS::EC2::Instance"
             - "AWS::EC2::ReservedInstance"
             - "AWS::ECS::ContainerInstance"
-            - "AWS::OpsWorks::Instance"
             - "AWS::RDS::DBInstance"
             - "AWS::RDS::ReservedDBInstance"
             - "AWS::SSM::ManagedInstance"


### PR DESCRIPTION
Got this message from a failed deployment[1]:

```
ERROR: Resource TagBasedGroup failed because Resource handler returned
message: "Invalid request provided: Query not valid: One or more resource
types are not valid: AWS::OpsWorks::Instance 
```

AWS OpsWorks is no longer supported[2] and we never used it anyway so removing references to it.

[1] https://github.com/Sage-Bionetworks-IT/organizations-infra/actions/runs/16654510163/job/47135896313
[2] https://docs.aws.amazon.com/opsworks/latest/userguide/stacks-eol-faqs.html

