### PR TITLE
setup sage-kb-chatbot-infra repo to deploy to AWS

### DIFF
--- a/org-formation/650-identity-providers/_tasks.yaml
+++ b/org-formation/650-identity-providers/_tasks.yaml
@@ -1108,6 +1108,9 @@ GithubOidcItSandboxDeploy:   # allow repos to make test deployments into ITSandb
       - owner: "Sage-Bionetworks-IT"
         name: "aws-cdk-ecs-infra-template"
         branches: ["dev"]
+      - owner: "Sage-Bionetworks-IT"
+        name: "sage-kb-chatbot-infra"
+        branches: ["dev"]
   DefaultOrganizationBinding:
     Account:
       - !Ref ITSandboxAccount


### PR DESCRIPTION
Allow GH action from sage-kb-chatbot-infra repo to deploy
ECS infrastruction to host the sage-kb-chatbot app[1]

[1] https://github.com/Sage-Bionetworks-IT/sage-kb-chatbot




#### PR Dependency Tree


* **PR #1629** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)