### PR TITLE
[IT-5049] Reduce Vanta scanner scope

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -212,8 +212,10 @@ VantaReadOnlyAccess:
   Template: vanta-readonly-role-cf.yml
   StackName: vanta-read-only-access
   DefaultOrganizationBinding:
-    IncludeMasterAccount: true
-    Account: '*'
+    IncludeMasterAccount: false
+    Account:
+      - !Ref SynapseLlmProdAccount
+      - !Ref SynapseProdAccount
     Region: !Ref primaryRegion
 
 

--- a/org-formation/600-access/vanta-readonly-role-cf.yml
+++ b/org-formation/600-access/vanta-readonly-role-cf.yml
@@ -1,4 +1,5 @@
 # This template was provided by Vanta
+# From Integrations->Add connection->Cloudformation->AWS->Policy and role
 AWSTemplateFormatVersion: 2010-09-09
 Parameters:
   ExternalId:
@@ -21,20 +22,6 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Effect: Allow
-            Action:
-              - identitystore:DescribeGroup
-              - identitystore:DescribeGroupMembership
-              - identitystore:DescribeUser
-              - identitystore:GetGroupId
-              - identitystore:GetGroupMembershipId
-              - identitystore:GetUserId
-              - identitystore:IsMemberInGroups
-              - identitystore:ListGroupMemberships
-              - identitystore:ListGroups
-              - identitystore:ListUsers
-              - identitystore:ListGroupMembershipsForMember
-            Resource: "*"
           - Effect: Deny
             Action:
               - datapipeline:EvaluateExpression


### PR DESCRIPTION
Instead of scanning the entire AWS account, scope the vanta
scanner to only scan synapse production accounts




#### PR Dependency Tree


* **PR #1587** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)