### PR TITLE
[IT-5068] Tower roles for Sagebrain account

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -955,6 +955,8 @@ SsoWorkflowNextflowTowerViewer:
       Account:
         - !Ref WorkflowsNextflowDevAccount
         - !Ref WorkflowsNextflowProdAccount
+        - !Ref SageBrainDevAccount
+        - !Ref SageBrainProdAccount
   Parameters:
     instanceArn: !Ref instanceArn
     principalId: !Ref workflowNextflowTowerViewerGroup

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -955,7 +955,6 @@ SsoWorkflowNextflowTowerViewer:
       Account:
         - !Ref WorkflowsNextflowDevAccount
         - !Ref WorkflowsNextflowProdAccount
-        - !Ref SageBrainDevAccount
         - !Ref SageBrainProdAccount
   Parameters:
     instanceArn: !Ref instanceArn


### PR DESCRIPTION
 The tower viewer role is required in tower linked accounts.
 It is passed down to the tower project configuration[1]

[1] https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/blob/dev/config/projects-prod/config.yaml



#### PR Dependency Tree


* **PR #1610** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)