### PR TITLE
[IT-4963] Remove references to openchallenges AWS accounts

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -902,28 +902,6 @@ GithubOidcModelAdExplorerInfra:
       - !Ref AgoraProdAccount
     Region: us-east-1
 
-GithubOidcOpenChallengesDeploy:
-  Type: update-stacks
-  DependsOn: GithubOidcSageBionetworks
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.7.6/templates/IAM/github-oidc-provider.j2
-  StackName: !Sub ${resourcePrefix}-${appName}-openchallenges-deploy
-  Parameters:
-    ProviderArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-ProviderArn' ]
-    ProviderRoleName: !Sub ${resourcePrefix}-${appName}-openchallenges-deploy
-    MaxSessionDuration: 7200
-    ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/AdministratorAccess"
-      - "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
-  TemplatingContext:
-    GitHubOrg: "Sage-Bionetworks-IT"
-    Repositories:
-      - name: "openchallenges"
-        branches: ["stage", "prod"]
-  DefaultOrganizationBinding:
-    Account:
-      - !Ref OpenChallengesProdAccount
-    Region: us-east-1
-
 GithubOidcSceptreAws:
   Type: update-stacks
   DependsOn: GithubOidcSageBionetworks

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -309,18 +309,6 @@ Parameters:
     Type: String
     Default: '2448e4e8-50b1-70e5-def0-07e0f4fcd60e'
 
-  OpenchallengesDevDeveloperGroup:     # JC aws-openchallenges-dev-developers
-    Type: String
-    Default: '44183438-a051-7070-f706-284ffd41907b'
-
-  OpenchallengesDevAdminGroup:     # JC aws-openchallenges-dev-admins
-    Type: String
-    Default: 'e4388458-2011-7096-3f98-3a6eeb10e458'
-
-  OpenchallengesProdAdminGroup:     # JC aws-openchallenges-prod-admins
-    Type: String
-    Default: 'c418a4d8-c021-70b6-6580-1e115806deb6'
-
   # Synapse LLM infra account
   SynapseLlmProdAdminGroup:     # JC aws-synapsellm-prod-admins
     Type: String
@@ -2243,57 +2231,6 @@ SsoItsandboxDeveloper:
     instanceArn: !Ref instanceArn
     principalId: !Ref itsandboxDeveloperGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
-
-SsoOpenchallengesDevDeveloper:
-  Type: update-stacks
-  DependsOn: SsoDeveloper
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/SSO/aws-sso.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-openchallenges-dev-developer'
-  StackDescription: 'SSO: Developer role used by openchallenges developer group'
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: true
-  OrganizationBindings:
-    TargetBinding:
-      Account: !Ref OpenChallengesDevAccount
-  Parameters:
-    instanceArn: !Ref instanceArn
-    principalId: !Ref OpenchallengesDevDeveloperGroup
-    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
-
-SsoOpenchallengesDevAdmin:
-  Type: update-stacks
-  DependsOn: SsoAdministrator
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.11/templates/SSO/aws-sso.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-openchallenges-dev-admin'
-  StackDescription: 'SSO: admin role used by OpenChallenges dev admin group'
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: true
-  OrganizationBindings:
-    TargetBinding:
-      Account: !Ref OpenChallengesDevAccount
-  Parameters:
-    instanceArn: !Ref instanceArn
-    principalId: !Ref OpenchallengesDevAdminGroup
-    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
-
-SsoOpenchallengesProdAdmin:
-  Type: update-stacks
-  DependsOn: SsoAdministrator
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.11/templates/SSO/aws-sso.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-openchallenges-prod-admin'
-  StackDescription: 'SSO: admin role used by OpenChallenges prod admin group'
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: true
-  OrganizationBindings:
-    TargetBinding:
-      Account: !Ref OpenChallengesProdAccount
-  Parameters:
-    instanceArn: !Ref instanceArn
-    principalId: !Ref OpenchallengesProdAdminGroup
-    permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
 
 SsoGenAiIcDevAdmin:
   Type: update-stacks

--- a/org-formation/organization.yaml
+++ b/org-formation/organization.yaml
@@ -33,7 +33,6 @@ Organization:
         - !Ref RecoverDevAccount
         - !Ref ScceDevAccount
         - !Ref CnbDevAccount
-        - !Ref OpenChallengesDevAccount
         - !Ref GenAiIcDevAccount
         - !Ref BixArenaDevAccount
         - !Ref BixArenaProdAccount
@@ -56,7 +55,6 @@ Organization:
         - !Ref GenieProdAccount
         - !Ref DCAProdAccount
         - !Ref DpeProdAccount
-        - !Ref OpenChallengesProdAccount
         - !Ref SageBrainProdAccount
 
   PlatformOU:
@@ -577,32 +575,6 @@ Organization:
         CostCenter: NO PROGRAM / 000000
         budget-alarm-threshold: 10000
         budget-alarm-threshold-email-recipient: aws-scce-dev@sagebase.org
-
-  OpenChallengesDevAccount:
-    Type: OC::ORG::Account
-    Properties:
-      AccountName: org-sagebase-openchallenges-dev
-      RootEmail: aws-openchallenges-dev@sagebase.org
-      Alias: org-sagebase-openchallenges-dev
-      Tags:
-        <<: !Include ./_default_org_tags.yaml
-        AccountOwner: thomas.schaffter@sagebase.org
-        CostCenter: ITCR / 101600
-        budget-alarm-threshold: 2000
-        budget-alarm-threshold-email-recipient: aws-openchallenges-dev@sagebase.org
-
-  OpenChallengesProdAccount:
-    Type: OC::ORG::Account
-    Properties:
-      AccountName: org-sagebase-openchallenges-prod
-      RootEmail: aws-openchallenges-prod@sagebase.org
-      Alias: org-sagebase-openchallenges-prod
-      Tags:
-        <<: !Include ./_default_org_tags.yaml
-        AccountOwner: thomas.schaffter@sagebase.org
-        CostCenter: ITCR / 101600
-        budget-alarm-threshold: 2000
-        budget-alarm-threshold-email-recipient: aws-openchallenges-prod@sagebase.org
 
 # Synapse Large Language Model dev account: hosts development Bedrock-related resources
   SynapseLlmDevAccount:


### PR DESCRIPTION
Remove infrastructure references to openchalleges AWS
accounts in preparation for closing the accounts.



#### PR Dependency Tree


* **PR #1598** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)