### PR TITLE
[PLFM-9782] Grant synapsedev Developer scoped IAM delete permissions

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -1098,6 +1098,47 @@ SsoSynapseDevDeveloper:
     principalId: !Ref synapseDevDeveloperGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
 
+SsoSynapseDevDeveloperIamScoped:
+  Type: update-stacks
+  DependsOn: SsoDeveloper
+  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/SSO/aws-sso.yaml
+  StackName: !Sub '${resourcePrefix}-${appName}-synapsedev-developer-iam-scoped'
+  StackDescription: 'SSO: additional scoped IAM role-management rights for synapsedev developer group'
+  TerminationProtection: false
+  DefaultOrganizationBindingRegion: !Ref primaryRegion
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+  OrganizationBindings:
+    TargetBinding:
+      Account: !Ref SynapseDevAccount
+  Parameters:
+    instanceArn: !Ref instanceArn
+    principalId: !Ref synapseDevDeveloperGroup
+    permissionSetName: 'Developer-IAM-Synapsedev'
+    managedPolicies: [ 'arn:aws:iam::aws:policy/PowerUserAccess' ]
+    sessionDuration: 'PT12H'
+    inlinePolicy: >-
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Sid": "ResourceConstrainedIAM",
+                  "Effect": "Allow",
+                  "Action": [
+                      "iam:DeleteRolePolicy",
+                      "iam:DeleteRole",
+                      "iam:DetachRolePolicy"
+                  ],
+                  "Resource": "arn:aws:iam::449435941126:role/*shared-resources*"
+              },
+              {
+                  "Effect": "Deny",
+                  "Action": "sts:AssumeRole",
+                  "Resource": "*"
+              }
+          ]
+      }
+
 SsoSynapseProdDeveloper:
   Type: update-stacks
   DependsOn: SsoDeveloper

--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -455,10 +455,21 @@ SsoDeveloper:
                   "Effect": "Allow",
                   "Action": "sts:AssumeRole",
                   "Resource": "${AllowedRole}"
+                },
+                {
+                  "Sid": "SynapseDevSharedResourcesCleanup",
+                  "Effect": "Allow",
+                  "Action": [
+                    "iam:DeleteRolePolicy",
+                    "iam:DeleteRole",
+                    "iam:DetachRolePolicy"
+                  ],
+                  "Resource": "arn:aws:iam::${SynapseDevAccountId}:role/*shared-resources*"
                 }
             ]
           }
         - AllowedRole: !CopyValue ['us-east-1-synapsellmprod-bedrock-full-access-ServiceRoleArn', !Ref SynapseLlmProdAccount]
+          SynapseDevAccountId: !Ref SynapseDevAccount
 
 SsoFinanceAuditor:
   Type: update-stacks
@@ -1097,47 +1108,6 @@ SsoSynapseDevDeveloper:
     instanceArn: !Ref instanceArn
     principalId: !Ref synapseDevDeveloperGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-developer-permission-set-arn' ]
-
-SsoSynapseDevDeveloperIamScoped:
-  Type: update-stacks
-  DependsOn: SsoDeveloper
-  Template: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.8/templates/SSO/aws-sso.yaml
-  StackName: !Sub '${resourcePrefix}-${appName}-synapsedev-developer-iam-scoped'
-  StackDescription: 'SSO: additional scoped IAM role-management rights for synapsedev developer group'
-  TerminationProtection: false
-  DefaultOrganizationBindingRegion: !Ref primaryRegion
-  DefaultOrganizationBinding:
-    IncludeMasterAccount: true
-  OrganizationBindings:
-    TargetBinding:
-      Account: !Ref SynapseDevAccount
-  Parameters:
-    instanceArn: !Ref instanceArn
-    principalId: !Ref synapseDevDeveloperGroup
-    permissionSetName: 'Developer-IAM-Synapsedev'
-    managedPolicies: [ 'arn:aws:iam::aws:policy/PowerUserAccess' ]
-    sessionDuration: 'PT12H'
-    inlinePolicy: >-
-      {
-          "Version": "2012-10-17",
-          "Statement": [
-              {
-                  "Sid": "ResourceConstrainedIAM",
-                  "Effect": "Allow",
-                  "Action": [
-                      "iam:DeleteRolePolicy",
-                      "iam:DeleteRole",
-                      "iam:DetachRolePolicy"
-                  ],
-                  "Resource": "arn:aws:iam::449435941126:role/*shared-resources*"
-              },
-              {
-                  "Effect": "Deny",
-                  "Action": "sts:AssumeRole",
-                  "Resource": "*"
-              }
-          ]
-      }
 
 SsoSynapseProdDeveloper:
   Type: update-stacks


### PR DESCRIPTION
## Summary
Adds `iam:DeleteRolePolicy` / `iam:DeleteRole` / `iam:DetachRolePolicy` to the shared `Developer` SSO permission set's inline policy, scoped to synapsedev roles named `*shared-resources*`, so developers can clean up `DELETE_FAILED` personal sandbox CloudFormation stacks.

Developers get the cleanup ability in the `Developer` role they already assume — no separate role to switch into. (AWS Identity Center permission sets don't compose/inherit, so a single usable role means adding the statement to the Developer set itself.)

### Why this is safe despite the permission set being shared across ~20 accounts
`iam:DeleteRole*` / `iam:DetachRolePolicy` act on IAM roles in the caller's own account, and the statement's `Resource` is pinned to the synapsedev account ID (`arn:aws:iam::<synapsedev>:role/*shared-resources*`). In any other account this permission set is assigned to, a caller's delete action targets that account's roles, whose ARNs can't match the synapsedev ARN — so the statement grants nothing there.

Note: deploying this re-provisions the `Developer` permission set in every account it's assigned to (the inline policy is re-pushed), but the effective permissions change only in synapsedev.

Jira: https://sagebionetworks.jira.com/browse/PLFM-9782

## Test plan
- [ ] Deploy and confirm the `Developer` permission set inline policy contains the new `SynapseDevSharedResourcesCleanup` statement
- [ ] Re-attempt deleting a `DELETE_FAILED` stack in synapsedev with the affected IAM roles and confirm it succeeds