### PR TITLE
[IT-4483] Update cfn-cr-synapse-tagger lambda version

### DIFF
--- a/sceptre/scipool/config/develop/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/develop/cfn-cr-synapse-tagger.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.5/cfn-cr-synapse-tagger.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.2.0/cfn-cr-synapse-tagger.yaml
 stack_name: cfn-cr-synapse-tagger
 stack_tags:
   OwnerEmail: "it@sagebase.org"

--- a/sceptre/scipool/config/prod/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/prod/cfn-cr-synapse-tagger.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.5/cfn-cr-synapse-tagger.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.2.0/cfn-cr-synapse-tagger.yaml
 stack_name: cfn-cr-synapse-tagger
 stack_tags:
   OwnerEmail: "it@sagebase.org"

--- a/sceptre/scipool/config/strides/cfn-cr-synapse-tagger.yaml
+++ b/sceptre/scipool/config/strides/cfn-cr-synapse-tagger.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.1.5/cfn-cr-synapse-tagger.yaml
+  url: https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-synapse-tagger/0.2.0/cfn-cr-synapse-tagger.yaml
 stack_name: cfn-cr-synapse-tagger
 stack_tags:
   OwnerEmail: "it@sagebase.org"


### PR DESCRIPTION
Update teh cfn-cr-synapse-tagger lambda to include a refactored get_synapse_owner_id method.

depends on https://github.com/Sage-Bionetworks-IT/cfn-cr-synapse-tagger/pull/63

