### PR TITLE
[IT-5070] Change patch schedule to daily

### DIFF
--- a/org-formation/090-systems-manager/_tasks.yaml
+++ b/org-formation/090-systems-manager/_tasks.yaml
@@ -52,7 +52,7 @@ PatchManager:
       Account: '*'
       IncludeMasterAccount: true
   Parameters:
-    EventBridgeRuleSchedule: "cron(15 22 ? * TUE *)"
+    EventBridgeRuleSchedule: "cron(15 22 * * ? *)"
     RunPatchBaselineRebootOption: "RebootIfNeeded"
     ResourceGroupName: !CopyValue sagebase-systemsmanager-patch-resource-group-TagBasedGroupName
     RunPatchBaselineOperation: "Install"


### PR DESCRIPTION
The patch manager is set to patch instances on a weekly schedule
which can leave instances vulnerable to security vulnerabilities.
    
We switch the schedule from weekly (Tuesdays at 10:15 PM UTC) to
daily (every day at 10:15 PM UTC).



#### PR Dependency Tree


* **PR #1602** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)