### PR TITLE
PORTALS-4145: Add permissions to namshub infra

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -1172,7 +1172,9 @@ SynapseMonorepoFileAccessPolicy:
                             "arn:aws:s3:::prod.classicportal.synapse.org/*",
                             "arn:aws:s3:::staging.classicportal.synapse.org/*",
                             "arn:aws:s3:::prod.arcusbio.synapse.org/*",
-                            "arn:aws:s3:::staging.arcusbio.synapse.org/*"
+                            "arn:aws:s3:::staging.arcusbio.synapse.org/*",
+                            "arn:aws:s3:::prod.namshub.synapse.org/*",
+                            "arn:aws:s3:::staging.namshub.synapse.org/*"
                           ]
           }
         ]
@@ -1240,7 +1242,9 @@ SynapseMonorepoCloudfrontAccessPolicy:
                             "arn:aws:cloudfront::797640923903:distribution/E2Q0H70VTYIILR",
                             "arn:aws:cloudfront::797640923903:distribution/EOJ4LGOT1G0D8",
                             "arn:aws:cloudfront::797640923903:distribution/E22C042TIAV42X",
-                            "arn:aws:cloudfront::797640923903:distribution/E1CMCI9H5DS1CH"
+                            "arn:aws:cloudfront::797640923903:distribution/E1CMCI9H5DS1CH",
+                            "arn:aws:cloudfront::797640923903:distribution/E3R49Y6WW3FQ76",
+                            "arn:aws:cloudfront::797640923903:distribution/E1OC3BFGAZBHRP"
                           ]
           }
         ]


### PR DESCRIPTION
This PR adds the infra for namsbub (NHDCC) to the resources where the deploy role can write / update distribution.
Note: branch is misnamed...
