### PR TITLE
[IT-4865] Add budget alarms for STRIDES accounts

### DIFF
--- a/sceptre/strides-ampad-workflows/config/prod/budgets.yaml
+++ b/sceptre/strides-ampad-workflows/config/prod/budgets.yaml
@@ -1,0 +1,10 @@
+template:
+  type: http
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.10.6/templates/Billing/budgets.yaml
+stack_name: "budget-alarms"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+parameters:
+  budgetName: "strides-ampad-workflows"
+  budgetAmount: 25000
+  emailAddress: "ADTR-computebudget@sagebase.org"

--- a/sceptre/strides/config/prod/budgets.yaml
+++ b/sceptre/strides/config/prod/budgets.yaml
@@ -1,0 +1,10 @@
+template:
+  type: http
+  url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.10.6/templates/Billing/budgets.yaml
+stack_name: "budget-alarms"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+parameters:
+  budgetName: strides
+  budgetAmount: 25000
+  emailAddress: "ADTR-computebudget@sagebase.org"


### PR DESCRIPTION
Create budget alarms for both STRIDES accounts. The alarms will fire at
80% threshold and 100% threshold. With a $25k threshold, the alarms will
fire at $20k and $25k.