### PR TITLE
[IT-5213] Suppress guardduty finding

### DIFF
--- a/org-formation/075-security-hub/security-hub.yaml
+++ b/org-formation/075-security-hub/security-hub.yaml
@@ -361,6 +361,38 @@ Resources:
               Text: "Automatically suppress Security Hub findings with INFORMATIONAL severity"
               UpdatedBy: "sechub-automation"
 
+  # Suppression for issue IT-5213
+  SuppressGuardDutyBedrockCrossAccountAnomaly:
+    Type: AWS::SecurityHub::AutomationRule
+    Properties:
+      RuleName: "SuppressGuardDutyBedrockCrossAccountAnomaly"
+      RuleOrder: "350"
+      RuleStatus: "ENABLED"
+      Description: "Suppress GuardDuty Bedrock cross-account role anomalous API finding (Impact TTP)"
+      Criteria:
+        RecordState:
+          - Value: "ACTIVE"
+            Comparison: "EQUALS"
+        WorkflowStatus:
+          - Value: "NEW"
+            Comparison: "EQUALS"
+          - Value: "NOTIFIED"
+            Comparison: "EQUALS"
+        ProductName:
+          - Value: "GuardDuty"
+            Comparison: "EQUALS"
+        Type:
+          - Value: "TTPs/Impact/IAMUser-AnomalousBehavior"
+            Comparison: "EQUALS"
+      Actions:
+        - Type: "FINDING_FIELDS_UPDATE"
+          FindingFieldsUpdate:
+            Workflow:
+              Status: "SUPPRESSED"
+            Note:
+              Text: "Suppressed: Bedrock cross-account role anomalous API is expected behavior"
+              UpdatedBy: "sechub-automation"
+
 Outputs:
   SecurityHubArn:
     Description: "The security hub ARN"


### PR DESCRIPTION
Suppress guardduty finding "Bedrock cross-account role anomalous API".
Cross account role access for bedrock is is expected.




#### PR Dependency Tree


* **PR #1626** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)