### PR TITLE
[IT-4823] Remove GH OIDC for data curator

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -78,28 +78,6 @@ GithubOidcSageBionetworksRecover:
       - !Ref RecoverDevAccount
     Region: us-east-1
 
-GithubOidcSageBionetworksDataCuratorInfra:
-  Type: update-stacks
-  DependsOn: GithubOidcSageBionetworks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
-  StackName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-data-curator-infra
-  Parameters:
-    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-sage-bionetworks-data-curator-infra
-    ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AdministratorAccess"
-      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
-  TemplatingContext:
-    GitHubOrg: "Sage-Bionetworks"
-    Repositories:
-      - name: "data_curator-infra"
-        branches: ["*"]
-  DefaultOrganizationBinding:
-    Account:
-      - !Ref DnTDevAccount
-      - !Ref DCAProdAccount
-    Region: us-east-1
-
 GithubOidcSageBionetworksItSchematicInfraV2:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks


### PR DESCRIPTION
Remove github oidc for deployment of the data curator app
to the AWS org-sagebase-dca-prod account.



#### PR Dependency Tree


* **PR #1578** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)