### PR TITLE
Update Administrator policy

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -400,6 +400,7 @@ SsoAdministrator:
     managedPolicies:
       - 'arn:aws:iam::aws:policy/AdministratorAccess'
       - 'arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser'
+      - 'arn:aws:iam::aws:policy/AWSMarketplaceFullAccess'
     sessionDuration: 'PT8H'
     masterAccountId: !Ref MasterAccount
 


### PR DESCRIPTION
 The AdministratorAccess policy does not cover giving full access to the
 AWS marketplace.  Add the policy to allow AWS admins to manage AWS apps
 from the marketplace.



#### PR Dependency Tree


* **PR #1585** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)