### PR TITLE
[IT-5133] llmb collaborator access

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -215,6 +215,118 @@ BedrockCentralCrossAccountAccess:
     OrganizationId: !Ref organizationPrincipalId
     RoleName: BedrockCrossAccountRole
 
+# Setup access for NYU collaborators for scce-dev account
+BenchmarkCollaboratorAccess:
+  Type: update-stacks
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.10.9/templates/IAM/cross-account-access.yaml
+  StackName: llmb-collaborator-access
+  DefaultOrganizationBinding:
+    Account: !Ref ScceDevAccount
+    Region: us-east-1
+  Parameters:
+    PrincipalArns:
+      - arn:aws:iam::246534652589:root      # Nikolaos Kalavros
+    PolicyDocument: >-
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iot:ListJobs",
+                "ecr:DescribeRepositories",
+                "ecr:GetAuthorizationToken",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:PutImage",
+                "batch:RegisterJobDefinition",
+                "batch:SubmitJob",
+                "batch:ListJobs"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:GetObjectAcl",
+                "s3:GetObjectVersion",
+                "s3:ListMultipartUploadParts",
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*/*",
+                "arn:aws:s3:us-east-1:*:accesspoint/*/object/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*",
+                "arn:aws:s3:us-east-1:*:accesspoint/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3-object-lambda:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*",
+                "arn:aws:s3:us-east-1:*:accesspoint/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kms:Decrypt",
+                "kms:GenerateDataKey"
+            ],
+            "Resource": [
+                "arn:aws:kms:us-east-1:*:key/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "kms:ViaService": [
+                        "s3.us-east-1.amazonaws.com"
+                    ]
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3-object-lambda:ListMultipartUploadParts",
+                "s3-object-lambda:PutObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*/*",
+                "arn:aws:s3:us-east-1:*:accesspoint/*/object/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:PassRole"
+            ],
+            "Resource": [
+                "arn:aws:iam::458117591059:role/headless-agents-batch-job-role",
+                "arn:aws:iam::458117591059:role/headless-agents-ecs-task-execution-role"
+            ]
+          }
+        ]
+      }
 #---------------------------------
 #  Managed Policies
 #---------------------------------

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -215,7 +215,7 @@ BedrockCentralCrossAccountAccess:
     OrganizationId: !Ref organizationPrincipalId
     RoleName: BedrockCrossAccountRole
 
-# Setup access for NYU collaborators for scce-dev account
+# Setup access for NYU collaborators for scce-dev account (IT-5133)
 BenchmarkCollaboratorAccess:
   Type: update-stacks
   Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.10.9/templates/IAM/cross-account-access.yaml
@@ -257,14 +257,10 @@ BenchmarkCollaboratorAccess:
                 "s3:GetObjectVersion",
                 "s3:ListMultipartUploadParts",
                 "s3:PutObject",
