### PR TITLE
bugfix: only create categories for active accounts

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -41,7 +41,7 @@ CostCategoryRulesMicroservice:
   Parameters:
     AcmCertificateArn: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-sageit-finops-cert-CertificateArn']
     DnsName: "cost-rules.finops.sageit.org"
-    ChartOfAccountsURL: "https://mips-api.finops.sageit.org/accounts?show_inactive_codes=on"
+    ChartOfAccountsURL: "https://mips-api.finops.sageit.org/accounts"
     ProgramCodeTagList: "CostCenterOther,CostCenter"
 
 # The underlying template uses AWS::Include, but CloudFormation will not detect changes in the included


### PR DESCRIPTION
The deploy is failing because the category rules are too long.

The cost category rules have become too long due to a change in lambda-mips-api that includes even more inactive accounts. Only create rules for active accounts to unblock the deploy pipeline. Resources tagged with deprecated accounts will still create categories for the arbitrary tag value, but without deduplicating names.