### PR TITLE
[IT-5017] Create SSO roles for AWS Bedrock External account

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -206,6 +206,18 @@ SynapseImageCentralImageBuilderPipelineAccess:
     ManagedPolicyArns:
       - arn:aws:iam::aws:policy/AWSImageBuilderReadOnlyAccess
 
+# Setup cross-account Bedrock access for all org accounts via BedrockCentral account
+BedrockCentralCrossAccountAccess:
+  Type: update-stacks
+  Template: bedrock-cross-account-role.yaml
+  StackName: bedrock-cross-account-role
+  DefaultOrganizationBinding:
+    Account: !Ref BedrockCentralAccount
+    Region: us-east-1
+  Parameters:
+    OrganizationId: !Ref organizationPrincipalId
+    RoleName: BedrockCrossAccountRole
+
 # Give Vanta compliance tool read-only access to our AWS ORG IT-4821
 VantaReadOnlyAccess:
   Type: update-stacks

--- a/org-formation/600-access/bedrock-cross-account-role.yaml
+++ b/org-formation/600-access/bedrock-cross-account-role.yaml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Cross-account role for Bedrock access. Allows all accounts in the
+  organization to assume this role.
+Parameters:
+  OrganizationId:
+    Type: String
+    Description: The AWS Organization ID (e.g., o-xxxxxxxxxx)
+  RoleName:
+    Type: String
+    Default: BedrockCrossAccountRole
+    Description: Name of the IAM role
+Resources:
+  BedrockCrossAccountRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: !Ref RoleName
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonBedrockFullAccess
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: '*'
+            Action:
+              - 'sts:AssumeRole'
+            Condition:
+              StringEquals:
+                'aws:PrincipalOrgID': !Ref OrganizationId
+Outputs:
+  RoleArn:
+    Value: !GetAtt BedrockCrossAccountRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-BedrockCrossAccountRoleArn'

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -366,6 +366,14 @@ Parameters:
     Type: String
     Default: '64c81408-e0a1-70a3-dbc1-143a8ebecd9e'
 
+  BedrockExternalDeveloperGroup:     # JC aws-bedrock-external-developers
+    Type: String
+    Default: 'TBD'
+
+  BedrockExternalInferenceManagerGroup:     # JC aws-bedrock-external-inference-managers
+    Type: String
+    Default: 'TBD'
+
   #------------- personal AWS accounts ------------------
   BuA2aDwAdminGroup:             #JC aws-BuA2aDw-admins
     Type: String
@@ -2422,3 +2430,75 @@ SsoSageBrainProdDeveloper:
     instanceArn: !Ref instanceArn
     principalId: !Ref SageBrainProdDeveloperGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
+
+SsoBedrockExternalDeveloper:
+  Type: update-stacks
+  DependsOn: SsoDeveloper
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.10.2/templates/SSO/aws-sso.njk
+  TemplatingContext: {}
+  StackName: !Sub '${resourcePrefix}-${appName}-bedrock-external-inference-developer'
+  StackDescription: 'SSO: developer role used by bedrock external inference developers group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref BedrockExternalAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref bedrockExternalDeveloperGroup
+    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
+
+# Least privileged access to manage bedrock API keys in BedrockExternalAccount
+SsoBedrockExternalInferenceManager:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.10.2/templates/SSO/aws-sso.njk
+  TemplatingContext:
+    customerManagedPolicies:
+      - Name: !Ref CostExplorerPolicyName
+  StackName: !Sub '${resourcePrefix}-${appName}-bedrock-external-inference-manager'
+  StackDescription: 'SSO: inference manager role used by bedrock external inference manager group'
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref BedrockExternalAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref bedrockExternalInferenceManagerGroup
+    permissionSetName: 'bedrock-external-inference-manager'
+    managedPolicies:
+      - 'arn:aws:iam::aws:policy/job-function/ViewOnlyAccess'
+      - 'arn:aws:iam::aws:policy/job-function/SupportUser'
+      - 'arn:aws:iam::aws:policy/AWSSupportAccess'
+    sessionDuration: 'PT12H'
+    inlinePolicy: >-
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "PreventPrivilegedEscalation",
+            "Effect": "Deny",
+            "Action": "sts:AssumeRole",
+            "Resource": "*"
+          },
+          {
+            "Sid": "AllowBedrockManagement",
+            "Effect": "Allow",
+            "Action": [
+              "bedrock:InvokeModel",
+              "bedrock:InvokeModelWithResponseStream",
+              "bedrock:Converse",
+              "bedrock:ConverseStream"
+              "bedrock:ListFoundationModels",
+              "bedrock:GetFoundationModel"
+              "bedrock:CreateApiKey",
+              "bedrock:GetApiKey",
+              "bedrock:ListApiKeys",
+              "bedrock:DeleteApiKey"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -368,11 +368,11 @@ Parameters:
 
   BedrockExternalDeveloperGroup:     # JC aws-bedrock-external-developers
     Type: String
-    Default: 'TBD'
+    Default: 'f4b8c448-00f1-70bd-c156-4d6c55aca173'
 
   BedrockExternalInferenceManagerGroup:     # JC aws-bedrock-external-inference-managers
     Type: String
-    Default: 'TBD'
+    Default: '14f81438-c091-70d4-43bc-87ad420e5cbf'
 
   #------------- personal AWS accounts ------------------
   BuA2aDwAdminGroup:             #JC aws-BuA2aDw-admins


### PR DESCRIPTION
 Create a few roles for SSO access to the bedrock external account.
    
    * The standard developer role
    * A inference manager role.  This is a least privileged role to
      allow users to manage AWS Bedrock, most importantly to create
      bedrock API keys to allow AI clients to use bedrock.
    
 The idea is to bestow this role on a limited set of users who can
 manage bedrock on behalf of their teams.







#### PR Dependency Tree


* **PR #1583** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)