-                "s3:PutObjectAcl",
-                "s3:PutObjectLegalHold",
-                "s3:PutObjectRetention",
                 "s3:PutObjectTagging"
             ],
             "Resource": [
-                "arn:aws:s3:::*/*",
-                "arn:aws:s3:us-east-1:*:accesspoint/*/object/*"
+                "arn:aws:s3:headless-agents-benchmark-results-458117591059/*",
             ]
         },
         {

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -225,7 +225,7 @@ BenchmarkCollaboratorAccess:
     Region: us-east-1
   Parameters:
     PrincipalArns:
-      - arn:aws:iam::246534652589:root      # Nikolaos Kalavros
+      - arn:aws:iam::246534652589:user/NKalavrosNYULangone     # Nikolaos Kalavros
     PolicyDocument: !Sub >-
       {
         "Version": "2012-10-17",

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -226,7 +226,7 @@ BenchmarkCollaboratorAccess:
   Parameters:
     PrincipalArns:
       - arn:aws:iam::246534652589:root      # Nikolaos Kalavros
-    PolicyDocument: >-
+    PolicyDocument: !Sub >-
       {
         "Version": "2012-10-17",
         "Statement": [

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -268,8 +268,7 @@ BenchmarkCollaboratorAccess:
             "s3:ListBucket"
           ],
           "Resource": [
-            "arn:aws:s3:::*",
-            "arn:aws:s3:us-east-1:*:accesspoint/*"
+            "arn:aws:s3:::headless-agents-benchmark-results-458117591059"
           ]
         },
         {

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -306,8 +306,8 @@ BenchmarkCollaboratorAccess:
                 "iam:PassRole"
             ],
             "Resource": [
-                "arn:aws:iam::458117591059:role/headless-agents-batch-job-role",
-                "arn:aws:iam::458117591059:role/headless-agents-ecs-task-execution-role"
+                "arn:aws:iam::${CurrentAccount.AccountId}:role/headless-agents-batch-job-role",
+                "arn:aws:iam::${CurrentAccount.AccountId}:role/headless-agents-ecs-task-execution-role"
             ]
           }
         ]

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -279,7 +279,7 @@ BenchmarkCollaboratorAccess:
                 "kms:GenerateDataKey"
             ],
             "Resource": [
-                "arn:aws:kms:us-east-1:*:key/*"
+                "arn:aws:kms:us-east-1:458117591059:key/*"
             ],
             "Condition": {
                 "StringEquals": {

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -292,17 +292,6 @@ BenchmarkCollaboratorAccess:
         {
             "Effect": "Allow",
             "Action": [
-                "s3-object-lambda:ListMultipartUploadParts",
-                "s3-object-lambda:PutObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::*/*",
-                "arn:aws:s3:us-east-1:*:accesspoint/*/object/*"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
                 "iam:PassRole"
             ],
             "Resource": [

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -231,72 +231,55 @@ BenchmarkCollaboratorAccess:
         "Version": "2012-10-17",
         "Statement": [
         {
-            "Effect": "Allow",
-            "Action": [
-                "ecr:DescribeRepositories",
-                "ecr:GetAuthorizationToken",
-                "ecr:InitiateLayerUpload",
-                "ecr:UploadLayerPart",
-                "ecr:CompleteLayerUpload",
-                "ecr:BatchCheckLayerAvailability",
-                "ecr:PutImage",
-                "batch:RegisterJobDefinition",
-                "batch:SubmitJob",
-                "batch:ListJobs"
-            ],
-            "Resource": [
-                "*"
-            ]
+          "Effect": "Allow",
+          "Action": [
+            "ecr:DescribeRepositories",
+            "ecr:GetAuthorizationToken",
+            "ecr:InitiateLayerUpload",
+            "ecr:UploadLayerPart",
+            "ecr:CompleteLayerUpload",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:PutImage",
+            "batch:RegisterJobDefinition",
+            "batch:SubmitJob",
+            "batch:ListJobs"
+          ],
+          "Resource": [
+            "*"
+          ]
         },
         {
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:GetObjectAcl",
-                "s3:GetObjectVersion",
-                "s3:ListMultipartUploadParts",
-                "s3:PutObject",
-                "s3:PutObjectTagging"
-            ],
-            "Resource": [
-                "arn:aws:s3:headless-agents-benchmark-results-458117591059/*",
-            ]
+          "Effect": "Allow",
+          "Action": [
+            "s3:GetObject",
+            "s3:GetObjectAcl",
+            "s3:GetObjectVersion",
+            "s3:ListMultipartUploadParts",
+            "s3:PutObject",
+            "s3:PutObjectTagging"
+          ],
+          "Resource": [
+            "arn:aws:s3:::headless-agents-benchmark-results-458117591059/*"
+          ]
         },
         {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::*",
-                "arn:aws:s3:us-east-1:*:accesspoint/*"
-            ]
+          "Effect": "Allow",
+          "Action": [
+            "s3:ListBucket"
+          ],
+          "Resource": [
+            "arn:aws:s3:::*",
+            "arn:aws:s3:us-east-1:*:accesspoint/*"
+          ]
         },
         {
-            "Effect": "Allow",
-            "Action": [
-                "kms:Decrypt",
-                "kms:GenerateDataKey"
-            ],
-            "Resource": [
-                "arn:aws:kms:us-east-1:458117591059:key/*"
-            ],
-            "Condition": {
-                "StringEquals": {
-                    "kms:ViaService": [
-                        "s3.us-east-1.amazonaws.com"
-                    ]
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "iam:PassRole"
-            ],
-            "Resource": [
-                "arn:aws:iam::${CurrentAccount.AccountId}:role/headless-agents-batch-job-role",
-                "arn:aws:iam::${CurrentAccount.AccountId}:role/headless-agents-ecs-task-execution-role"
+          "Effect": "Allow",
+          "Action": [
+            "iam:PassRole"
+          ],
+          "Resource": [
+              "arn:aws:iam::${CurrentAccount.AccountId}:role/headless-agents-batch-job-role",
+              "arn:aws:iam::${CurrentAccount.AccountId}:role/headless-agents-ecs-task-execution-role"
             ]
           }
         ]

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -256,11 +256,20 @@ BenchmarkCollaboratorAccess:
             "s3:GetObjectVersion",
             "s3:ListMultipartUploadParts",
             "s3:PutObject",
-            "s3:PutObjectTagging",
-            "s3:ListBucket"
+            "s3:PutObjectTagging"
           ],
           "Resource": [
             "arn:aws:s3:::headless-agents-benchmark-results-458117591059/*"
+          ]
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "s3:ListBucket"
+          ],
+          "Resource": [
+            "arn:aws:s3:::*",
+            "arn:aws:s3:us-east-1:*:accesspoint/*"
           ]
         },
         {

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -275,16 +275,6 @@ BenchmarkCollaboratorAccess:
         {
             "Effect": "Allow",
             "Action": [
-                "s3-object-lambda:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::*",
-                "arn:aws:s3:us-east-1:*:accesspoint/*"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
                 "kms:Decrypt",
                 "kms:GenerateDataKey"
             ],

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -256,20 +256,11 @@ BenchmarkCollaboratorAccess:
             "s3:GetObjectVersion",
             "s3:ListMultipartUploadParts",
             "s3:PutObject",
-            "s3:PutObjectTagging"
-          ],
-          "Resource": [
-            "arn:aws:s3:::headless-agents-benchmark-results-458117591059/*"
-          ]
-        },
-        {
-          "Effect": "Allow",
-          "Action": [
+            "s3:PutObjectTagging",
             "s3:ListBucket"
           ],
           "Resource": [
-            "arn:aws:s3:::*",
-            "arn:aws:s3:us-east-1:*:accesspoint/*"
+            "arn:aws:s3:::headless-agents-benchmark-results-458117591059/*"
           ]
         },
         {

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -259,7 +259,7 @@ BenchmarkCollaboratorAccess:
             "s3:PutObjectTagging"
           ],
           "Resource": [
-            "arn:aws:s3:::headless-agents-benchmark-results-458117591059/*"
+            "arn:aws:s3:::headless-agents-benchmark-results-${CurrentAccount.AccountId}/*"
           ]
         },
         {
@@ -268,7 +268,7 @@ BenchmarkCollaboratorAccess:
             "s3:ListBucket"
           ],
           "Resource": [
-            "arn:aws:s3:::headless-agents-benchmark-results-458117591059"
+            "arn:aws:s3:::headless-agents-benchmark-results-${CurrentAccount.AccountId}"
           ]
         },
         {

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -233,7 +233,6 @@ BenchmarkCollaboratorAccess:
         {
             "Effect": "Allow",
             "Action": [
-                "iot:ListJobs",
                 "ecr:DescribeRepositories",
                 "ecr:GetAuthorizationToken",
                 "ecr:InitiateLayerUpload",


### PR DESCRIPTION
This PR adds changes identified by Copilot in my previous PR: https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/1603

Testing with this permission configuration allows me to run all required scripts (submit, monitor, fetch)

- added IT-5133 ticket reference to header comment
- added !Sub to start of permissions
- added ARN for benchmarking bucket to limit access
- replaced account ID in iam:PassRole section with account ID references
- updated PrincipleArns to scope to collaborator username (awaiting info from collaborator)
- updated "s3ListBucket" scope to benchmarking bucket only

- removed "s3:PutObjectAcl", "s3:PutObjectLegalHold", "s3:PutObjectRetention"
- removed iot:ListJobs (not needed)
- removed s3-lambda-object permissions (unused)
- removed KMS permissions, since decryption is performed automatically
