### PR TITLE
[IT-4823] Remove branches from schematic infra deployment

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -115,10 +115,9 @@ GithubOidcSageBionetworksItSchematicInfraV2:
     GitHubOrg: "Sage-Bionetworks-IT"
     Repositories:
       - name: "schematic-infra-v2"
-        branches: ["dev", "stage", "prod"]
+        branches: ["prod"]
   DefaultOrganizationBinding:
     Account:
-      - !Ref DnTDevAccount
       - !Ref DCAProdAccount
     Region: us-east-1
 


### PR DESCRIPTION
The dev and stage branches have been removed in
the schematic-infra-v2 repo




#### PR Dependency Tree


* **PR #1594** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)