### PR TITLE
[IT-5171] Grant SecurityAuditor role full Macie access

### DIFF
--- a/org-formation/700-aws-sso/_tasks.yaml
+++ b/org-formation/700-aws-sso/_tasks.yaml
@@ -528,7 +528,7 @@ SsoSecurityAuditor:
       - 'arn:aws:iam::aws:policy/AWSSecurityHubReadOnlyAccess'
       - 'arn:aws:iam::aws:policy/AWSArtifactReportsReadOnlyAccess'
       - 'arn:aws:iam::aws:policy/AWSArtifactAgreementsReadOnlyAccess'
-      - 'arn:aws:iam::aws:policy/AmazonMacieReadOnlyAccess'
+      - 'arn:aws:iam::aws:policy/AmazonMacieFullAccess'
     sessionDuration: 'PT1H'
     masterAccountId: !Ref MasterAccount
 


### PR DESCRIPTION
Add the AmazonMacieFullAccess AWS-managed policy to our SecurityAuditor role. Macie is intended to be used for security auditing, making it appropriate for our
security auditors to have full access to the service.