### PR TITLE
[IT-4990] Expand SecurityAuditor permissions

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -513,6 +513,8 @@ SsoSecurityAuditor:
       - 'arn:aws:iam::aws:policy/job-function/SupportUser'
       - 'arn:aws:iam::aws:policy/AmazonInspector2ReadOnlyAccess'
       - 'arn:aws:iam::aws:policy/AWSSecurityHubReadOnlyAccess'
+      - 'arn:aws:iam::aws:policy/AWSArtifactReportsReadOnlyAccess'
+      - 'arn:aws:iam::aws:policy/AWSArtifactAgreementsReadOnlyAccess'
     sessionDuration: 'PT1H'
     masterAccountId: !Ref MasterAccount
 


### PR DESCRIPTION
Add AWSArtifactReportsReadOnlyAccess and AWSArtifactAgreementsReadOnlyAccess managed policies to the SecurityAuditor SSO permission set. This grants read-only access to AWS Artifact reports (including artifact:ListReports) and agreements for users in the aws-security-auditors JumpCloud group.