### PR TITLE
Add user-specific ARN for BenchmarkCollaboratorAccess

### DIFF
--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -225,7 +225,7 @@ BenchmarkCollaboratorAccess:
     Region: us-east-1
   Parameters:
     PrincipalArns:
-      - arn:aws:iam::246534652589:root     # Nikolaos Kalavros
+      - arn:aws:iam::246534652589:user/OrionLLMBenchUser     # Nikolaos Kalavros
     PolicyDocument: !Sub >-
       {
         "Version": "2012-10-17",

--- a/org-formation/600-access/_tasks.yaml
+++ b/org-formation/600-access/_tasks.yaml
@@ -225,7 +225,9 @@ BenchmarkCollaboratorAccess:
     Region: us-east-1
   Parameters:
     PrincipalArns:
-      - arn:aws:iam::246534652589:user/OrionLLMBenchUser     # Nikolaos Kalavros
+      # ARN provided by collaborators at NYU
+      # OrionLLMBenchUser was the name used to create the user ARN and Nikolaos Kalavros is the user with access
+      - arn:aws:iam::246534652589:user/OrionLLMBenchUser
     PolicyDocument: !Sub >-
       {
         "Version": "2012-10-17",


### PR DESCRIPTION
Replaces root ARN previously listed for collaborator account
