### PR TITLE
[IT-5017] AWS account for clients to use bedrock

### DIFF
--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -77,7 +77,7 @@ Organization:
         - !Ref RestrictDnsRegistrationSCP
       Accounts:
         - !Ref SceptreDevAccount
-        - !Ref BedrockExternalAccount
+        - !Ref BedrockCentralAccount
 
   ItProdOU:
     Type: OC::ORG::OrganizationalUnit
@@ -698,14 +698,14 @@ Organization:
         budget-alarm-threshold: 2000
         budget-alarm-threshold-email-recipient: aws-sagebrain-dev@sagebase.org
 
-  # This account is for external-facing Bedrock workloads
+  # Centralized Bedrock services for other accounts.
   # External clients (claude, copilot, etc..) will use Bedrock in this account
-  BedrockExternalAccount:
+  BedrockCentralAccount:
     Type: OC::ORG::Account
     Properties:
-      AccountName: org-sagebase-bedrock-external
-      RootEmail: aws-bedrock-external@sagebase.org
-      Alias: org-sagebase-bedrock-external
+      AccountName: org-sagebase-bedrockcentral
+      RootEmail: aws-bedrockcentral@sagebase.org
+      Alias: org-sagebase-bedrockcentral
       Tags:
         <<: !Include ./_default_org_tags.yaml
         AccountOwner: it@sagebase.org

--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -77,6 +77,7 @@ Organization:
         - !Ref RestrictDnsRegistrationSCP
       Accounts:
         - !Ref SceptreDevAccount
+        - !Ref BedrockExternalInferenceAccount
 
   ItProdOU:
     Type: OC::ORG::OrganizationalUnit
@@ -696,6 +697,21 @@ Organization:
         CostCenter: NO PROGRAM / 000000
         budget-alarm-threshold: 2000
         budget-alarm-threshold-email-recipient: aws-sagebrain-dev@sagebase.org
+
+  # This account is for external-facing Bedrock inference workloads
+  # External clients (claude, copilot, etc..) will use Bedrock from this account
+  BedrockExternalInferenceAccount:
+    Type: OC::ORG::Account
+    Properties:
+      AccountName: org-sagebase-bedrock-external-inference
+      RootEmail: aws-bedrock-external-inference@sagebase.org
+      Alias: org-sagebase-bedrock-external-inference
+      Tags:
+        <<: !Include ./_default_org_tags.yaml
+        AccountOwner: it@sagebase.org
+        CostCenter: NO PROGRAM / 000000
+        budget-alarm-threshold: 2000
+        budget-alarm-threshold-email-recipient: it@sagebase.org
 
   #------------ Personal Accounts -----------
   BuA2aDwAccount:

--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -77,7 +77,7 @@ Organization:
         - !Ref RestrictDnsRegistrationSCP
       Accounts:
         - !Ref SceptreDevAccount
-        - !Ref BedrockExternalInferenceAccount
+        - !Ref BedrockExternalAccount
 
   ItProdOU:
     Type: OC::ORG::OrganizationalUnit
@@ -698,14 +698,14 @@ Organization:
         budget-alarm-threshold: 2000
         budget-alarm-threshold-email-recipient: aws-sagebrain-dev@sagebase.org
 
-  # This account is for external-facing Bedrock inference workloads
-  # External clients (claude, copilot, etc..) will use Bedrock from this account
-  BedrockExternalInferenceAccount:
+  # This account is for external-facing Bedrock workloads
+  # External clients (claude, copilot, etc..) will use Bedrock in this account
+  BedrockExternalAccount:
     Type: OC::ORG::Account
     Properties:
-      AccountName: org-sagebase-bedrock-external-inference
-      RootEmail: aws-bedrock-external-inference@sagebase.org
-      Alias: org-sagebase-bedrock-external-inference
+      AccountName: org-sagebase-bedrock-external
+      RootEmail: aws-bedrock-external@sagebase.org
+      Alias: org-sagebase-bedrock-external
       Tags:
         <<: !Include ./_default_org_tags.yaml
         AccountOwner: it@sagebase.org

--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -704,7 +704,7 @@ Organization:
     Type: OC::ORG::Account
     Properties:
       AccountName: org-sagebase-bedrockcentral
-      RootEmail: aws-bedrockcentral@sagebase.org
+      RootEmail: aws.bedrockcentral@sagebase.org
       Alias: org-sagebase-bedrockcentral
       Tags:
         <<: !Include ./_default_org_tags.yaml


### PR DESCRIPTION
Create a centralized Bedrock account. This keeps all AI spend in one place,
makes credit application straightforward and gives us a single pane for quotas,
logging, guardrails, and cost reporting.

We use this account to allow clients such as claude code to use Bedrock from
this account.  This allows us to use bedrock credits that will be applied to this account.


#### PR Dependency Tree


* **PR #1582** 👈
  * **PR #1583**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)