### PR TITLE
IT-4981: Add temporary redirector from modeladexplorer.org to prod.modeladexpl…

### DIFF
--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -555,3 +555,20 @@ NamshubRedirect:
     TargetDomainName: "namshub.synapse.org"
     AcmCertificateArn: "arn:aws:acm:us-east-1:797640923903:certificate/b68960cb-012e-4984-af83-ef093c63608f"
     RedirectFctName: !Sub '${resourcePrefix}-namshub-redirect-cloudfront-fct'
+
+# Issue IT-4981, redirect from  https://modeladexplorer.org to https://prod.modeladexplorer.org
+ModeladexplorerRedirect:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.10.3/templates/S3/s3-apex-redirector.yaml
+  StackName: !Sub '${resourcePrefix}-modeladexplorer-redirect'
+  StackDescription: Setup a redirect from modeladexplorer.org to prod.modeladexplorer.org
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    Account: !Ref SageITAccount
+  Parameters:
+    # the endpoint we are redirecting from
+    SourceDomainName: "modeladexplorer.org"
+    # the endpoint we are redirecting to
+    TargetDomainName: "prod.modeladexplorer.org"
+    AcmCertificateArn: "arn:aws:acm:us-east-1:797640923903:certificate/0792e7eb-c2f2-43e0-9a4b-be015c3e4f23"
+    RedirectFctName: !Sub '${resourcePrefix}-modeladexplorer-redirect-cloudfront-fct'

--- a/org-formation/800-redirects/_tasks.yaml
+++ b/org-formation/800-redirects/_tasks.yaml
@@ -556,7 +556,8 @@ NamshubRedirect:
     AcmCertificateArn: "arn:aws:acm:us-east-1:797640923903:certificate/b68960cb-012e-4984-af83-ef093c63608f"
     RedirectFctName: !Sub '${resourcePrefix}-namshub-redirect-cloudfront-fct'
 
-# Issue IT-4981, redirect from  https://modeladexplorer.org to https://prod.modeladexplorer.org
+# Issue IT-4981, temporary redirect from  https://modeladexplorer.org to https://prod.modeladexplorer.org
+# This will be removed once we fix the certificate on the ALB
 ModeladexplorerRedirect:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.10.3/templates/S3/s3-apex-redirector.yaml


### PR DESCRIPTION
This PR sets up a temporary redirect to get around a certificate issue.