### PR TITLE
[PLFM-9782] Extend synapsedev Developer cleanup to instance profiles and policies

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -460,11 +460,19 @@ SsoDeveloper:
                   "Sid": "SynapseDevSharedResourcesCleanup",
                   "Effect": "Allow",
                   "Action": [
-                    "iam:DeleteRolePolicy",
                     "iam:DeleteRole",
-                    "iam:DetachRolePolicy"
+                    "iam:DeleteRolePolicy",
+                    "iam:DetachRolePolicy",
+                    "iam:RemoveRoleFromInstanceProfile",
+                    "iam:DeleteInstanceProfile",
+                    "iam:DeletePolicy",
+                    "iam:DeletePolicyVersion"
                   ],
-                  "Resource": "arn:aws:iam::${SynapseDevAccountId}:role/*"
+                  "Resource": [
+                    "arn:aws:iam::${SynapseDevAccountId}:role/*",
+                    "arn:aws:iam::${SynapseDevAccountId}:instance-profile/*",
+                    "arn:aws:iam::${SynapseDevAccountId}:policy/*"
+                  ]
                 }
             ]
           }


### PR DESCRIPTION
## Summary
Follow-up to #1619 and #1622. Deleting a synapsedev personal sandbox stack (Synapse-Stack-Builder `shared-resources`) still hit `iam:RemoveRoleFromInstanceProfile` AccessDenied — the prior grant only covered `role/*` with role-only actions, but the stack also creates **instance profiles** and **managed policies**.

I enumerated the IAM resource types the shared-resources stack actually creates (Stack-Builder main template + all `#parse` sub-templates): **roles, instance profiles, managed policies** (no users/groups). This extends the `SynapseDevSharedResourcesCleanup` statement with the **cleanup-only** actions (delete/detach/remove — no create or modify) for those three resource types, scoped to the synapsedev account:

```
"Action": [
  "iam:DeleteRole", "iam:DeleteRolePolicy", "iam:DetachRolePolicy",
  "iam:RemoveRoleFromInstanceProfile", "iam:DeleteInstanceProfile",
  "iam:DeletePolicy", "iam:DeletePolicyVersion"
],
"Resource": [
  "arn:aws:iam::${SynapseDevAccountId}:role/*",
  "arn:aws:iam::${SynapseDevAccountId}:instance-profile/*",
  "arn:aws:iam::${SynapseDevAccountId}:policy/*"
]
```

Account-pinned to synapsedev, so inert in every other account sharing the `Developer` permission set.

Jira: https://sagebionetworks.jira.com/browse/PLFM-9782

## Test plan
- [ ] Deploy and confirm the `Developer` permission set inline policy shows the cleanup actions scoped to synapsedev role/instance-profile/policy ARNs
- [ ] Re-run a full synapsedev sandbox stack delete and confirm it reaches DELETE_COMPLETE with no IAM AccessDenied