### PR TITLE
[DPE-1612] Add dpe team to owner.txt

### DIFF
--- a/sceptre/aws-opendata/config/prod/darteval-bucket.yaml
+++ b/sceptre/aws-opendata/config/prod/darteval-bucket.yaml
@@ -8,3 +8,4 @@ parameters:
 sceptre_user_data:
   SynapseIDs:
     - "3453016" # DPE team
+    - "3485485" # DPE service account

--- a/sceptre/aws-opendata/config/prod/darteval-bucket.yaml
+++ b/sceptre/aws-opendata/config/prod/darteval-bucket.yaml
@@ -8,4 +8,3 @@ parameters:
 sceptre_user_data:
   SynapseIDs:
     - "3453016" # DPE team
-    - "3485485" # DPE service account

--- a/sceptre/aws-opendata/config/prod/darteval-bucket.yaml
+++ b/sceptre/aws-opendata/config/prod/darteval-bucket.yaml
@@ -5,3 +5,6 @@ dependencies:
   - "prod/bootstrap.yaml"
 parameters:
   DataSetName: "darteval.opendata.sagebase.org"
+sceptre_user_data:
+  SynapseIDs:
+    - "3453016" # DPE team


### PR DESCRIPTION
Problem:
Need to add an owner.txt file with DPE as the data migration synapse account to the darteval AOD bucket

Solution:
Can automate the owner.txt generation following this [example.](https://github.com/Sage-Bionetworks/scicomp-provisioner/blob/master/config/prod/psychencode-migration-bucket.yaml#L25-L29) 

Added DPE synapse team (so any DPE member's synapse account or the DPE service account can be used for the migration)

PR Checklist:
- [X] Describe and explain your intentions for this change
- [X] Setup pre-commit and run the validators (info in README.md)

<img width="564" height="145" alt="image" src="https://github.com/user-attachments/assets/1012a636-17d6-4921-bfa1-b5a31f95a916" />

