### PR TITLE
[IT-4949] Wire IAM auth for floqast-sftp to mips-api

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -78,6 +78,7 @@ FloQastSftpMicroservice:
   Type: update-stacks
   Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-finops-floqast-sftp/1.0.1/lambda-finops-floqast-sftp.yaml'
   StackName: !Sub '${resourcePrefix}-floqast-microservice'
+  DependsOn: MipsMicroservice
   DefaultOrganizationBinding:
     IncludeMasterAccount: false
     Account: !Ref AdminCentralAccount
@@ -85,6 +86,12 @@ FloQastSftpMicroservice:
   Parameters:
     Schedule: "cron(0 4 * * ? *)"
     PeriodCount: "13"
+    # Use the API Gateway URL directly (not CloudFront) for IAM-authenticated access
+    MipApiBalances: !Sub
+      - "${OriginUrl}balances"
+      - OriginUrl: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-mips-microservice-OriginUrl']
+    MipApiRegion: !Ref primaryRegion
+    MipApiExecuteArn: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-mips-microservice-BalancesExecuteArn']
     SsmPrefix: "/lambda/floqast-sftp"
     KmsKeyAdminArns:
       - 'arn:aws:sts::745159704268:assumed-role/AWSReservedSSO_Administrator_30244677b3ea9498/joni.harker@sagebase.org'

--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -15,7 +15,7 @@ AnomalyDetectorService:
 # Deploy a general-use microservice for interacting with MIPS in admincentral
 MipsMicroservice:
   Type: update-stacks
-  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-mips-api/1.3.1/lambda-mips-api.yaml'
+  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-mips-api/1.3.2/lambda-mips-api.yaml'
   StackName: !Sub '${resourcePrefix}-mips-microservice'
   DefaultOrganizationBinding:
     IncludeMasterAccount: false
@@ -76,8 +76,9 @@ CostNotificationMicroservice:
 # Run daily at 8pm PDT (4am UTC)
 FloQastSftpMicroservice:
   Type: update-stacks
-  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-finops-floqast-sftp/1.0.1/lambda-finops-floqast-sftp.yaml'
+  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-finops-floqast-sftp/1.0.3/lambda-finops-floqast-sftp.yaml'
   StackName: !Sub '${resourcePrefix}-floqast-microservice'
+  DependsOn: MipsMicroservice
   DefaultOrganizationBinding:
     IncludeMasterAccount: false
     Account: !Ref AdminCentralAccount
@@ -85,6 +86,12 @@ FloQastSftpMicroservice:
   Parameters:
     Schedule: "cron(0 4 * * ? *)"
     PeriodCount: "13"
+    # Use the API Gateway URL directly (not CloudFront) for IAM-authenticated access
+    MipApiBalances: !Sub
+      - "${OriginUrl}balances"
+      - OriginUrl: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-mips-microservice-OriginUrl']
+    MipApiRegion: !Ref primaryRegion
+    MipApiExecuteArn: !CopyValue [!Sub '${primaryRegion}-${resourcePrefix}-mips-microservice-BalancesExecuteArn']
     SsmPrefix: "/lambda/floqast-sftp"
     KmsKeyAdminArns:
       - 'arn:aws:sts::745159704268:assumed-role/AWSReservedSSO_Administrator_30244677b3ea9498/joni.harker@sagebase.org'


### PR DESCRIPTION
Update the FloQastSftpMicroservice deployment to pass the mips-api API Gateway URL and execute-api ARN to the floqast-sftp lambda via stack exports.

- MipApiBalances: constructed from the mips-api OriginUrl export (API Gateway, not CloudFront).
- MipApiRegion: set to primaryRegion for SigV4.
- MipApiExecuteArn: consumed directly from the mips-api BalancesExecuteArn export.

This completes the IAM auth chain: mips-api requires IAM auth on /balances, floqast-sftp signs requests with SigV4, and this config wires them together.

Depends on Sage-Bionetworks-IT/lambda-mips-api#63
Depends on Sage-Bionetworks-IT/lambda-finops-floqast-sftp#13
