### PR TITLE
[IT-4823] Remove data curator deployment to DNT dev account

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -93,10 +93,9 @@ GithubOidcSageBionetworksDataCuratorInfra:
     GitHubOrg: "Sage-Bionetworks"
     Repositories:
       - name: "data_curator-infra"
-        branches: ["*"]
+        branches: ["prod"]
   DefaultOrganizationBinding:
     Account:
-      - !Ref DnTDevAccount
       - !Ref DCAProdAccount
     Region: us-east-1
 


### PR DESCRIPTION
Only allow deployments from the prod branch to the data curator prod environment. 

#### PR Dependency Tree


* **PR #1599** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)