### PR TITLE
bugfix: Fix bucket reference name

### DIFF
--- a/sceptre/aws-opendata/templates/opendata-bucket.j2
+++ b/sceptre/aws-opendata/templates/opendata-bucket.j2
@@ -148,7 +148,7 @@ Resources:
             - E3001
     Properties:
       Target:
-        Bucket: !Ref Bucket
+        Bucket: !Ref DataSetBucket
         Key: owner.txt
         ContentType: text
       Body: >-


### PR DESCRIPTION
The deploy pipeline is failing due to an unresolved reference to `Bucket`, correct it to be `DataSetBucket`.