### PR TITLE
IT-4431: Activate IAM Access Analyzer on all accounts

### DIFF
--- a/org-formation/077-macie/README.md
+++ b/org-formation/077-macie/README.md
@@ -1,5 +1,5 @@
 ### Purpose of these templates
-The templates in this folder enables
+The templates in this folder enable
 [AWS Macie](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html)
 across our AWS organization.
 

--- a/org-formation/079-access-analyzer/README.md
+++ b/org-formation/079-access-analyzer/README.md
@@ -1,0 +1,8 @@
+### Purpose of these templates
+The templates in this folder enable
+[IAM Access Analyzer](https://aws.amazon.com/iam/access-analyzer/)
+across our AWS organization.
+
+IAM Access Analyzer is a security feature in AWS that helps you identify
+and analyze potential access risks within your AWS environment by examining
+your IAM policies and resource policies.

--- a/org-formation/079-access-analyzer/_tasks.yaml
+++ b/org-formation/079-access-analyzer/_tasks.yaml
@@ -1,0 +1,15 @@
+Parameters:
+  <<: !Include '../_parameters.yaml'
+
+  appName:
+    Type: String
+    Default: 'access_analyzer'
+
+AccessAnalyzer:
+  Type: update-stacks
+  Template: access_analyzer.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}'
+  StackDescription: Setup IAM Access Analyzer service
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: '*'

--- a/org-formation/079-access-analyzer/access_analyzer.yaml
+++ b/org-formation/079-access-analyzer/access_analyzer.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Setup IAM Access Analyzer"
+Resources:
+  AccessAnalyzer:
+    Type: AWS::AccessAnalyzer::Analyzer
+    Properties:
+      # External access analyzers help you identify potential risks of accessing
+      # resources by enabling you to identify any resource policies that grant access
+      # to an external principal.
+      Type: ACCOUNT

--- a/org-formation/README.md
+++ b/org-formation/README.md
@@ -28,6 +28,8 @@ prefixed with numbers to enforce the order they are deployed in.
   Configure Security Hub for all accounts.
 - 077 [Macie](./077-macie) \
   Configure AWS Macie for all accounts.
+- 079 [Access Analyzer](./079-access-analyzer) \
+  Configure IAM Access Analyzer for all accounts.
 - 080 [AWS Config](./080-aws-config-inventory) \
   Configure AWS Config for all accounts.
 - 090 [Systems Manager](./090-systems-manager) \

--- a/org-formation/_tasks.yaml
+++ b/org-formation/_tasks.yaml
@@ -36,6 +36,11 @@ Macie:
   DependsOn: [ Types ]
   Path: ./077-macie/_tasks.yaml
 
+AccessAnalyzer:
+  Type: include
+  DependsOn: [ Types ]
+  Path: ./079-access-analyzer/_tasks.yaml
+
 AwsConfigInventory:
   Type: include
   DependsOn: [ Types ]


### PR DESCRIPTION
This PR activates IAM Access Analyzer on all accounts, as required by Microsoft Defender:

>AWS IAM Access Analyzer helps you identify the resources in your organization and accounts, such as Amazon S3 buckets or IAM roles, that are shared with an external entity and identify unintended access to your resources and data.

There are three types of analyzers.  This PR creates an [External access analyzer](https://docs.aws.amazon.com/access-analyzer/latest/APIReference/Welcome.html) which:

>  help[s] you identify potential risks of accessing resources by enabling you to identify any resource policies that grant access to an external principal.

