### PR TITLE
[IT-5171] Add AmazonMacieReadOnly to SsoSecurityAuditor

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -509,6 +509,7 @@ SsoSecurityAuditor:
       - 'arn:aws:iam::aws:policy/AWSSecurityHubReadOnlyAccess'
       - 'arn:aws:iam::aws:policy/AWSArtifactReportsReadOnlyAccess'
       - 'arn:aws:iam::aws:policy/AWSArtifactAgreementsReadOnlyAccess'
+      - 'arn:aws:iam::aws:policy/AmazonMacieReadOnlyAccess'
     sessionDuration: 'PT1H'
     masterAccountId: !Ref MasterAccount
 


### PR DESCRIPTION
Add the AWS managed policy AmazonMacieReadOnly to our SsoSecurityAuditor role.

Access granted by the managed policy can be found at: https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonMacieReadOnlyAccess.html