### PR TITLE
[IT-5068] give repo access to assume role

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -976,6 +976,7 @@ GithubOidcWorkflowsProdNextflowInfra:
   DefaultOrganizationBinding:
     Account:
       - !Ref WorkflowsNextflowProdAccount
+      - !Ref SageBrainProdAccount
     Region: us-east-1
 
 GithubOidcAgoraInfraV3:


### PR DESCRIPTION
Give GH action in nextflow-infra repo access to assume roles
to deploy templates to SageBrain account



#### PR Dependency Tree


* **PR #1612** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)