### PR TITLE
bugfix: strip leading/trailing whitespace from cost category name

### DIFF
--- a/org-formation/050-costs/_tasks.yaml
+++ b/org-formation/050-costs/_tasks.yaml
@@ -32,7 +32,7 @@ MipsMicroservice:
 # Deploy a microservice for generating cost category rules
 CostCategoryRulesMicroservice:
   Type: update-stacks
-  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-finops-cost-rules/1.0.2/lambda-finops-cost-rules.yaml'
+  Template: !Sub 'https://${AdminCentralCfnBucket}.s3.amazonaws.com/lambda-finops-cost-rules/1.0.3/lambda-finops-cost-rules.yaml'
   StackName: !Sub '${resourcePrefix}-rules-microservice'
   DefaultOrganizationBinding:
     IncludeMasterAccount: false


### PR DESCRIPTION
Update lambda-finops-cost-rules to strip any leading or trailing whitespace after truncation to adhere to the allowed name regex.

Depends on https://github.com/Sage-Bionetworks-IT/lambda-finops-cost-rules/pull/44