### PR TITLE
[IT-5017] Create a cross account role for BedrockCentral

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -218,6 +218,17 @@ VantaReadOnlyAccess:
       - !Ref SynapseProdAccount
     Region: !Ref primaryRegion
 
+# Setup cross-account Bedrock access for all org accounts
+BedrockCentralCrossAccountAccess:
+  Type: update-stacks
+  Template: bedrock-cross-account-role.yaml
+  StackName: bedrock-cross-account-role
+  DefaultOrganizationBinding:
+    Account: !Ref BedrockCentralAccount
+    Region: us-east-1
+  Parameters:
+    OrganizationId: !Ref organizationPrincipalId
+    RoleName: BedrockCrossAccountRole
 
 #---------------------------------
 #  Managed Policies

--- a/org-formation/600-access/bedrock-cross-account-role.yaml
+++ b/org-formation/600-access/bedrock-cross-account-role.yaml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Cross-account role for Bedrock access. Allows all accounts in the
+  organization to assume this role.
+Parameters:
+  OrganizationId:
+    Type: String
+    Description: The AWS Organization ID (e.g., o-xxxxxxxxxx)
+  RoleName:
+    Type: String
+    Default: BedrockCrossAccountRole
+    Description: Name of the IAM role
+Resources:
+  BedrockCrossAccountRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: !Ref RoleName
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonBedrockFullAccess
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: '*'
+            Action:
+              - 'sts:AssumeRole'
+            Condition:
+              StringEquals:
+                'aws:PrincipalOrgID': !Ref OrganizationId
+Outputs:
+  RoleArn:
+    Value: !GetAtt BedrockCrossAccountRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-BedrockCrossAccountRoleArn'

--- a/org-formation/600-access/bedrock-cross-account-role.yaml
+++ b/org-formation/600-access/bedrock-cross-account-role.yaml
@@ -32,4 +32,4 @@ Outputs:
   RoleArn:
     Value: !GetAtt BedrockCrossAccountRole.Arn
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-BedrockCrossAccountRoleArn'
+      Name: !Sub '${AWS::StackName}-BedrockCrossAccountRoleArn'


### PR DESCRIPTION
Create an IAM role in BedrockCentralAccount with AWS managed
policy AmazonBedrockFullAccess to allow the role access
to Bedrock resources.






#### PR Dependency Tree


* **PR #1588** 👈
  * **PR #1589**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)