### PR TITLE
Add collaborator access to scce-dev account

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -215,6 +215,118 @@ BedrockCentralCrossAccountAccess:
     OrganizationId: !Ref organizationPrincipalId
     RoleName: BedrockCrossAccountRole
 
+# Setup access for NYU collaborators for scce-dev account
+BenchmarkCollaboratorAccess:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.10.9/templates/IAM/cross-account-access.yaml
+  StackName: llmb-collaborator-access
+  DefaultOrganizationBinding:
+    Account: !Ref ScceDevAccount
+    Region: us-east-1
+  Parameters:
+    PrincipalArns:
+      - arn:aws:iam::246534652589:root      # Nikolaos Kalavros
+    PolicyDocument: >-
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iot:ListJobs",
+                "ecr:DescribeRepositories",
+                "ecr:GetAuthorizationToken",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:PutImage",
+                "batch:RegisterJobDefinition",
+                "batch:SubmitJob",
+                "batch:ListJobs"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:GetObjectAcl",
+                "s3:GetObjectVersion",
+                "s3:ListMultipartUploadParts",
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*/*",
+                "arn:aws:s3:us-east-1:*:accesspoint/*/object/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*",
+                "arn:aws:s3:us-east-1:*:accesspoint/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3-object-lambda:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*",
+                "arn:aws:s3:us-east-1:*:accesspoint/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kms:Decrypt",
+                "kms:GenerateDataKey"
+            ],
+            "Resource": [
+                "arn:aws:kms:us-east-1:*:key/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "kms:ViaService": [
+                        "s3.us-east-1.amazonaws.com"
+                    ]
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3-object-lambda:ListMultipartUploadParts",
+                "s3-object-lambda:PutObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*/*",
+                "arn:aws:s3:us-east-1:*:accesspoint/*/object/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:PassRole"
+            ],
+            "Resource": [
+                "arn:aws:iam::458117591059:role/headless-agents-batch-job-role",
+                "arn:aws:iam::458117591059:role/headless-agents-ecs-task-execution-role"
+            ]
+          }
+        ]
+      }
 #---------------------------------
 #  Managed Policies
 #---------------------------------


### PR DESCRIPTION
Related to this ticket: https://sagebionetworks.jira.com/browse/IT-5133

PR Checklist:
- [x] Describe and explain your intentions for this change
- [x] Setup pre-commit and run the validators (info in README.md)

This PR adds an access config to enable an external collaborator to submit, retrieve, and monitor LLM benchmarking runs via an AWS stack in the ScceDevAccount. 

The permissions enable upload/download from S3, upload to ECR, and AWS Batch read/submission.

`pre-commit run --all-files` was run before creating the PR.