### PR TITLE
[PLFM-9782] Grant Developer scoped IAM cleanup for synapsedev sandbox stacks

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -464,7 +464,7 @@ SsoDeveloper:
                     "iam:DeleteRole",
                     "iam:DetachRolePolicy"
                   ],
-                  "Resource": "arn:aws:iam::${SynapseDevAccountId}:role/*shared-resources*"
+                  "Resource": "arn:aws:iam::${SynapseDevAccountId}:role/*"
                 }
             ]
           }


### PR DESCRIPTION
## Summary
Follow-up to #1619. Deleting a synapsedev personal sandbox stack (Synapse-Stack-Builder `shared-resources`) kept hitting AccessDenied across successive IAM actions/resource-types (`iam:DeleteRolePolicy` on roles, then `iam:RemoveRoleFromInstanceProfile` on instance profiles).

Rather than chase these one at a time, I enumerated the IAM resource types the shared-resources stack actually creates (verified across the Stack-Builder main template + all `#parse` sub-templates): **roles, instance profiles, and managed policies** (no users/groups). This grants the `Developer` role the **cleanup-only** actions (delete/detach/remove — no create or modify) for exactly those three resource types, scoped to the synapsedev account:

```
"Action": [
  "iam:DeleteRole", "iam:DeleteRolePolicy", "iam:DetachRolePolicy",
  "iam:RemoveRoleFromInstanceProfile", "iam:DeleteInstanceProfile",
  "iam:DeletePolicy", "iam:DeletePolicyVersion"
],
"Resource": [
  "arn:aws:iam::${SynapseDevAccountId}:role/*",
  "arn:aws:iam::${SynapseDevAccountId}:instance-profile/*",
  "arn:aws:iam::${SynapseDevAccountId}:policy/*"
]
```

Account-pinned to synapsedev, so it remains inert in every other account that shares the `Developer` permission set.

Jira: https://sagebionetworks.jira.com/browse/PLFM-9782

## Note
A separate `kms:DeleteAlias` failure on the same stacks is a CMK **key-policy** Deny in `Sage-Bionetworks/Synapse-Stack-Builder` (not fixable from this repo) — handled in Sage-Bionetworks/Synapse-Stack-Builder#903.

## Test plan
- [ ] Deploy and confirm the `Developer` permission set inline policy shows the cleanup actions scoped to synapsedev role/instance-profile/policy ARNs
- [ ] Re-run a full synapsedev sandbox stack delete and confirm it reaches DELETE_COMPLETE with no IAM AccessDenied